### PR TITLE
Small refactorings before releasing 0.3.0

### DIFF
--- a/examples/Elastic.Channels.Example/Drain.cs
+++ b/examples/Elastic.Channels.Example/Drain.cs
@@ -47,10 +47,10 @@ public static class Drain
 		var bufferOptions = new BufferOptions
 		{
 			WaitHandle = new CountdownEvent(expectedSentBuffers),
-			MaxInFlightMessages = maxInFlight,
-			MaxConsumerBufferSize = bufferSize,
-			ConcurrentConsumers = concurrency,
-			MaxConsumerBufferLifetime = TimeSpan.FromSeconds(20)
+			InboundBufferMaxSize = maxInFlight,
+			OutboundBufferMaxSize = bufferSize,
+			ExportMaxConcurrency = concurrency,
+			OutboundBufferMaxLifetime = TimeSpan.FromSeconds(20)
 
 		};
 		var channel = new DiagnosticsBufferedChannel(bufferOptions, observeConcurrency: false);

--- a/examples/Elastic.Channels.Example/Program.cs
+++ b/examples/Elastic.Channels.Example/Program.cs
@@ -43,7 +43,7 @@ Console.WriteLine();
 Console.WriteLine(channel);
 Console.WriteLine();
 
-Console.WriteLine($"Written buffers: {channel.SentBuffersCount:N0}");
+Console.WriteLine($"Written buffers: {channel.ExportedBuffers:N0}");
 Console.WriteLine($"Written events: {writtenElastic:N0} events");
 Console.WriteLine($"ObservedConcurrency: {channel.ObservedConcurrency:N0}");
 Console.WriteLine($"Duration: {sw.Elapsed:g}");

--- a/examples/Elastic.Ingest.Apm.Example/Program.cs
+++ b/examples/Elastic.Ingest.Apm.Example/Program.cs
@@ -61,7 +61,7 @@ namespace Elastic.Ingest.Apm.Example
 				},
 				ExportMaxRetriesCallback = (list) => Interlocked.Increment(ref _maxRetriesExceeded),
 				ExportRetryCallback = (list) => Interlocked.Increment(ref _retries),
-				ExceptionCallback = (e) => _exception = e
+				ExportExceptionCallback = (e) => _exception = e
 			};
 			var channel = new ApmChannel(channelOptions);
 

--- a/examples/Elastic.Ingest.Apm.Example/Program.cs
+++ b/examples/Elastic.Ingest.Apm.Example/Program.cs
@@ -41,13 +41,13 @@ namespace Elastic.Ingest.Apm.Example
 			var options =
 				new BufferOptions
 				{
-					ConcurrentConsumers = 1,
-					MaxConsumerBufferSize = 200,
-					MaxConsumerBufferLifetime = TimeSpan.FromSeconds(10),
+					ExportMaxConcurrency = 1,
+					OutboundBufferMaxSize = 200,
+					OutboundBufferMaxLifetime = TimeSpan.FromSeconds(10),
 					WaitHandle = handle,
-					MaxRetries = 3,
-					BackoffPeriod = times => TimeSpan.FromMilliseconds(1),
-					BufferExportedCallback = () => Console.WriteLine("Flushed"),
+					ExportMaxRetries = 3,
+					ExportBackoffPeriod = times => TimeSpan.FromMilliseconds(1),
+					ExportBufferCallback = () => Console.WriteLine("Flushed"),
 				};
 			var channelOptions = new ApmChannelOptions(transport)
 			{

--- a/src/Elastic.Channels/BufferOptions.cs
+++ b/src/Elastic.Channels/BufferOptions.cs
@@ -45,7 +45,7 @@ namespace Elastic.Channels
 
 		/// <summary>
 		/// Called once after a buffer has been flushed, if the buffer is retried this callback is only called once
-		/// all retries have been exhausted. Its called regardless of whether the call to <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.Send"/>
+		/// all retries have been exhausted. Its called regardless of whether the call to <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.Export"/>
 		/// succeeded.
 		/// </summary>
 		public Action? BufferExportedCallback { get; set; }

--- a/src/Elastic.Channels/BufferOptions.cs
+++ b/src/Elastic.Channels/BufferOptions.cs
@@ -11,44 +11,51 @@ namespace Elastic.Channels
 	{
 		/// <summary>
 		/// The maximum number of in flight instances that can be queued in memory. If this threshold is reached, events will be dropped
+		/// <para>Defaults to <c>100_000</c></para>
 		/// </summary>
-		public int MaxInFlightMessages { get; set; } = 100_000;
+		public int InboundBufferMaxSize { get; set; } = 100_000;
 
 		/// <summary>
-		/// The number of events a local buffer should reach before sending the events in a single call to Elasticsearch.
+		/// The maximum size to export to <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.Export"/> at once.
+		/// <para>Defaults to <c>1_000</c></para>
 		/// </summary>
-		public int MaxConsumerBufferSize { get; set; } = 1_000;
+		public int OutboundBufferMaxSize { get; set; } = 1_000;
 
 		/// <summary>
-		/// The maximum number of times that an item that returns with a retryable status code is retried to be stored in Elasticsearch.
-		/// <see cref="BackoffPeriod"/> to implement a backoff period of your choosing. MaxRetries default to 3.
+		/// The maximum lifetime of a buffer to export to <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.Export"/>.
+		/// If a buffer is older then the configured <see cref="OutboundBufferMaxLifetime"/> it will be flushed to
+		/// <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.Export"/> regardless of it's current size
+		/// <para>Defaults to <c>5 seconds</c></para>
 		/// </summary>
-		public int MaxRetries { get; set; } = 3;
+		public TimeSpan OutboundBufferMaxLifetime { get; set; } = TimeSpan.FromSeconds(5);
 
 		/// <summary>
-		/// A consumer builds up a local buffer until <see cref="MaxConsumerBufferSize"/> is reached. If events come in too slow, these
-		/// events could end up taking forever to be sent to Elasticsearch. This controls how long a buffer may exist before a flush is triggered.
+		/// The maximum number of consumers allowed to poll for new events on the channel.
+		/// <para>Defaults to <c>1</c>, increase to introduce concurrency.</para>
 		/// </summary>
-		public TimeSpan MaxConsumerBufferLifetime { get; set; } = TimeSpan.FromSeconds(5);
+		public int ExportMaxConcurrency { get; set; } = 1;
 
 		/// <summary>
-		/// The maximum number of consumers allowed to poll for new events on the channel. Defaults to 1, increase to introduce concurrency.
+		/// The times to retry an export if <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.RetryBuffer"/> yields items to retry.
+		/// <para>Whether or not items are selected for retrying depends on the actual channel implementation</para>
+		/// <see cref="ExportBackoffPeriod"/> to implement a backoff period of your choosing.
+		/// <para>Defaults to <c>3</c>, when <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.RetryBuffer"/> yields any items</para>
 		/// </summary>
-		public int ConcurrentConsumers { get; set; } = 1;
+		public int ExportMaxRetries { get; set; } = 3;
 
 
 		/// <summary>
 		/// A function to calculate the backoff period, gets passed the number of retries attempted starting at 0.
 		/// By default backs off in increments of 2 seconds.
 		/// </summary>
-		public Func<int, TimeSpan> BackoffPeriod { get; set; } = (i) => TimeSpan.FromSeconds(2 * (i + 1));
+		public Func<int, TimeSpan> ExportBackoffPeriod { get; set; } = (i) => TimeSpan.FromSeconds(2 * (i + 1));
 
 		/// <summary>
 		/// Called once after a buffer has been flushed, if the buffer is retried this callback is only called once
 		/// all retries have been exhausted. Its called regardless of whether the call to <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.Export"/>
 		/// succeeded.
 		/// </summary>
-		public Action? BufferExportedCallback { get; set; }
+		public Action? ExportBufferCallback { get; set; }
 
 		/// <summary>
 		/// Allows you to inject a <see cref="CountdownEvent"/> to wait for N number of buffers to flush.

--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -126,7 +126,7 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 		return false;
 	}
 
-	protected abstract Task<TResponse> Send(IReadOnlyCollection<TEvent> buffer, CancellationToken ctx = default);
+	protected abstract Task<TResponse> Export(IReadOnlyCollection<TEvent> buffer, CancellationToken ctx = default);
 
 	private static readonly IReadOnlyCollection<TEvent> DefaultRetryBuffer = new TEvent[] { };
 
@@ -180,7 +180,7 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 			TResponse? response;
 			try
 			{
-				response = await Send(items, TokenSource.Token).ConfigureAwait(false);
+				response = await Export(items, TokenSource.Token).ConfigureAwait(false);
 				Options.ExportResponseCallback?.Invoke(response, buffer);
 			}
 			catch (Exception e)

--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Elastic.Channels.Buffers;
 
 namespace Elastic.Channels;
 

--- a/src/Elastic.Channels/Buffers/IWriteTrackingBuffer.cs
+++ b/src/Elastic.Channels/Buffers/IWriteTrackingBuffer.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace Elastic.Channels;
+namespace Elastic.Channels.Buffers;
 
 /// <summary>
 /// Represents a buffer that tracks the <see cref="DurationSinceFirstWrite"/> and it's current <see cref="Count"/>

--- a/src/Elastic.Channels/Buffers/InboundBuffer.cs
+++ b/src/Elastic.Channels/Buffers/InboundBuffer.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 
-namespace Elastic.Channels;
+namespace Elastic.Channels.Buffers;
 
 /// <summary>
 /// <see cref="InboundBuffer{TEvent}"/> is a buffer that will block <see cref="WaitToReadAsync"/> until

--- a/src/Elastic.Channels/Buffers/OutboundBuffer.cs
+++ b/src/Elastic.Channels/Buffers/OutboundBuffer.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Elastic.Channels;
+namespace Elastic.Channels.Buffers;
 
 public interface IOutboundBuffer<out TEvent> : IWriteTrackingBuffer
 {

--- a/src/Elastic.Channels/ChannelOptionsBase.cs
+++ b/src/Elastic.Channels/ChannelOptionsBase.cs
@@ -20,14 +20,10 @@ namespace Elastic.Channels
 
 		public Func<Stream, CancellationToken, TEvent, Task> WriteEvent { get; set; } = null!;
 
-		/// <summary>
-		/// If <see cref="Channels.BufferOptions.InboundBufferMaxSize"/> is reached, <see cref="TEvent"/>'s will fail to be published to the channel. You can be notified of dropped
-		/// events with this callback
-		/// </summary>
-		public Action<TEvent>? PublishRejectionCallback { get; set; }
+		/// <summary> Called if the call to <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.Export"/> throws. </summary>
+		public Action<Exception>? ExportExceptionCallback { get; set; }
 
-		public Action<Exception>? ExceptionCallback { get; set; }
-
+		/// <summary> Called with (number of retries) (number of items to be exported) </summary>
 		public Action<int, int>? ExportItemsAttemptCallback { get; set; }
 
 		/// <summary> Subscribe to be notified of events that are retryable but did not store correctly withing the boundaries of <see cref="Channels.BufferOptions.ExportMaxRetries"/></summary>
@@ -40,20 +36,24 @@ namespace Elastic.Channels
 		public Action<TResponse, IWriteTrackingBuffer>? ExportResponseCallback { get; set; }
 
 		/// <summary>Called everytime an event is written to the inbound channel </summary>
-		public Action? PublishToInboundChannel { get; set; }
+		public Action? PublishToInboundChannelCallback { get; set; }
 
 		/// <summary>Called everytime an event is not written to the inbound channel </summary>
-		public Action? PublishToInboundChannelFailure { get; set; }
+		public Action? PublishToInboundChannelFailureCallback { get; set; }
 
 		/// <summary>Called everytime the inbound channel publishes to the outbound channel. </summary>
-		public Action? PublishToOutboundChannel { get; set; }
+		public Action? PublishToOutboundChannelCallback { get; set; }
 
-		public Action? OutboundChannelStarted { get; set; }
-		public Action? OutboundChannelExited { get; set; }
-		public Action? InboundChannelStarted { get; set; }
+		/// <summary> Called when the thread to read the outbound channel is started </summary>
+		public Action? OutboundChannelStartedCallback { get; set; }
+		/// <summary> Called when the thread to read the outbound channel has exited</summary>
+		public Action? OutboundChannelExitedCallback { get; set; }
+
+		/// <summary> Called when the thread to read the inbound channel has started</summary>
+		public Action? InboundChannelStartedCallback { get; set; }
 
 		/// <summary>Called everytime the inbound channel fails to publish to the outbound channel. </summary>
-		public Action? PublishToOutboundChannelFailure { get; set; }
+		public Action? PublishToOutboundChannelFailureCallback { get; set; }
 	}
 
 }

--- a/src/Elastic.Channels/ChannelOptionsBase.cs
+++ b/src/Elastic.Channels/ChannelOptionsBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Elastic.Channels.Buffers;
 
 namespace Elastic.Channels
 {

--- a/src/Elastic.Channels/ChannelOptionsBase.cs
+++ b/src/Elastic.Channels/ChannelOptionsBase.cs
@@ -21,7 +21,7 @@ namespace Elastic.Channels
 		public Func<Stream, CancellationToken, TEvent, Task> WriteEvent { get; set; } = null!;
 
 		/// <summary>
-		/// If <see cref="Elastic.Channels.BufferOptions.MaxInFlightMessages"/> is reached, <see cref="TEvent"/>'s will fail to be published to the channel. You can be notified of dropped
+		/// If <see cref="Channels.BufferOptions.InboundBufferMaxSize"/> is reached, <see cref="TEvent"/>'s will fail to be published to the channel. You can be notified of dropped
 		/// events with this callback
 		/// </summary>
 		public Action<TEvent>? PublishRejectionCallback { get; set; }
@@ -30,10 +30,10 @@ namespace Elastic.Channels
 
 		public Action<int, int>? ExportItemsAttemptCallback { get; set; }
 
-		/// <summary> Subscribe to be notified of events that are retryable but did not store correctly withing the boundaries of <see cref="Elastic.Channels.BufferOptions.MaxRetries"/></summary>
+		/// <summary> Subscribe to be notified of events that are retryable but did not store correctly withing the boundaries of <see cref="Channels.BufferOptions.ExportMaxRetries"/></summary>
 		public Action<IReadOnlyCollection<TEvent>>? ExportMaxRetriesCallback { get; set; }
 
-		/// <summary> Subscribe to be notified of events that are retryable but did not store correctly within the number of configured <see cref="Elastic.Channels.BufferOptions.MaxRetries"/></summary>
+		/// <summary> Subscribe to be notified of events that are retryable but did not store correctly within the number of configured <see cref="Channels.BufferOptions.ExportMaxRetries"/></summary>
 		public Action<IReadOnlyCollection<TEvent>>? ExportRetryCallback { get; set; }
 
 		/// <summary> A generic hook to be notified of any bulk request being initiated by <see cref="InboundBuffer{TEvent}"/> </summary>

--- a/src/Elastic.Channels/Diagnostics/ChannelListener.cs
+++ b/src/Elastic.Channels/Diagnostics/ChannelListener.cs
@@ -19,7 +19,6 @@ public class ChannelListener<TEvent, TResponse>
 	public ChannelListener(string? name = null) => _name = name;
 
 	private long _responses;
-	private long _rejections;
 	private long _retries;
 	private long _items;
 	private long _maxRetriesExceeded;
@@ -35,7 +34,6 @@ public class ChannelListener<TEvent, TResponse>
 	public ChannelListener<TEvent, TResponse> Register(ChannelOptionsBase<TEvent, TResponse> options)
 	{
 		options.BufferOptions.ExportBufferCallback = () => Interlocked.Increment(ref _exportedBuffers);
-		options.PublishRejectionCallback = _ => Interlocked.Increment(ref _rejections);
 		options.ExportItemsAttemptCallback = (retries, count) =>
 		{
 			if (retries == 0) Interlocked.Add(ref _items, count);
@@ -43,25 +41,27 @@ public class ChannelListener<TEvent, TResponse>
 		options.ExportRetryCallback = _ => Interlocked.Increment(ref _retries);
 		options.ExportResponseCallback = (_, _) => Interlocked.Increment(ref _responses);
 		options.ExportMaxRetriesCallback = _ => Interlocked.Increment(ref _maxRetriesExceeded);
-		options.PublishToInboundChannel = () => Interlocked.Increment(ref _inboundPublishes);
-		options.PublishToInboundChannelFailure = () => Interlocked.Increment(ref _inboundPublishFailures);
-		options.PublishToOutboundChannel = () => Interlocked.Increment(ref _outboundPublishes);
-		options.PublishToOutboundChannelFailure = () => Interlocked.Increment(ref _outboundPublishFailures);
-		options.InboundChannelStarted = () => _inboundChannelStarted = true;
-		options.OutboundChannelStarted = () => _outboundChannelStarted = true;
-		options.OutboundChannelExited = () => _outboundChannelExited = true;
+		options.PublishToInboundChannelCallback = () => Interlocked.Increment(ref _inboundPublishes);
+		options.PublishToInboundChannelFailureCallback = () => Interlocked.Increment(ref _inboundPublishFailures);
+		options.PublishToOutboundChannelCallback = () => Interlocked.Increment(ref _outboundPublishes);
+		options.PublishToOutboundChannelFailureCallback = () => Interlocked.Increment(ref _outboundPublishFailures);
+		options.InboundChannelStartedCallback = () => _inboundChannelStarted = true;
+		options.OutboundChannelStartedCallback = () => _outboundChannelStarted = true;
+		options.OutboundChannelExitedCallback = () => _outboundChannelExited = true;
 
-		if (options.ExceptionCallback == null) options.ExceptionCallback = e => ObservedException ??= e;
-		else options.ExceptionCallback += e => ObservedException ??= e;
+		if (options.ExportExceptionCallback == null) options.ExportExceptionCallback = e => ObservedException ??= e;
+		else options.ExportExceptionCallback += e => ObservedException ??= e;
 		return this;
 	}
 
 	protected virtual string AdditionalData => string.Empty;
 
 	public override string ToString() => $@"{(!PublishSuccess ? "Failed" : "Successful")} publish over channel: {_name ?? nameof(ChannelListener<TEvent, TResponse>)}.
-Total Exported Buffers: {_exportedBuffers:N0}
-Total Exported Items: {_items:N0}
-Responses: {_responses:N0}
+Exported Buffers: {_exportedBuffers:N0}
+Exported Items: {_items:N0}
+Export Responses: {_responses:N0}
+Export Retries: {_retries:N0}
+Export Exhausts: {_maxRetriesExceeded:N0}
 Inbound Buffer Read Loop Started: {_inboundChannelStarted}
 Inbound Buffer Publishes: {_inboundPublishes:N0}
 Inbound Buffer Publish Failures: {_inboundPublishFailures:N0}
@@ -69,8 +69,7 @@ Outbound Buffer Read Loop Started: {_outboundChannelStarted}
 Outbound Buffer Read Loop Exited: {_outboundChannelExited}
 Outbound Buffer Publishes: {_outboundPublishes:N0}
 Outbound Buffer Publish Failures: {_outboundPublishes:N0}
-Export() Retries: {_retries:N0}
-Export() Exhausts: {_maxRetriesExceeded:N0}{AdditionalData}
+{AdditionalData}
 Exception: {ObservedException}
 ";
 }

--- a/src/Elastic.Channels/Diagnostics/ChannelListener.cs
+++ b/src/Elastic.Channels/Diagnostics/ChannelListener.cs
@@ -69,8 +69,8 @@ Outbound Buffer Read Loop Started: {_outboundChannelStarted}
 Outbound Buffer Read Loop Exited: {_outboundChannelExited}
 Outbound Buffer Publishes: {_outboundPublishes:N0}
 Outbound Buffer Publish Failures: {_outboundPublishes:N0}
-Send() Retries: {_retries:N0}
-Send() Exhausts: {_maxRetriesExceeded:N0}{AdditionalData}
+Export() Retries: {_retries:N0}
+Export() Exhausts: {_maxRetriesExceeded:N0}{AdditionalData}
 Exception: {ObservedException}
 ";
 }

--- a/src/Elastic.Channels/Diagnostics/ChannelListener.cs
+++ b/src/Elastic.Channels/Diagnostics/ChannelListener.cs
@@ -34,7 +34,7 @@ public class ChannelListener<TEvent, TResponse>
 	// ReSharper disable once MemberCanBeProtected.Global
 	public ChannelListener<TEvent, TResponse> Register(ChannelOptionsBase<TEvent, TResponse> options)
 	{
-		options.BufferOptions.BufferExportedCallback = () => Interlocked.Increment(ref _exportedBuffers);
+		options.BufferOptions.ExportBufferCallback = () => Interlocked.Increment(ref _exportedBuffers);
 		options.PublishRejectionCallback = _ => Interlocked.Increment(ref _rejections);
 		options.ExportItemsAttemptCallback = (retries, count) =>
 		{

--- a/src/Elastic.Channels/Diagnostics/DiagnosticsBufferedChannel.cs
+++ b/src/Elastic.Channels/Diagnostics/DiagnosticsBufferedChannel.cs
@@ -29,7 +29,7 @@ InboundBuffer Count: {InboundBuffer.Count:N0}
 InboundBuffer Duration Since First Wait: {InboundBuffer.DurationSinceFirstWaitToRead}
 InboundBuffer Duration Since First Write: {InboundBuffer.DurationSinceFirstWrite}
 InboundBuffer No Thresholds hit: {InboundBuffer.NoThresholdsHit}
-Send Invocations: {SentBuffersCount:N0}
+Exported Buffers: {ExportedBuffers:N0}
 Observed Concurrency: {ObservedConcurrency:N0}
 ------------------------------------------";
 }

--- a/src/Elastic.Channels/Diagnostics/NoopBufferedChannel.cs
+++ b/src/Elastic.Channels/Diagnostics/NoopBufferedChannel.cs
@@ -11,7 +11,7 @@ namespace Elastic.Channels.Diagnostics;
 
 /// <summary>
 /// A NOOP implementation of <see cref="BufferedChannelBase{TEvent,TResponse}"/> that:
-/// <para> -tracks the number of times <see cref="Export"/> is invoked under <see cref="SentBuffersCount"/> </para>
+/// <para> -tracks the number of times <see cref="Export"/> is invoked under <see cref="ExportedBuffers"/> </para>
 /// <para> -observes the maximum concurrent calls to <see cref="Export"/> under <see cref="ObservedConcurrency"/> </para>
 /// </summary>
 public class NoopBufferedChannel
@@ -31,15 +31,15 @@ public class NoopBufferedChannel
 		ObserverConcurrency = observeConcurrency
 	}) { }
 
-	private long _sentBuffersCount;
-	public long SentBuffersCount => _sentBuffersCount;
+	private long _exportedBuffers;
+	public long ExportedBuffers => _exportedBuffers;
 
 	private int _currentMax;
 	public int ObservedConcurrency { get; private set; }
 
 	protected override async Task<NoopResponse> Export(IReadOnlyCollection<NoopEvent> buffer, CancellationToken ctx = default)
 	{
-		Interlocked.Increment(ref _sentBuffersCount);
+		Interlocked.Increment(ref _exportedBuffers);
 		if (!Options.ObserverConcurrency) return new NoopResponse();
 
 		var max = Interlocked.Increment(ref _currentMax);

--- a/src/Elastic.Channels/Diagnostics/NoopBufferedChannel.cs
+++ b/src/Elastic.Channels/Diagnostics/NoopBufferedChannel.cs
@@ -11,8 +11,8 @@ namespace Elastic.Channels.Diagnostics;
 
 /// <summary>
 /// A NOOP implementation of <see cref="BufferedChannelBase{TEvent,TResponse}"/> that:
-/// <para> -tracks the number of times <see cref="Send"/> is invoked under <see cref="SentBuffersCount"/> </para>
-/// <para> -observes the maximum concurrent calls to <see cref="Send"/> under <see cref="ObservedConcurrency"/> </para>
+/// <para> -tracks the number of times <see cref="Export"/> is invoked under <see cref="SentBuffersCount"/> </para>
+/// <para> -observes the maximum concurrent calls to <see cref="Export"/> under <see cref="ObservedConcurrency"/> </para>
 /// </summary>
 public class NoopBufferedChannel
 	: BufferedChannelBase<NoopBufferedChannel.NoopChannelOptions, NoopBufferedChannel.NoopEvent, NoopBufferedChannel.NoopResponse>
@@ -37,7 +37,7 @@ public class NoopBufferedChannel
 	private int _currentMax;
 	public int ObservedConcurrency { get; private set; }
 
-	protected override async Task<NoopResponse> Send(IReadOnlyCollection<NoopEvent> buffer, CancellationToken ctx = default)
+	protected override async Task<NoopResponse> Export(IReadOnlyCollection<NoopEvent> buffer, CancellationToken ctx = default)
 	{
 		Interlocked.Increment(ref _sentBuffersCount);
 		if (!Options.ObserverConcurrency) return new NoopResponse();

--- a/src/Elastic.Channels/README.md
+++ b/src/Elastic.Channels/README.md
@@ -78,11 +78,11 @@ Each `ChannelOptionsBase<>` implementation takes and exposes a `BufferOptions` i
 
 | Option                      | Description                                                                                                                  |
 |-----------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| `MaxInFlightMessages`       | The maximum number of in flight instances that can be queued in memory. If this threshold is reached, events will be dropped |
-| `MaxConsumerBufferSize`     | The number of events a local buffer should reach before sending the events in a single call to Elasticsearch.                |
-| `MaxRetries`                | The maximum number of retries over `Export`                                                                                  |
-| `MaxConsumerBufferLifetime` | The maximum age of buffer before its flushed                                                                                 |
-| `ConcurrentConsumers`       | Controls how many concurrent `Export` operations may occur                                                                   |
-| `BackOfPeriod`              | Func that calculates an appropriate backoff time for a retry                                                                 |
-| `BufferFlushCallback`       | Called `once` whenever a buffer is flushed, excluding retries                                                                |
+| `InboundBufferMaxSize`      | The maximum number of in flight instances that can be queued in memory. If this threshold is reached, events will be dropped |
+| `OutboundBufferMaxSize`     | The number of events a local buffer should reach before sending the events in a single call to Elasticsearch.                |
+| `OutboundBufferMaxLifetime` | The maximum age of buffer before its flushed                                                                                 |
+| `ExportMaxConcurrency`      | Controls how many concurrent `Export` operations may occur                                                                   |
+| `ExportMaxRetries`          | The maximum number of retries over `Export`                                                                                  |
+| `ExportBackOfPeriod`        | Func that calculates an appropriate backoff time for a retry                                                                 |
+| `ExportBufferCallback`      | Called `once` whenever a buffer is flushed, excluding retries                                                                |
 | `WaitHandle`                | Inject a waithandle that will be signalled after each flush, excluding retries.                                              |

--- a/src/Elastic.Channels/README.md
+++ b/src/Elastic.Channels/README.md
@@ -10,7 +10,7 @@ This allows data of various rates to pushed in the same manner while different i
 This package serves mainly as a core library with abstract classes 
 and does not ship any useful implementations.
 
-It ships with a `NoopBufferedChannel` implementation that does nothing in its `Send` implementation for unit test and benchmark purposes.
+It ships with a `NoopBufferedChannel` implementation that does nothing in its `ExporExport implementation for unit test and benchmark purposes.
 
 
 ## BufferedChannelBase<>
@@ -18,7 +18,7 @@ It ships with a `NoopBufferedChannel` implementation that does nothing in its `S
 An abstract class that requires implementers to implement:
 
 ```csharp
-protected abstract Task<TResponse> Send(IReadOnlyCollection<TEvent> buffer);
+protected abstract Task<TResponse> Export(IReadOnlyCollection<TEvent> buffer, CancellationToken ctx);
 ```
 
 Any implementation allows data to pushed to it through:
@@ -51,7 +51,7 @@ public class NoopBufferedChannel
   public NoopBufferedChannel(NoopChannelOptions options) 
     : base(options) { }
 
-  protected override Task<Response> Send(IReadOnlyCollection<NoopEvent> buffer)
+  protected override Task<Response> Export(IReadOnlyCollection<NoopEvent> buffer, CancellationToken ctx)
   {
     return Task.FromResult(new Response());
   }
@@ -66,6 +66,10 @@ if (await noopChannel.WaitToWriteAsync(e))
 	written++;
 ```
 
+Both `NoopBufferedChannel` and a more specialized `DiagnosticsBufferedChannel` exist for test or debugging purposes.
+
+`DiagnosticsBufferedChannel.ToString()` uncovers a lot of insights into the state machinery. 
+
 
 ## BufferOptions
 
@@ -76,9 +80,9 @@ Each `ChannelOptionsBase<>` implementation takes and exposes a `BufferOptions` i
 |-----------------------------|------------------------------------------------------------------------------------------------------------------------------|
 | `MaxInFlightMessages`       | The maximum number of in flight instances that can be queued in memory. If this threshold is reached, events will be dropped |
 | `MaxConsumerBufferSize`     | The number of events a local buffer should reach before sending the events in a single call to Elasticsearch.                |
-| `MaxRetries`                | The maximum number of retries over `Send`                                                                                    |
+| `MaxRetries`                | The maximum number of retries over `Export`                                                                                  |
 | `MaxConsumerBufferLifetime` | The maximum age of buffer before its flushed                                                                                 |
-| `ConcurrentConsumers`       | Controls how many concurrent `Send` operations may occur                                                                     |
+| `ConcurrentConsumers`       | Controls how many concurrent `Export` operations may occur                                                                   |
 | `BackOfPeriod`              | Func that calculates an appropriate backoff time for a retry                                                                 |
 | `BufferFlushCallback`       | Called `once` whenever a buffer is flushed, excluding retries                                                                |
 | `WaitHandle`                | Inject a waithandle that will be signalled after each flush, excluding retries.                                              |

--- a/src/Elastic.Channels/ResponseItemsBufferedChannelBase.cs
+++ b/src/Elastic.Channels/ResponseItemsBufferedChannelBase.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Elastic.Channels.Buffers;
 
 namespace Elastic.Channels;
 

--- a/src/Elastic.Ingest.Apm/ApmChannel.cs
+++ b/src/Elastic.Ingest.Apm/ApmChannel.cs
@@ -48,7 +48,7 @@ namespace Elastic.Ingest.Apm
 		protected override bool RetryEvent((IIntakeObject, IntakeErrorItem) @event) => false;
 		protected override bool RejectEvent((IIntakeObject, IntakeErrorItem) @event) => false;
 
-		protected override Task<EventIntakeResponse> Send(HttpTransport transport, IReadOnlyCollection<IIntakeObject> page, CancellationToken ctx = default) =>
+		protected override Task<EventIntakeResponse> Export(HttpTransport transport, IReadOnlyCollection<IIntakeObject> page, CancellationToken ctx = default) =>
 			transport.RequestAsync<EventIntakeResponse>(HttpMethod.POST, "/intake/v2/events",
 				PostData.StreamHandler(page,
 					(_, _) =>

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
@@ -39,7 +39,7 @@ namespace Elastic.Ingest.Elasticsearch
 		protected override bool RejectEvent((TEvent, BulkResponseItem) @event) =>
 			@event.Item2.Status < 200 || @event.Item2.Status > 300;
 
-		protected override Task<BulkResponse> Send(HttpTransport transport, IReadOnlyCollection<TEvent> page, CancellationToken ctx = default) =>
+		protected override Task<BulkResponse> Export(HttpTransport transport, IReadOnlyCollection<TEvent> page, CancellationToken ctx = default) =>
 			transport.RequestAsync<BulkResponse>(HttpMethod.POST, "/_bulk",
 				PostData.StreamHandler(page,
 					(_, _) =>

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
@@ -24,7 +24,7 @@ namespace Elastic.Ingest.Elasticsearch
 		{
 			var details = response.ApiCallDetails;
 			if (!details.HasSuccessfulStatusCode)
-				Options.ExceptionCallback?.Invoke(new Exception(details.ToString(), details.OriginalException));
+				Options.ExportExceptionCallback?.Invoke(new Exception(details.ToString(), details.OriginalException));
 			return details.HasSuccessfulStatusCode;
 		}
 

--- a/src/Elastic.Ingest.OpenTelemetry/CustomOtlpTraceExporter.cs
+++ b/src/Elastic.Ingest.OpenTelemetry/CustomOtlpTraceExporter.cs
@@ -55,10 +55,10 @@ namespace Elastic.Ingest.OpenTelemetry
             o.Headers = $"Authorization=Bearer {options.SecretToken}";
             TraceExporter = new CustomOtlpTraceExporter(o, options);
             Processor = new CustomActivityProcessor(TraceExporter,
-				maxExportBatchSize: options.BufferOptions.MaxConsumerBufferSize,
-				maxQueueSize: options.BufferOptions.MaxInFlightMessages,
-				scheduledDelayMilliseconds: (int)options.BufferOptions.MaxConsumerBufferLifetime.TotalMilliseconds,
-				exporterTimeoutMilliseconds: (int)options.BufferOptions.MaxConsumerBufferLifetime.TotalMilliseconds
+				maxExportBatchSize: options.BufferOptions.OutboundBufferMaxSize,
+				maxQueueSize: options.BufferOptions.InboundBufferMaxSize,
+				scheduledDelayMilliseconds: (int)options.BufferOptions.OutboundBufferMaxLifetime.TotalMilliseconds,
+				exporterTimeoutMilliseconds: (int)options.BufferOptions.OutboundBufferMaxLifetime.TotalMilliseconds
 			);
 			var bufferType = typeof(BaseExporter<>).Assembly.GetTypes().First(t=>t.Name == "CircularBuffer`1");
 			var activityBuffer = bufferType.GetGenericTypeDefinition().MakeGenericType(typeof(Activity));
@@ -70,9 +70,9 @@ namespace Elastic.Ingest.OpenTelemetry
 
 			BatchCreator = (page) =>
 			{
-				var buffer = bufferTypeConstructor.Invoke(new object[] {options.BufferOptions.MaxConsumerBufferSize });
+				var buffer = bufferTypeConstructor.Invoke(new object[] {options.BufferOptions.OutboundBufferMaxSize });
 				bufferAddMethod.Invoke(buffer, new[] { page });
-				var batch = (Batch<Activity>)batchConstructor.Invoke(new[] {buffer, options.BufferOptions.MaxConsumerBufferSize });
+				var batch = (Batch<Activity>)batchConstructor.Invoke(new[] {buffer, options.BufferOptions.OutboundBufferMaxSize });
 				return batch;
 			};
 

--- a/src/Elastic.Ingest.OpenTelemetry/CustomOtlpTraceExporter.cs
+++ b/src/Elastic.Ingest.OpenTelemetry/CustomOtlpTraceExporter.cs
@@ -84,7 +84,7 @@ namespace Elastic.Ingest.OpenTelemetry
 
 		public CustomActivityProcessor Processor { get; }
 
-		protected override Task<TraceExportResult> Send(IReadOnlyCollection<Activity> page, CancellationToken ctx = default)
+		protected override Task<TraceExportResult> Export(IReadOnlyCollection<Activity> page, CancellationToken ctx = default)
 		{
 			var batch = BatchCreator(page);
 			var result = TraceExporter.Export(batch);

--- a/src/Elastic.Ingest.Transport/TransportChannelBase.cs
+++ b/src/Elastic.Ingest.Transport/TransportChannelBase.cs
@@ -22,8 +22,8 @@ namespace Elastic.Ingest.Transport
 		/// <param name="transport"></param>
 		/// <param name="page">Active page of the buffer that needs to be send to the output</param>
 		/// <returns><see cref="TResponse"/></returns>
-		protected abstract Task<TResponse> Send(HttpTransport transport, IReadOnlyCollection<TEvent> page, CancellationToken ctx = default);
+		protected abstract Task<TResponse> Export(HttpTransport transport, IReadOnlyCollection<TEvent> page, CancellationToken ctx = default);
 
-		protected override Task<TResponse> Send(IReadOnlyCollection<TEvent> buffer, CancellationToken ctx = default) => Send(Options.Transport, buffer, ctx);
+		protected override Task<TResponse> Export(IReadOnlyCollection<TEvent> buffer, CancellationToken ctx = default) => Export(Options.Transport, buffer, ctx);
 	}
 }

--- a/tests/Elastic.Channels.Tests/BehaviorTests.cs
+++ b/tests/Elastic.Channels.Tests/BehaviorTests.cs
@@ -39,7 +39,7 @@ namespace Elastic.Channels.Tests
 			var signalled = bufferOptions.WaitHandle.Wait(TimeSpan.FromSeconds(5));
 			signalled.Should().BeTrue("The channel was not drained in the expected time");
 			written.Should().Be(totalEvents);
-			channel.SentBuffersCount.Should().Be(expectedSentBuffers);
+			channel.ExportedBuffers.Should().Be(expectedSentBuffers);
 		}
 
 		/// <summary>
@@ -69,7 +69,7 @@ namespace Elastic.Channels.Tests
 			var signalled = bufferOptions.WaitHandle.Wait(TimeSpan.FromSeconds(1));
 			signalled.Should().BeTrue("The channel was not drained in the expected time");
 			written.Should().Be(100);
-			channel.SentBuffersCount.Should().Be(1);
+			channel.ExportedBuffers.Should().Be(1);
 		}
 
 		[Fact] public async Task ConcurrencyIsApplied()
@@ -96,7 +96,7 @@ namespace Elastic.Channels.Tests
 			var signalled = bufferOptions.WaitHandle.Wait(TimeSpan.FromSeconds(5));
 			signalled.Should().BeTrue("The channel was not drained in the expected time");
 			written.Should().Be(totalEvents);
-			channel.SentBuffersCount.Should().Be(expectedPages);
+			channel.ExportedBuffers.Should().Be(expectedPages);
 			channel.ObservedConcurrency.Should().Be(4);
 		}
 
@@ -130,7 +130,7 @@ namespace Elastic.Channels.Tests
 				bufferOptions.WaitHandle.Wait(TimeSpan.FromMilliseconds(500));
 
 				written.Should().BeGreaterThan(0).And.BeLessThan(totalEvents);
-				channel.SentBuffersCount.Should().BeGreaterThan(0, "Parallel invocation: {0} channel: {1}", taskNumber, channel);
+				channel.ExportedBuffers.Should().BeGreaterThan(0, "Parallel invocation: {0} channel: {1}", taskNumber, channel);
 				Interlocked.Increment(ref closedThread);
 				return t;
 			}
@@ -170,9 +170,9 @@ namespace Elastic.Channels.Tests
 			bufferOptions.WaitHandle.Wait(TimeSpan.FromMilliseconds(500));
 			//Ensure we written to the channel but not enough to satisfy MaxConsumerBufferSize
 			written.Should().BeGreaterThan(0).And.BeLessThan(10_000);
-			//even though MaxConsumerBufferSize was not hit we should still observe an invocation to Send()
+			//even though MaxConsumerBufferSize was not hit we should still observe an invocation to Export()
 			//because MaxConsumerBufferLifeTime was hit
-			channel.SentBuffersCount.Should().BeGreaterThan(0, "{0}", channel);
+			channel.ExportedBuffers.Should().BeGreaterThan(0, "{0}", channel);
 		}
 	}
 }

--- a/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/DataStreamIngestionTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/DataStreamIngestionTests.cs
@@ -29,7 +29,7 @@ namespace Elastic.Ingest.Elasticsearch.IntegrationTests
 			var options = new DataStreamChannelOptions<TimeSeriesDocument>(Client.Transport)
 			{
 				DataStream = targetDataStream,
-				BufferOptions = new BufferOptions { WaitHandle = slim, MaxConsumerBufferSize = 1 }
+				BufferOptions = new BufferOptions { WaitHandle = slim, OutboundBufferMaxSize = 1 }
 			};
 			var channel = new DataStreamChannel<TimeSeriesDocument>(options);
 

--- a/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/IndexIngestionTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/IndexIngestionTests.cs
@@ -32,7 +32,7 @@ namespace Elastic.Ingest.Elasticsearch.IntegrationTests
 				TimestampLookup = c => c.Created,
 				BufferOptions = new BufferOptions
 				{
-					WaitHandle = slim, MaxConsumerBufferSize = 1,
+					WaitHandle = slim, OutboundBufferMaxSize = 1,
 				}
 			};
 			var channel = new IndexChannel<CatalogDocument>(options);

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/Setup.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/Setup.cs
@@ -48,12 +48,12 @@ namespace Elastic.Ingest.Elasticsearch.Tests
 				Transport = transport;
 				BufferOptions = new BufferOptions
 				{
-					ConcurrentConsumers = 1,
-					MaxConsumerBufferSize = 2,
-					MaxConsumerBufferLifetime = TimeSpan.FromSeconds(10),
+					ExportMaxConcurrency = 1,
+					OutboundBufferMaxSize = 2,
+					OutboundBufferMaxLifetime = TimeSpan.FromSeconds(10),
 					WaitHandle = WaitHandle,
-					MaxRetries = 3,
-					BackoffPeriod = _ => TimeSpan.FromMilliseconds(1),
+					ExportMaxRetries = 3,
+					ExportBackoffPeriod = _ => TimeSpan.FromMilliseconds(1),
 				};
 				ChannelOptions = new IndexChannelOptions<TestDocument>(transport)
 				{

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/Setup.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/Setup.cs
@@ -63,7 +63,7 @@ namespace Elastic.Ingest.Elasticsearch.Tests
 					ExportResponseCallback = (_, _) => Interlocked.Increment(ref _responses),
 					ExportMaxRetriesCallback = (_) => Interlocked.Increment(ref _maxRetriesExceeded),
 					ExportRetryCallback = (_) => Interlocked.Increment(ref _retries),
-					ExceptionCallback= (e) => LastException = e
+					ExportExceptionCallback= (e) => LastException = e
 				};
 				Channel = new IndexChannel<TestDocument>(ChannelOptions);
 			}


### PR DESCRIPTION
- Rename Send() to Export()
- Update naming in readme's
- Rename buffer options to be more alligned and normalized
- rename channeloptions
- Move internal buffers to Elastic.Ingest.Buffers namespace
