### PR TITLE
Improve exception messages to actually contain debug information when bootstrapping templates

### DIFF
--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.Bootstrap.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.Bootstrap.cs
@@ -108,7 +108,7 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 		return bootstrapMethod == BootstrapMethod.Silent
 			? false
 			: throw new Exception(
-				$"Failure to create index templates for {TemplateWildcard}: {putIndexTemplateResponse}");
+				$"Failure to create index templates for {TemplateWildcard}: {putIndexTemplateResponse.ApiCallDetails.OriginalException.Message}", putIndexTemplateResponse.ApiCallDetails.OriginalException);
 	}
 
 	/// <summary></summary>
@@ -122,7 +122,7 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 		return bootstrapMethod == BootstrapMethod.Silent
 			? false
 			: throw new Exception(
-				$"Failure to create index templates for {TemplateWildcard}: {putIndexTemplateResponse}");
+				$"Failure to create index templates for {TemplateWildcard}: {putIndexTemplateResponse.ApiCallDetails.OriginalException.Message}", putIndexTemplateResponse.ApiCallDetails.OriginalException);
 	}
 
 	/// <summary></summary>
@@ -135,7 +135,7 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 		return bootstrapMethod == BootstrapMethod.Silent
 			? false
 			: throw new Exception(
-				$"Failure to create component template `${name}` for {TemplateWildcard}: {putComponentTemplate}");
+				$"Failure to create component template `${name}` for {TemplateWildcard}: {putComponentTemplate.ApiCallDetails.OriginalException.Message}", putComponentTemplate.ApiCallDetails.OriginalException);
 	}
 
 	/// <summary></summary>
@@ -149,7 +149,7 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 		return bootstrapMethod == BootstrapMethod.Silent
 			? false
 			: throw new Exception(
-				$"Failure to create component template `${name}` for {TemplateWildcard}: {putComponentTemplate}");
+				$"Failure to create component template `${name}` for {TemplateWildcard}: {putComponentTemplate.ApiCallDetails.OriginalException.Message}", putComponentTemplate.ApiCallDetails.OriginalException);
 	}
 
 	/// <summary>


### PR DESCRIPTION
Hi,
there's no issue tracked for this but it's something I just encountered recently. If we fall into an exception when f.e. creating a template, an exception is thrown depending on BootstrapMethod enum. The issue is that exception doesn't really contain any info on why it failed, because currently message has a serialized object instead of an actual text.
I've made a change so that we put InnerException's Message into the content. I've also included InnerException in the newly thrown one. Let me know if this is wrong or you have a better idea on what we could include there, I just found that DebugInformation is too big to put into message and currently without stepping down into third party code it's impossible to tell what's wrong while bootstrapping.

Example of a current message:
```
System.Exception: Failure to create index templates for logs-alpha-otb-web-customercare-*: Elastic.Ingest.Elasticsearch.ElasticsearchChannelBase`2+PutIndexTemplateResponse[Teqcycle.API.Logger.Ecs.TeqcycleEcsEvent,Elastic.Ingest.Elasticsearch.DataStreams.DataStreamChannelOptions`1[Teqcycle.API.Logger.Ecs.TeqcycleEcsEvent]]
```

new message:
```
Failure to create component template `$logs-alpha-otb-web-customercare-8.6.0` for logs-alpha-otb-web-customercare-*: Could not authenticate with the specified node. Try verifying your credentials or check your Shield configuration. Call: Status code 401 from: PUT /_index_template/logs-alpha-otb-web-customercare-8.6.0
```