### PR TITLE
Prefer index name on URL for fixed index names and data streams

### DIFF
--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkIngestionBenchmarks.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkIngestionBenchmarks.cs
@@ -8,7 +8,7 @@ using Performance.Common;
 namespace Elastic.Ingest.Elasticsearch.Benchmarks;
 
 [SimpleJob(RunStrategy.Monitoring, invocationCount: 10, id: "BulkIngestionJob")]
-public class BulkIngestion
+public class BulkIngestionBenchmarks
 {
 	private static readonly int MaxExportSize = 5_000;
 	

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkRequestCreationBenchmarks.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkRequestCreationBenchmarks.cs
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Ingest.Elasticsearch.Serialization;
+using Performance.Common;
+
+namespace Elastic.Ingest.Elasticsearch.Benchmarks.Benchmarks;
+
+public class BulkRequestCreationBenchmarks
+{
+	private static readonly int DocumentsToIndex = 1_000;
+
+	private IndexChannelOptions<StockData>? _options;
+	private HttpTransport? _transport;
+	private TransportConfiguration? _transportConfiguration;
+	private StockData[] _data = Array.Empty<StockData>();
+
+	public Stream MemoryStream { get; } = new MemoryStream();
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		_transportConfiguration = new TransportConfiguration(
+				new SingleNodePool(new("http://localhost:9200")),
+				new InMemoryConnection(StockData.CreateSampleDataSuccessWithFilterPathResponseBytes(DocumentsToIndex)));
+
+		_transport = new DefaultHttpTransport(_transportConfiguration);
+
+		_options = new IndexChannelOptions<StockData>(_transport)
+		{
+			BufferOptions = new Channels.BufferOptions
+			{
+				OutboundBufferMaxSize = DocumentsToIndex
+			},
+			IndexFormat = "stock-data-v8"
+		};
+
+		_data = StockData.CreateSampleData(DocumentsToIndex);
+	}
+
+	[Benchmark(Baseline = true)]
+	public async Task FixedIndexName_WriteToStreamAsync()
+	{
+		MemoryStream.Position = 0;
+		var bytes = BulkRequestDataFactory.GetBytes(_data, _options!, CreateBulkOperationHeaderOld);
+		var requestData = new RequestData(Elastic.Transport.HttpMethod.POST, "/_bulk", PostData.ReadOnlyMemory(bytes), _transportConfiguration!, null!, ((ITransportConfiguration)_transportConfiguration!).MemoryStreamFactory);
+		await requestData.PostData.WriteAsync(MemoryStream, _transportConfiguration!, CancellationToken.None);
+	}
+
+	[Benchmark]
+	public async Task FixedIndexName_WriteToStreamOptimizedAsync()
+	{
+		MemoryStream.Position = 0;
+		var bytes = BulkRequestDataFactory.GetBytes(_data, _options!, e => BulkRequestDataFactory.CreateBulkOperationHeaderForIndex(e, _options!, true));
+		var requestData = new RequestData(Elastic.Transport.HttpMethod.POST, "/_bulk", PostData.ReadOnlyMemory(bytes), _transportConfiguration!, null!, ((ITransportConfiguration)_transportConfiguration!).MemoryStreamFactory);
+		await requestData.PostData.WriteAsync(MemoryStream, _transportConfiguration!, CancellationToken.None);
+	}
+
+	// This is duplicated from the original code for the purpose of comparison
+	private BulkOperationHeader CreateBulkOperationHeaderOld(StockData @event)
+	{
+		var indexTime = _options!.TimestampLookup?.Invoke(@event) ?? DateTimeOffset.Now;
+		if(_options.IndexOffset.HasValue) indexTime = indexTime.ToOffset(_options.IndexOffset.Value);
+
+		var index = string.Format(_options.IndexFormat, indexTime);
+		var id = _options.BulkOperationIdLookup?.Invoke(@event);
+		if (!string.IsNullOrWhiteSpace(id) && id != null && (_options.BulkUpsertLookup?.Invoke(@event, id) ?? false))
+			return new UpdateOperation { Id = id, Index = index };
+		return
+			!string.IsNullOrWhiteSpace(id)
+				? new IndexOperation { Index = index, Id = id }
+				: new CreateOperation { Index = index };
+	}
+}

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkRequestCreationWithFixedIndexNameBenchmarks.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkRequestCreationWithFixedIndexNameBenchmarks.cs
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Ingest.Elasticsearch.Serialization;
+using Performance.Common;
+
+namespace Elastic.Ingest.Elasticsearch.Benchmarks.Benchmarks;
+
+public class BulkRequestCreationWithFixedIndexNameBenchmarks
+{
+	private static readonly int DocumentsToIndex = 1_000;
+
+	private IndexChannelOptions<StockData>? _options;
+	private HttpTransport? _transport;
+	private TransportConfiguration? _transportConfiguration;
+	private StockData[] _data = Array.Empty<StockData>();
+
+	public Stream MemoryStream { get; } = new MemoryStream();
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		_transportConfiguration = new TransportConfiguration(
+				new SingleNodePool(new("http://localhost:9200")),
+				new InMemoryConnection(StockData.CreateSampleDataSuccessWithFilterPathResponseBytes(DocumentsToIndex)));
+
+		_transport = new DefaultHttpTransport(_transportConfiguration);
+
+		_options = new IndexChannelOptions<StockData>(_transport)
+		{
+			BufferOptions = new Channels.BufferOptions
+			{
+				OutboundBufferMaxSize = DocumentsToIndex
+			},
+			IndexFormat = "stock-data-v8"
+		};
+
+		_data = StockData.CreateSampleData(DocumentsToIndex);
+	}
+
+	[Benchmark(Baseline = true)]
+	public async Task FixedIndexName_WriteToStreamAsync()
+	{
+		MemoryStream.Position = 0;
+		var bytes = BulkRequestDataFactory.GetBytes(_data, _options!, CreateBulkOperationHeaderOld);
+		var requestData = new RequestData(Elastic.Transport.HttpMethod.POST, "/_bulk", PostData.ReadOnlyMemory(bytes), _transportConfiguration!, null!, ((ITransportConfiguration)_transportConfiguration!).MemoryStreamFactory);
+		await requestData.PostData.WriteAsync(MemoryStream, _transportConfiguration!, CancellationToken.None);
+	}
+
+	[Benchmark]
+	public async Task FixedIndexName_WriteToStreamOptimizedAsync()
+	{
+		MemoryStream.Position = 0;
+		var bytes = BulkRequestDataFactory.GetBytes(_data, _options!, e => BulkRequestDataFactory.CreateBulkOperationHeaderForIndex(e, _options!, true));
+		var requestData = new RequestData(Elastic.Transport.HttpMethod.POST, "/_bulk", PostData.ReadOnlyMemory(bytes), _transportConfiguration!, null!, ((ITransportConfiguration)_transportConfiguration!).MemoryStreamFactory);
+		await requestData.PostData.WriteAsync(MemoryStream, _transportConfiguration!, CancellationToken.None);
+	}
+
+	// This is duplicated from the original code for the purpose of comparison
+	private BulkOperationHeader CreateBulkOperationHeaderOld(StockData @event)
+	{
+		var indexTime = _options!.TimestampLookup?.Invoke(@event) ?? DateTimeOffset.Now;
+		if(_options.IndexOffset.HasValue) indexTime = indexTime.ToOffset(_options.IndexOffset.Value);
+
+		var index = string.Format(_options.IndexFormat, indexTime);
+		var id = _options.BulkOperationIdLookup?.Invoke(@event);
+		if (!string.IsNullOrWhiteSpace(id) && id != null && (_options.BulkUpsertLookup?.Invoke(@event, id) ?? false))
+			return new UpdateOperation { Id = id, Index = index };
+		return
+			!string.IsNullOrWhiteSpace(id)
+				? new IndexOperation { Index = index, Id = id }
+				: new CreateOperation { Index = index };
+	}
+}

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkRequestCreationWithFixedIndexNameBenchmarks.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkRequestCreationWithFixedIndexNameBenchmarks.cs
@@ -43,33 +43,8 @@ public class BulkRequestCreationWithFixedIndexNameBenchmarks
 	public async Task FixedIndexName_WriteToStreamAsync()
 	{
 		MemoryStream.Position = 0;
-		var bytes = BulkRequestDataFactory.GetBytes(_data, _options!, CreateBulkOperationHeaderOld);
-		var requestData = new RequestData(Elastic.Transport.HttpMethod.POST, "/_bulk", PostData.ReadOnlyMemory(bytes), _transportConfiguration!, null!, ((ITransportConfiguration)_transportConfiguration!).MemoryStreamFactory);
-		await requestData.PostData.WriteAsync(MemoryStream, _transportConfiguration!, CancellationToken.None);
-	}
-
-	[Benchmark]
-	public async Task FixedIndexName_WriteToStreamOptimizedAsync()
-	{
-		MemoryStream.Position = 0;
 		var bytes = BulkRequestDataFactory.GetBytes(_data, _options!, e => BulkRequestDataFactory.CreateBulkOperationHeaderForIndex(e, _options!, true));
 		var requestData = new RequestData(Elastic.Transport.HttpMethod.POST, "/_bulk", PostData.ReadOnlyMemory(bytes), _transportConfiguration!, null!, ((ITransportConfiguration)_transportConfiguration!).MemoryStreamFactory);
 		await requestData.PostData.WriteAsync(MemoryStream, _transportConfiguration!, CancellationToken.None);
-	}
-
-	// This is duplicated from the original code for the purpose of comparison
-	private BulkOperationHeader CreateBulkOperationHeaderOld(StockData @event)
-	{
-		var indexTime = _options!.TimestampLookup?.Invoke(@event) ?? DateTimeOffset.Now;
-		if(_options.IndexOffset.HasValue) indexTime = indexTime.ToOffset(_options.IndexOffset.Value);
-
-		var index = string.Format(_options.IndexFormat, indexTime);
-		var id = _options.BulkOperationIdLookup?.Invoke(@event);
-		if (!string.IsNullOrWhiteSpace(id) && id != null && (_options.BulkUpsertLookup?.Invoke(@event, id) ?? false))
-			return new UpdateOperation { Id = id, Index = index };
-		return
-			!string.IsNullOrWhiteSpace(id)
-				? new IndexOperation { Index = index, Id = id }
-				: new CreateOperation { Index = index };
 	}
 }

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks.csproj
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Program.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Program.cs
@@ -12,17 +12,28 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using System.Globalization;
+using Elastic.Ingest.Elasticsearch.Benchmarks.Benchmarks;
 
 #if DEBUG
 // MANUALLY RUN A BENCHMARKED METHOD DURING DEBUGGING
+
 //var bm = new BulkIngestion();
 //bm.Setup();
 //await bm.BulkAllAsync();
 //Console.WriteLine("DONE");
+
+var bm = new BulkRequestCreationBenchmarks();
+bm.Setup();
+await bm.WriteToStreamOptimizedAsync();
+bm.MemoryStream.Position = 0;
+var sr = new StreamReader(bm.MemoryStream);
+var json = sr.ReadToEnd();
+
+Console.ReadKey();
 #else
 var config = ManualConfig.Create(DefaultConfig.Instance);
 config.SummaryStyle = new SummaryStyle(CultureInfo.CurrentCulture, true, BenchmarkDotNet.Columns.SizeUnit.B, null!, ratioStyle: BenchmarkDotNet.Columns.RatioStyle.Percentage);
 config.AddDiagnoser(MemoryDiagnoser.Default);
 
-BenchmarkRunner.Run<BulkIngestion>(config);
+BenchmarkRunner.Run<BulkRequestCreationBenchmarks>(config);
 #endif

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Program.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Program.cs
@@ -35,5 +35,5 @@ var config = ManualConfig.Create(DefaultConfig.Instance);
 config.SummaryStyle = new SummaryStyle(CultureInfo.CurrentCulture, true, BenchmarkDotNet.Columns.SizeUnit.B, null!, ratioStyle: BenchmarkDotNet.Columns.RatioStyle.Percentage);
 config.AddDiagnoser(MemoryDiagnoser.Default);
 
-BenchmarkRunner.Run<BulkRequestCreationBenchmarks>(config);
+BenchmarkRunner.Run<BulkRequestCreationWithTemplatedIndexNameBenchmarks>(config);
 #endif

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Program.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Program.cs
@@ -22,9 +22,12 @@ using Elastic.Ingest.Elasticsearch.Benchmarks.Benchmarks;
 //await bm.BulkAllAsync();
 //Console.WriteLine("DONE");
 
-var bm = new BulkRequestCreationBenchmarks();
+var bm = new BulkRequestCreationWithFixedIndexNameBenchmarks();
 bm.Setup();
-await bm.WriteToStreamOptimizedAsync();
+await bm.WriteToStreamAsync_OLD();
+
+var length = bm.MemoryStream.Length;
+
 bm.MemoryStream.Position = 0;
 var sr = new StreamReader(bm.MemoryStream);
 var json = sr.ReadToEnd();

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Results/ManualResults.txt
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Results/ManualResults.txt
@@ -46,3 +46,12 @@ Baseline for commit 8eef0e1dfbee8c5198ec0ab975b5d826e2356fcd (from 2023-05-02) i
 | BulkAll |              False |              True |  116.5 ms |   47.78 ms |    31.60 ms | 11600.0000 | 2400.0000 | 2000.0000 |    97934119 B |
 | BulkAll |               True |             False |  150.9 ms |   78.36 ms |    51.83 ms | 34800.0000 | 5400.0000 | 1700.0000 |    82012232 B |
 | BulkAll |               True |              True |  150.3 ms |   66.08 ms |    43.71 ms | 20900.0000 | 3700.0000 | 2000.0000 |    91253012 B |
+
+
+FixedIndexName_WriteToStreamAsync
+---------------------------------
+
+|                                     Method | Mean [ms] | Error [ms] | StdDev [ms] |    Ratio | RatioSD |      Gen0 |      Gen1 |      Gen2 | Allocated [B] | Alloc Ratio |
+|------------------------------------------- |----------:|-----------:|------------:|---------:|--------:|----------:|----------:|----------:|--------------:|------------:|
+|          FixedIndexName_WriteToStreamAsync |  71.62 ms |   1.425 ms |    3.358 ms | baseline |         | 3000.0000 | 1000.0000 | 1000.0000 |    29581107 B |             |
+| FixedIndexName_WriteToStreamOptimizedAsync |  53.11 ms |   1.057 ms |    2.430 ms |     -26% |    7.1% | 1300.0000 |  600.0000 |  600.0000 |     8997235 B |        -70% |

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Results/ManualResults.txt
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Results/ManualResults.txt
@@ -51,15 +51,33 @@ Baseline for commit 8eef0e1dfbee8c5198ec0ab975b5d826e2356fcd (from 2023-05-02) i
 BulkRequestCreationWithFixedIndexNameBenchmarks
 -----------------------------------------------
 
-|                                     Method | Mean [ms] | Error [ms] | StdDev [ms] |    Ratio | RatioSD |      Gen0 |      Gen1 |      Gen2 | Allocated [B] | Alloc Ratio |
-|------------------------------------------- |----------:|-----------:|------------:|---------:|--------:|----------:|----------:|----------:|--------------:|------------:|
-|          FixedIndexName_WriteToStreamAsync |  71.62 ms |   1.425 ms |    3.358 ms | baseline |         | 3000.0000 | 1000.0000 | 1000.0000 |    29581107 B |             |
-| FixedIndexName_WriteToStreamOptimizedAsync |  53.11 ms |   1.057 ms |    2.430 ms |     -26% |    7.1% | 1300.0000 |  600.0000 |  600.0000 |     8997235 B |        -70% |
+|                 Method | Mean [ms] | Error [ms] | StdDev [ms] |    Ratio | RatioSD |     Gen0 |     Gen1 |     Gen2 | Allocated [B] | Alloc Ratio |
+|----------------------- |----------:|-----------:|------------:|---------:|--------:|---------:|---------:|---------:|--------------:|------------:|
+| WriteToStreamAsync_OLD |  2.666 ms |  0.0553 ms |   0.1578 ms | baseline |         | 121.0938 | 121.0938 | 121.0938 |      653139 B |             |
+|     WriteToStreamAsync |  2.447 ms |  0.0487 ms |   0.1148 ms |      -8% |    7.5% | 121.0938 | 121.0938 | 121.0938 |      573139 B |        -12% |
 
-BulkRequestCreationWithTemplatedIndexNameBenchmarks
----------------------------------------------------
+Previous Request Body = 205000B
+New Request Body = 181000B
+Saves 24B per operation in the request body
 
-|                                       Method | Mean [ms] | Error [ms] | StdDev [ms] |    Ratio | RatioSD |      Gen0 |     Gen1 |     Gen2 | Allocated [B] | Alloc Ratio |
-|--------------------------------------------- |----------:|-----------:|------------:|---------:|--------:|----------:|---------:|---------:|--------------:|------------:|
-|          DynamicIndexName_WriteToStreamAsync |  112.7 ms |    3.53 ms |    10.17 ms | baseline |         | 2800.0000 | 800.0000 | 800.0000 |    30380834 B |             |
-| DynamicIndexName_WriteToStreamOptimizedAsync |  101.1 ms |    2.53 ms |     7.38 ms |     -10% |   11.4% | 2800.0000 | 800.0000 | 800.0000 |    30379709 B |         -0% |
+BulkRequestCreationWithFixedIndexNameBenchmarks (1k events)
+-----------------------------------------------------------
+
+|                            Method | Mean [ms] | Error [ms] | StdDev [ms] |     Gen0 |     Gen1 |     Gen2 | Allocated [B] |
+|---------------------------------- |----------:|-----------:|------------:|---------:|---------:|---------:|--------------:|
+| FixedIndexName_WriteToStreamAsync |  2.351 ms |  0.0481 ms |   0.1364 ms | 121.0938 | 121.0938 | 121.0938 |      573139 B |
+
+BulkRequestCreationWithTemplatedIndexNameBenchmarks (1k events)
+---------------------------------------------------------------
+
+|                              Method | Mean [ms] | Error [ms] | StdDev [ms] |      Gen0 |     Gen1 |     Gen2 | Allocated [B] |
+|------------------------------------ |----------:|-----------:|------------:| ---------:|---------:|---------:|--------------:|
+| DynamicIndexName_WriteToStreamAsync |  2.836 ms |  0.0564 ms |   0.1002 ms |  121.0938 | 121.0938 | 121.0938 |      661139 B |
+
+
+BulkRequestCreationForDataStreamBenchmarks (1k events)
+------------------------------------------------------
+
+|             Method | Mean [ms] | Error [ms] | StdDev [ms] |     Gen0 |     Gen1 |     Gen2 | Allocated [B] |
+|------------------- |----------:|-----------:|------------:|---------:|---------:|---------:|--------------:|
+| WriteToStreamAsync |  2.261 ms |  0.0442 ms |   0.1041 ms | 121.0938 | 121.0938 | 121.0938 |      525139 B |

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Results/ManualResults.txt
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Results/ManualResults.txt
@@ -48,10 +48,18 @@ Baseline for commit 8eef0e1dfbee8c5198ec0ab975b5d826e2356fcd (from 2023-05-02) i
 | BulkAll |               True |              True |  150.3 ms |   66.08 ms |    43.71 ms | 20900.0000 | 3700.0000 | 2000.0000 |    91253012 B |
 
 
-FixedIndexName_WriteToStreamAsync
----------------------------------
+BulkRequestCreationWithFixedIndexNameBenchmarks
+-----------------------------------------------
 
 |                                     Method | Mean [ms] | Error [ms] | StdDev [ms] |    Ratio | RatioSD |      Gen0 |      Gen1 |      Gen2 | Allocated [B] | Alloc Ratio |
 |------------------------------------------- |----------:|-----------:|------------:|---------:|--------:|----------:|----------:|----------:|--------------:|------------:|
 |          FixedIndexName_WriteToStreamAsync |  71.62 ms |   1.425 ms |    3.358 ms | baseline |         | 3000.0000 | 1000.0000 | 1000.0000 |    29581107 B |             |
 | FixedIndexName_WriteToStreamOptimizedAsync |  53.11 ms |   1.057 ms |    2.430 ms |     -26% |    7.1% | 1300.0000 |  600.0000 |  600.0000 |     8997235 B |        -70% |
+
+BulkRequestCreationWithTemplatedIndexNameBenchmarks
+---------------------------------------------------
+
+|                                       Method | Mean [ms] | Error [ms] | StdDev [ms] |    Ratio | RatioSD |      Gen0 |     Gen1 |     Gen2 | Allocated [B] | Alloc Ratio |
+|--------------------------------------------- |----------:|-----------:|------------:|---------:|--------:|----------:|---------:|---------:|--------------:|------------:|
+|          DynamicIndexName_WriteToStreamAsync |  112.7 ms |    3.53 ms |    10.17 ms | baseline |         | 2800.0000 | 800.0000 | 800.0000 |    30380834 B |             |
+| DynamicIndexName_WriteToStreamOptimizedAsync |  101.1 ms |    2.53 ms |     7.38 ms |     -10% |   11.4% | 2800.0000 | 800.0000 | 800.0000 |    30379709 B |         -0% |

--- a/benchmarks/Performance.Common/StockData.cs
+++ b/benchmarks/Performance.Common/StockData.cs
@@ -75,11 +75,11 @@ public sealed class StockData
 			if (i < count - 1)
 			{
 				responseBytes[offset + FilterPathItemResponseBytes.Length] = Comma;
-				offset += (FilterPathItemResponseBytes.Length + 1);
+				offset += FilterPathItemResponseBytes.Length + 1;
 			}
 			else
 			{
-				offset += (FilterPathItemResponseBytes.Length);
+				offset += FilterPathItemResponseBytes.Length;
 			}
 		}
 

--- a/benchmarks/Performance.Common/StockData.cs
+++ b/benchmarks/Performance.Common/StockData.cs
@@ -49,7 +49,7 @@ public sealed class StockData
 
 	public static StockData[] CreateSampleData(long count)
 	{
-		var data = new StockData[100_000];
+		var data = new StockData[count];
 
 		for (var i = 0; i < count; i++)
 		{

--- a/src/Elastic.Ingest.Elasticsearch/DataStreams/DataStreamChannel.cs
+++ b/src/Elastic.Ingest.Elasticsearch/DataStreams/DataStreamChannel.cs
@@ -24,7 +24,7 @@ public class DataStreamChannel<TEvent> : ElasticsearchChannelBase<TEvent, DataSt
 	{
 		var dataStream = Options.DataStream.ToString();
 
-		_url = $"/{dataStream}/{base.BulkUrl}";
+		_url = $"/{dataStream}{base.BulkUrl}";
 		
 		_fixedHeader = new CreateOperation();
 	}

--- a/src/Elastic.Ingest.Elasticsearch/DataStreams/DataStreamChannel.cs
+++ b/src/Elastic.Ingest.Elasticsearch/DataStreams/DataStreamChannel.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Elastic.Channels;
 using Elastic.Channels.Diagnostics;
 using Elastic.Ingest.Elasticsearch.Serialization;
 using Elastic.Ingest.Transport;
@@ -15,6 +14,7 @@ namespace Elastic.Ingest.Elasticsearch.DataStreams;
 public class DataStreamChannel<TEvent> : ElasticsearchChannelBase<TEvent, DataStreamChannelOptions<TEvent>>
 {
 	private readonly CreateOperation _fixedHeader;
+	private readonly string _url;
 
 	/// <inheritdoc cref="DataStreamChannel{TEvent}"/>
 	public DataStreamChannel(DataStreamChannelOptions<TEvent> options) : this(options, null) { }
@@ -22,8 +22,11 @@ public class DataStreamChannel<TEvent> : ElasticsearchChannelBase<TEvent, DataSt
 	/// <inheritdoc cref="DataStreamChannel{TEvent}"/>
 	public DataStreamChannel(DataStreamChannelOptions<TEvent> options, ICollection<IChannelCallbacks<TEvent, BulkResponse>>? callbackListeners) : base(options, callbackListeners)
 	{
-		var target = Options.DataStream.ToString();
-		_fixedHeader = new CreateOperation { Index = target };
+		var dataStream = Options.DataStream.ToString();
+
+		_url = $"/{dataStream}/{base.BulkUrl}";
+		
+		_fixedHeader = new CreateOperation();
 	}
 
 	/// <inheritdoc cref="ElasticsearchChannelBase{TEvent,TChannelOptions}.CreateBulkOperationHeader"/>
@@ -33,6 +36,9 @@ public class DataStreamChannel<TEvent> : ElasticsearchChannelBase<TEvent, DataSt
 	protected override string TemplateName => Options.DataStream.GetTemplateName();
 	/// <inheritdoc cref="ElasticsearchChannelBase{TEvent,TChannelOptions}.TemplateWildcard"/>
 	protected override string TemplateWildcard => Options.DataStream.GetNamespaceWildcard();
+
+	/// <inheritdoc cref="ElasticsearchChannelBase{TEvent, TChannelOptions}.BulkUrl"/>
+	protected override string BulkUrl => _url;
 
 	/// <summary>
 	/// Gets a default index template for the current <see cref="DataStreamChannel{TEvent}"/>

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
@@ -76,6 +76,7 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 			return transport.RequestAsync<BulkResponse>(HttpMethod.POST, BulkUrl, PostData.ReadOnlyMemory(bytes), RequestParams, ctx);
 		}
 #endif
+#pragma warning disable IDE0022 // Use expression body for method
 		return transport.RequestAsync<BulkResponse>(HttpMethod.POST, BulkUrl,
 			PostData.StreamHandler(page,
 				(_, _) =>
@@ -84,6 +85,7 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 				},
 				async (b, stream, ctx) => { await BulkRequestDataFactory.WriteBufferToStreamAsync(b, stream, Options, CreateBulkOperationHeader, ctx).ConfigureAwait(false); })
 			, RequestParams, ctx);
+#pragma warning restore IDE0022 // Use expression body for method
 	}
 
 	/// <summary>

--- a/src/Elastic.Ingest.Elasticsearch/Indices/IndexChannel.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Indices/IndexChannel.cs
@@ -30,7 +30,7 @@ public class IndexChannel<TEvent> : ElasticsearchChannelBase<TEvent, IndexChanne
 		// We can later avoid the overhead of calculating and adding the index name to the operation headers.
 		if (string.Format(Options.IndexFormat, DateTimeOffset.Now).Equals(Options.IndexFormat, StringComparison.Ordinal))
 		{
-			_url = $"/{Options.IndexFormat}/{base.BulkUrl}";
+			_url = $"/{Options.IndexFormat}{base.BulkUrl}";
 			_skipIndexNameOnOperations = true;
 		}
 

--- a/src/Elastic.Ingest.Elasticsearch/Serialization/BulkRequestDataFactory.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Serialization/BulkRequestDataFactory.cs
@@ -1,0 +1,150 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+#if NETSTANDARD2_1_OR_GREATER
+using System.Buffers;
+#else
+using System.Collections.Generic;
+#endif
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Ingest.Elasticsearch.Indices;
+using static Elastic.Ingest.Elasticsearch.ElasticsearchChannelStatics;
+
+namespace Elastic.Ingest.Elasticsearch.Serialization;
+
+/// <summary>
+/// Provides static factory methods from producing request data for bulk requests.
+/// </summary>
+public static class BulkRequestDataFactory
+{
+#if NETSTANDARD2_1_OR_GREATER
+	/// <summary>
+	/// Get the NDJSON request body bytes for a page of <typeparamref name="TEvent"/> events.
+	/// </summary>
+	/// <typeparam name="TEvent">The type for the event being ingested.</typeparam>
+	/// <param name="page">A page of <typeparamref name="TEvent"/> events.</param>
+	/// <param name="options">The <see cref="ElasticsearchChannelOptionsBase{TEvent}"/> for the channel where the request will be written.</param>
+	/// <param name="createHeaderFactory">A function which takes an instance of <typeparamref name="TEvent"/> and produces the operation header containing the action and optional meta data.</param>
+	/// <returns>A <see cref="ReadOnlyMemory{T}"/> of <see cref="byte"/> representing the entire request body in NDJSON format.</returns>
+	public static ReadOnlyMemory<byte> GetBytes<TEvent>(ArraySegment<TEvent> page,
+		ElasticsearchChannelOptionsBase<TEvent> options, Func<TEvent, BulkOperationHeader> createHeaderFactory)
+	{
+		// ArrayBufferWriter inserts comma's when serializing multiple times
+		// Hence the multiple writer.Resets() as advised on this feature request
+		// https://github.com/dotnet/runtime/issues/82314
+		var bufferWriter = new ArrayBufferWriter<byte>();
+		using var writer = new Utf8JsonWriter(bufferWriter, WriterOptions);
+		foreach (var @event in page.AsSpan())
+		{
+			var indexHeader = createHeaderFactory(@event);
+			JsonSerializer.Serialize(writer, indexHeader, indexHeader.GetType(), SerializerOptions);
+			bufferWriter.Write(LineFeed);
+			writer.Reset();
+
+			if (indexHeader is UpdateOperation)
+			{
+				bufferWriter.Write(DocUpdateHeaderStart);
+				writer.Reset();
+			}
+
+			if (options.EventWriter?.WriteToArrayBuffer != null)
+				options.EventWriter.WriteToArrayBuffer(bufferWriter, @event);
+			else
+				JsonSerializer.Serialize(writer, @event, SerializerOptions);
+			writer.Reset();
+
+			if (indexHeader is UpdateOperation)
+			{
+				bufferWriter.Write(DocUpdateHeaderEnd);
+				writer.Reset();
+			}
+
+			bufferWriter.Write(LineFeed);
+			writer.Reset();
+		}
+		return bufferWriter.WrittenMemory;
+	}
+#endif
+
+	/// <summary>
+	/// Asynchronously write the NDJSON request body for a page of <typeparamref name="TEvent"/> events to <see cref="Stream"/>.
+	/// </summary>
+	/// <typeparam name="TEvent">The type for the event being ingested.</typeparam>
+	/// <param name="page">A page of <typeparamref name="TEvent"/> events.</param>
+	/// <param name="stream">The target <see cref="Stream"/> for the request.</param>
+	/// <param name="options">The <see cref="ElasticsearchChannelOptionsBase{TEvent}"/> for the channel where the request will be written.</param>
+	/// <param name="createHeaderFactory">A function which takes an instance of <typeparamref name="TEvent"/> and produces the operation header containing the action and optional meta data.</param>
+	/// <param name="ctx">The cancellation token to cancel operation.</param>
+	/// <returns></returns>
+	public static async Task WriteBufferToStreamAsync<TEvent>(ArraySegment<TEvent> page, Stream stream,
+		ElasticsearchChannelOptionsBase<TEvent> options, Func<TEvent, BulkOperationHeader> createHeaderFactory,
+		CancellationToken ctx = default)
+	{
+#if NETSTANDARD2_1_OR_GREATER
+		var items = page;
+#else
+			// needs cast prior to netstandard2.0
+			IReadOnlyList<TEvent> items = page;
+#endif
+		// for is okay on ArraySegment, foreach performs bad:
+		// https://antao-almada.medium.com/how-to-use-span-t-and-memory-t-c0b126aae652
+		// ReSharper disable once ForCanBeConvertedToForeach
+		for (var i = 0; i < items.Count; i++)
+		{
+			var @event = items[i];
+			if (@event == null) continue;
+
+			var indexHeader = createHeaderFactory(@event);
+			await JsonSerializer.SerializeAsync(stream, indexHeader, indexHeader.GetType(), SerializerOptions, ctx)
+				.ConfigureAwait(false);
+			await stream.WriteAsync(LineFeed, 0, 1, ctx).ConfigureAwait(false);
+
+			if (indexHeader is UpdateOperation)
+				await stream.WriteAsync(DocUpdateHeaderStart, 0, DocUpdateHeaderStart.Length, ctx).ConfigureAwait(false);
+
+			if (options.EventWriter?.WriteToStreamAsync != null)
+				await options.EventWriter.WriteToStreamAsync(stream, @event, ctx).ConfigureAwait(false);
+			else
+				await JsonSerializer.SerializeAsync(stream, @event, SerializerOptions, ctx)
+					.ConfigureAwait(false);
+
+			if (indexHeader is UpdateOperation)
+				await stream.WriteAsync(DocUpdateHeaderEnd, 0, DocUpdateHeaderEnd.Length, ctx).ConfigureAwait(false);
+
+			await stream.WriteAsync(LineFeed, 0, 1, ctx).ConfigureAwait(false);
+		}
+	}
+
+	/// <summary>
+	/// Create the bulk operation header with the appropriate action and meta data for a bulk request targeting an index.
+	/// </summary>
+	/// <typeparam name="TEvent">The type for the event being ingested.</typeparam>
+	/// <param name="event">The <typeparamref name="TEvent"/> for which the header will be produced.</param>
+	/// <param name="options">The <see cref="IndexChannelOptions{TEvent}"/> for the channel.</param>
+	/// <param name="skipIndexName">Control whether the index name is included in the meta data for the operation.</param>
+	/// <returns>A <see cref="BulkOperationHeader"/> instance.</returns>
+	public static BulkOperationHeader CreateBulkOperationHeaderForIndex<TEvent>(TEvent @event, IndexChannelOptions<TEvent> options,
+		bool skipIndexName = false)
+	{
+		var indexTime = options.TimestampLookup?.Invoke(@event) ?? DateTimeOffset.Now;
+		if (options.IndexOffset.HasValue) indexTime = indexTime.ToOffset(options.IndexOffset.Value);
+
+		var index = skipIndexName ? string.Empty : string.Format(options.IndexFormat, indexTime);
+
+		var id = options.BulkOperationIdLookup?.Invoke(@event);
+
+		if (!string.IsNullOrWhiteSpace(id) && id != null && (options.BulkUpsertLookup?.Invoke(@event, id) ?? false))
+			return skipIndexName ? new UpdateOperation { Id = id } : new UpdateOperation { Id = id, Index = index };
+
+		return
+			!string.IsNullOrWhiteSpace(id)
+				? skipIndexName ? new IndexOperation { Id = id } : new IndexOperation { Index = index, Id = id }
+				: skipIndexName ? new CreateOperation() : new CreateOperation { Index = index };
+	}
+}
+

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/ChannelTestWithSingleDocResponseBase.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/ChannelTestWithSingleDocResponseBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/ChannelTestWithSingleDocResponseBase.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/ChannelTestWithSingleDocResponseBase.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Text;
+using Elastic.Transport;
+
+namespace Elastic.Ingest.Elasticsearch.Tests;
+
+public abstract class ChannelTestWithSingleDocResponseBase
+{
+	protected static readonly HttpTransport _transport = new DefaultHttpTransport<TransportConfiguration>(
+		new TransportConfiguration(new SingleNodePool(new Uri("http://localhost:9200")),
+			new InMemoryConnection(Encoding.UTF8.GetBytes("{\"items\":[{\"create\":{\"status\":201}}]}")))
+				.DisablePing()
+				.EnableDebugMode());
+}

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/DataStreamChannelTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/DataStreamChannelTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/DataStreamChannelTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/DataStreamChannelTests.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO;
+using System.Threading;
+using Elastic.Ingest.Elasticsearch.DataStreams;
+using Elastic.Transport;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Ingest.Elasticsearch.Tests;
+
+public class DataStreamChannelTests : ChannelTestWithSingleDocResponseBase
+{
+	[Fact]
+	public void DataStreamChannel_UsesCorrectUrlAndOperationHeader()
+	{
+		ApiCallDetails callDetails = null;
+
+		var wait = new ManualResetEvent(false);
+
+		using var channel = new DataStreamChannel<TestDocument>(new DataStreamChannelOptions<TestDocument>(_transport)
+		{
+			BufferOptions = new()
+			{
+				OutboundBufferMaxSize = 1
+			},
+			DataStream = new("type"),
+			ExportResponseCallback = (response, _) =>
+			{
+				callDetails = response.ApiCallDetails;
+				wait.Set();
+			},
+		});
+
+		channel.TryWrite(new TestDocument());
+		wait.WaitOne();
+
+		callDetails.Uri.AbsolutePath.Should().Be("/type-generic-default/_bulk");
+
+		var stream = new MemoryStream(callDetails.RequestBodyInBytes);
+		var sr = new StreamReader(stream);
+		var operation = sr.ReadLine();
+		operation.Should().Be("{\"create\":{}}");
+	}
+}

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/ElasticsearchChannelTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/ElasticsearchChannelTests.cs
@@ -38,13 +38,13 @@ public class ElasticsearchChannelTests
 	public void BackoffRetries()
 	{
 		var client = TestSetup.CreateClient(v => v
-				// first two events keep bouncing
+			// first two events keep bouncing
 			.ClientCalls(c => c.BulkResponse(429, 429))
 			.ClientCalls(c => c.BulkResponse(429, 429)) //retry 1
 			.ClientCalls(c => c.BulkResponse(429, 429)) //retry 2
-				// finally succeeds
+														// finally succeeds
 			.ClientCalls(c => c.BulkResponse(200, 200)) //retry 3
-				// next two succeed straight away
+														// next two succeed straight away
 			.ClientCalls(c => c.BulkResponse(200, 200)) //next batch
 		);
 		using var session = TestSetup.CreateTestSession(client);
@@ -61,19 +61,18 @@ public class ElasticsearchChannelTests
 		session.TotalBulkRequests.Should().Be(5);
 		session.TotalRetries.Should().Be(3);
 		session.Rejections.Should().Be(0);
-
 	}
 
 	[Fact]
 	public void BackoffTooMuchEndsUpOnDLQ()
 	{
 		var client = TestSetup.CreateClient(v => v
-				// first two events keep bouncing
+			// first two events keep bouncing
 			.ClientCalls(c => c.BulkResponse(429, 429))
 			.ClientCalls(c => c.BulkResponse(429, 429)) //retry 1
 			.ClientCalls(c => c.BulkResponse(429, 429)) //retry 2
 			.ClientCalls(c => c.BulkResponse(429, 429)) //retry 3
-				// next two succeed straight away
+														// next two succeed straight away
 			.ClientCalls(c => c.BulkResponse(200, 200)) //next batch
 		);
 		using var session = TestSetup.CreateTestSession(client);
@@ -97,9 +96,9 @@ public class ElasticsearchChannelTests
 	public void ExceptionDoesNotHaltProcessingAndIsReported()
 	{
 		var client = TestSetup.CreateClient(v => v
-				// first two events throws an exception in the client call
+			// first two events throws an exception in the client call
 			.ClientCalls(c => c.Fails(TimesHelper.Once, new Exception("boom!")))
-				// next two succeed straight away
+			// next two succeed straight away
 			.ClientCalls(c => c.BulkResponse(200, 200)) //next batch
 		);
 		using var session = TestSetup.CreateTestSession(client);
@@ -120,6 +119,5 @@ public class ElasticsearchChannelTests
 		session.TotalBulkResponses.Should().Be(1);
 		session.TotalRetries.Should().Be(0);
 		session.Rejections.Should().Be(0);
-
 	}
 }

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/ElasticsearchChannelTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/ElasticsearchChannelTests.cs
@@ -42,9 +42,9 @@ public class ElasticsearchChannelTests
 			.ClientCalls(c => c.BulkResponse(429, 429))
 			.ClientCalls(c => c.BulkResponse(429, 429)) //retry 1
 			.ClientCalls(c => c.BulkResponse(429, 429)) //retry 2
-														// finally succeeds
+			// finally succeeds
 			.ClientCalls(c => c.BulkResponse(200, 200)) //retry 3
-														// next two succeed straight away
+			// next two succeed straight away
 			.ClientCalls(c => c.BulkResponse(200, 200)) //next batch
 		);
 		using var session = TestSetup.CreateTestSession(client);

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/IndexChannelTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/IndexChannelTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/IndexChannelTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/IndexChannelTests.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Threading;
+using Elastic.Ingest.Elasticsearch.Indices;
+using Elastic.Transport;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Ingest.Elasticsearch.Tests;
+
+public class IndexChannelTests : ChannelTestWithSingleDocResponseBase
+{
+	[Fact]
+	public void IndexChannel_WithFixedIndexName_UsesCorrectUrlAndOperationHeader() =>
+		ExecuteAndAssert("/fixed-index/_bulk", "{\"create\":{}}", "fixed-index");
+
+	[Fact]
+	public void IndexChannel_WithDynamicIndexName_UsesCorrectUrlAndOperationHeader() =>
+		ExecuteAndAssert("/_bulk", "{\"create\":{\"_index\":\"dotnet-2023.07.29\"}}");
+
+	private static void ExecuteAndAssert(string expectedUrl, string expectedOperationHeader, string indexName = null)
+	{
+		ApiCallDetails callDetails = null;
+
+		var wait = new ManualResetEvent(false);
+
+		var options = new IndexChannelOptions<TestDocument>(_transport)
+		{
+			BufferOptions = new()
+			{
+				OutboundBufferMaxSize = 1
+			},
+			ExportResponseCallback = (response, _) =>
+			{
+				callDetails = response.ApiCallDetails;
+				wait.Set();
+			},
+			TimestampLookup = _ => new DateTimeOffset(2023, 07, 29, 20, 00, 00, TimeSpan.Zero),
+		};
+
+		if (indexName is not null)
+		{
+			options.IndexFormat = indexName;
+		}
+
+		using var channel = new IndexChannel<TestDocument>(options);
+
+		channel.TryWrite(new TestDocument());
+		wait.WaitOne();
+
+		callDetails.Should().NotBeNull();
+		callDetails.Uri.AbsolutePath.Should().Be(expectedUrl);
+
+		var stream = new MemoryStream(callDetails.RequestBodyInBytes);
+		var sr = new StreamReader(stream);
+		var operation = sr.ReadLine();
+		operation.Should().Be(expectedOperationHeader);
+	}
+}


### PR DESCRIPTION
When a fixed index name is used for an `IndexChannel`, we can avoid including the index name for each operation. This PR implements this optimisation, saving 12% on allocations and 8% on execution time. It also produces a 12% smaller request body (for 1k events).

```
|                 Method | Mean [ms] | Error [ms] | StdDev [ms] |    Ratio | RatioSD |     Gen0 |     Gen1 |     Gen2 | Allocated [B] | Alloc Ratio |
|----------------------- |----------:|-----------:|------------:|---------:|--------:|---------:|---------:|---------:|--------------:|------------:|
| WriteToStreamAsync_OLD |  2.666 ms |  0.0553 ms |   0.1578 ms | baseline |         | 121.0938 | 121.0938 | 121.0938 |      653139 B |             |
|     WriteToStreamAsync |  2.447 ms |  0.0487 ms |   0.1148 ms |      -8% |    7.5% | 121.0938 | 121.0938 | 121.0938 |      573139 B |        -12% |
```