### PR TITLE
Improve Exception Messages

### DIFF
--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.Bootstrap.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.Bootstrap.cs
@@ -108,7 +108,9 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 		return bootstrapMethod == BootstrapMethod.Silent
 			? false
 			: throw new Exception(
-				$"Failure to create index templates for {TemplateWildcard}: {putIndexTemplateResponse}");
+				$"Failure to create index templates for {TemplateWildcard}: {putIndexTemplateResponse}",
+				putIndexTemplateResponse.ApiCallDetails.OriginalException
+			);
 	}
 
 	/// <summary></summary>
@@ -122,7 +124,9 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 		return bootstrapMethod == BootstrapMethod.Silent
 			? false
 			: throw new Exception(
-				$"Failure to create index templates for {TemplateWildcard}: {putIndexTemplateResponse}");
+				$"Failure to create index templates for {TemplateWildcard}: {putIndexTemplateResponse}",
+				putIndexTemplateResponse.ApiCallDetails.OriginalException
+			);
 	}
 
 	/// <summary></summary>
@@ -135,7 +139,9 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 		return bootstrapMethod == BootstrapMethod.Silent
 			? false
 			: throw new Exception(
-				$"Failure to create component template `${name}` for {TemplateWildcard}: {putComponentTemplate}");
+				$"Failure to create component template `{name}` for {TemplateWildcard}: {putComponentTemplate}",
+				putComponentTemplate.ApiCallDetails.OriginalException
+			);
 	}
 
 	/// <summary></summary>
@@ -149,7 +155,9 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 		return bootstrapMethod == BootstrapMethod.Silent
 			? false
 			: throw new Exception(
-				$"Failure to create component template `${name}` for {TemplateWildcard}: {putComponentTemplate}");
+				$"Failure to create component template `{name}` for {TemplateWildcard}: {putComponentTemplate}",
+				putComponentTemplate.ApiCallDetails.OriginalException
+			);
 	}
 
 	/// <summary>

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
@@ -14,6 +14,7 @@ using Elastic.Ingest.Elasticsearch.Indices;
 using Elastic.Ingest.Elasticsearch.Serialization;
 using Elastic.Ingest.Transport;
 using Elastic.Transport;
+using Elastic.Transport.Products.Elasticsearch;
 using static Elastic.Ingest.Elasticsearch.ElasticsearchChannelStatics;
 
 namespace Elastic.Ingest.Elasticsearch;
@@ -94,11 +95,11 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 	protected abstract BulkOperationHeader CreateBulkOperationHeader(TEvent @event);
 
 	/// <summary>  </summary>
-	protected class HeadIndexTemplateResponse : TransportResponse { }
+	protected class HeadIndexTemplateResponse : ElasticsearchResponse { }
 
 	/// <summary>  </summary>
-	protected class PutIndexTemplateResponse : TransportResponse { }
+	protected class PutIndexTemplateResponse : ElasticsearchResponse { }
 
 	/// <summary>  </summary>
-	protected class PutComponentTemplateResponse : TransportResponse { }
+	protected class PutComponentTemplateResponse : ElasticsearchResponse { }
 }

--- a/src/Elastic.Ingest.Elasticsearch/Serialization/BulkResponse.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Serialization/BulkResponse.cs
@@ -6,14 +6,12 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Elastic.Transport;
 using Elastic.Transport.Products.Elasticsearch;
 
 namespace Elastic.Ingest.Elasticsearch.Serialization;
 
-
 /// <summary>Represents the _bulk response from Elasticsearch</summary>
-public class BulkResponse : TransportResponse
+public class BulkResponse : ElasticsearchResponse
 {
 	/// <summary>
 	/// Individual bulk response items information
@@ -35,9 +33,6 @@ public class BulkResponse : TransportResponse
 		reason = Error?.Reason;
 		return !string.IsNullOrWhiteSpace(reason);
 	}
-
-	/// <inheritdoc cref="object.ToString"/>
-	public override string ToString() => ApiCallDetails.DebugInformation;
 }
 
 internal class ResponseItemsConverter : JsonConverter<IReadOnlyCollection<BulkResponseItem>>

--- a/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
+++ b/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Channels\Elastic.Channels.csproj" />
-    <PackageReference Include="Elastic.Transport" Version="0.4.9" />
+    <PackageReference Include="Elastic.Transport" Version="0.4.11" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
   </ItemGroup>
 

--- a/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/BootstrapFailureTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/BootstrapFailureTests.cs
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Channels;
+using Elastic.Ingest.Elasticsearch.DataStreams;
+using Elastic.Transport;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.Ingest.Elasticsearch.IntegrationTests;
+
+public class BootstrapFailureTests : IntegrationTestBase<SecurityCluster>
+{
+	public BootstrapFailureTests(SecurityCluster cluster, ITestOutputHelper output) : base(cluster, output)
+	{
+	}
+
+	[Fact]
+	public async Task BootstrapSilentShouldReportError()
+	{
+		var targetDataStream = new DataStreamName("logs", "silent-failure");
+		var slim = new CountdownEvent(1);
+		var transport = new DefaultHttpTransport(new TransportConfiguration(Cluster.NodesUris().First()));
+		var options = new DataStreamChannelOptions<TimeSeriesDocument>(transport)
+		{
+			DataStream = targetDataStream,
+			BufferOptions = new BufferOptions { WaitHandle = slim, OutboundBufferMaxSize = 1 }
+		};
+		var channel = new DataStreamChannel<TimeSeriesDocument>(options);
+		var bootstrapped = await channel.BootstrapElasticsearchAsync(BootstrapMethod.Silent, "7-days-default");
+		bootstrapped.Should().BeFalse("Insufficient rights");
+	}
+
+	[Fact]
+	public async Task BootstrapFailureShouldReportError()
+	{
+		var targetDataStream = new DataStreamName("logs", "exception-failure");
+		var slim = new CountdownEvent(1);
+		var transport = new DefaultHttpTransport(new TransportConfiguration(Cluster.NodesUris().First()));
+		var options = new DataStreamChannelOptions<TimeSeriesDocument>(transport)
+		{
+			DataStream = targetDataStream,
+			BufferOptions = new BufferOptions { WaitHandle = slim, OutboundBufferMaxSize = 1 }
+		};
+		var channel = new DataStreamChannel<TimeSeriesDocument>(options);
+		Exception caughtException = null;
+		try
+		{
+			await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure, "7-days-default");
+		}
+		catch (Exception e)
+		{
+			caughtException = e;
+		}
+		caughtException.Should().NotBeNull();
+
+		caughtException.Message.Should().StartWith("Failure to create component template `logs-exception-failure-settings` for logs-exception-failure-*:");
+		caughtException.Message.Should().Contain("Could not authenticate with the specified node. Try verifying your credentials or check your Shield configuration.");
+		caughtException.Message.Should().Contain("Invalid Elasticsearch response built from a unsuccessful (401) low level call on PUT:");
+	}
+}

--- a/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/Elastic.Ingest.Elasticsearch.IntegrationTests.csproj
+++ b/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/Elastic.Ingest.Elasticsearch.IntegrationTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.4" />
-    <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.3.5" />
+    <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/IngestionCluster.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/IngestionCluster.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Elastic.Clients.Elasticsearch;
+using Elastic.Elasticsearch.Ephemeral;
 using Elastic.Elasticsearch.Xunit;
 using Elastic.Transport;
 using Xunit;
@@ -16,7 +17,9 @@ namespace Elastic.Ingest.Elasticsearch.IntegrationTests;
 /// <summary> Declare our cluster that we want to inject into our test classes </summary>
 public class IngestionCluster : XunitClusterBase
 {
-	public IngestionCluster() : base(new XunitClusterConfiguration("8.7.0") { StartingPortNumber = 9202 }) { }
+	protected static string Version = "8.7.0";
+	public IngestionCluster() : this(new XunitClusterConfiguration(Version) { StartingPortNumber = 9202 }) { }
+	public IngestionCluster(XunitClusterConfiguration xunitClusterConfiguration) : base(xunitClusterConfiguration) { }
 
 	public ElasticsearchClient CreateClient(ITestOutputHelper output) =>
 		this.GetOrAddClient(_ =>
@@ -40,4 +43,14 @@ public class IngestionCluster : XunitClusterBase
 				.EnableDebugMode();
 			return new ElasticsearchClient(settings);
 		});
+}
+
+public class SecurityCluster : IngestionCluster
+{
+	public SecurityCluster() : base(new XunitClusterConfiguration(Version, ClusterFeatures.Security)
+	{
+		StartingPortNumber = 9202, TrialMode = XPackTrialMode.Trial
+		,
+
+	}) { }
 }

--- a/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/IntegrationTestBase.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/IntegrationTestBase.cs
@@ -1,16 +1,27 @@
 // Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
+
 using Elastic.Clients.Elasticsearch;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Xunit.Abstractions;
 
 namespace Elastic.Ingest.Elasticsearch.IntegrationTests;
 
-public abstract class IntegrationTestBase : IClusterFixture<IngestionCluster>
+public abstract class IntegrationTestBase : IntegrationTestBase<IngestionCluster>
 {
+	protected IntegrationTestBase(IngestionCluster cluster, ITestOutputHelper output) : base(cluster, output) { }
+}
+public abstract class IntegrationTestBase<TCluster> : IClusterFixture<TCluster>
+	where TCluster : IngestionCluster, new()
+{
+	protected IngestionCluster Cluster { get; }
 	protected ElasticsearchClient Client { get; }
 
-	protected IntegrationTestBase(IngestionCluster cluster, ITestOutputHelper output) =>
+
+	protected IntegrationTestBase(IngestionCluster cluster, ITestOutputHelper output)
+	{
+		Cluster = cluster;
 		Client = cluster.CreateClient(output);
+	}
 }

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/Elastic.Ingest.Elasticsearch.Tests.csproj
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/Elastic.Ingest.Elasticsearch.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Transport.VirtualizedCluster" Version="0.4.5" />
+    <PackageReference Include="Elastic.Transport.VirtualizedCluster" Version="0.4.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
By deriving from ElasticsearchResponse instead of TransportResponse.

Updated dependency on Elastic.Transport that includes more useful ToString() implementation on responses.
