### PR TITLE
Allow consumers to choose BoundedChannelFullMode

### DIFF
--- a/src/Elastic.Channels/BufferOptions.cs
+++ b/src/Elastic.Channels/BufferOptions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Channels;
 
 namespace Elastic.Channels;
 
@@ -62,4 +63,13 @@ public class BufferOptions
 	/// Allows you to inject a <see cref="CountdownEvent"/> to wait for N number of buffers to flush.
 	/// </summary>
 	public CountdownEvent? WaitHandle { get; set; }
+
+	/// <summary>
+	/// <inheritdoc cref="BoundedChannelFullMode" path="summary" />
+	/// <para>Defaults to <see cref="BoundedChannelFullMode.Wait"/>, this will use more memory as overproducing will need to wait to enqueue data</para>
+	/// <para>Use <see cref="BoundedChannelFullMode.DropWrite"/> to minimize memory consumption at the expense of more  likely to drop data</para>
+	/// <para>You might need to tweak <see cref="InboundBufferMaxSize"/> and <see cref="OutboundBufferMaxSize"/> to ensure sufficient allocations are available </para>
+	/// <para>The defaults for both <see cref="InboundBufferMaxSize"/> adn <see cref="OutboundBufferMaxSize"/> are quite liberal already though.</para>
+	/// </summary>
+	public BoundedChannelFullMode BoundedChannelFullMode { get; set; } = BoundedChannelFullMode.Wait;
 }

--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -113,10 +113,10 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 			AllowSynchronousContinuations = true,
 			// wait does not block it simply signals that Writer.TryWrite should return false and be retried
 			// DropWrite will make `TryWrite` always return true, which is not what we want.
-			FullMode = BoundedChannelFullMode.Wait
+			FullMode = options.BufferOptions.BoundedChannelFullMode
 		});
 		OutChannel = Channel.CreateBounded<IOutboundBuffer<TEvent>>(
-			new BoundedChannelOptions(maxOut)
+			new BoundedChannelOptions(_maxConcurrency * 2)
 			{
 				SingleReader = false,
 				SingleWriter = true,


### PR DESCRIPTION
This PR exposes [BoundedChannelFullMode](https://learn.microsoft.com/en-us/dotnet/api/system.threading.channels.boundedchannelfullmode?view=net-8.0)

This allows consumers to decide certain trade offs themselves. 

Here are four example all pushing a million documents to the channel in a tight loop (extreme case of overproducing). 

`BoundedChannelFullMode.Wait` is still the default but in these cases where we extremely overproduce it can allocate more then expected see: https://github.com/dotnet/runtime/blob/fadd8313653f71abd0068c8bf914be88edb2c8d3/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs#L609

A downside of `BoundedChannelFullMode.DropWrite` is that `TryWrite` on a `BoundedChannel` will always return true: https://github.com/dotnet/runtime/blob/fadd8313653f71abd0068c8bf914be88edb2c8d3/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs#L428 and there won't be any notifications of items that failed to write.

On a dataset of a million documents using the following buffer options:

## default scenario 

<table>
<tr>
 <th>Inbound
 <th>Outbound
 <th>Concurrency
 <th>FullMode
 <th>Indexed All
</tr>
<tr>
 <td>100_000 (default)
 <td>1_000 (default)
 <td>default (>1)
 <td>WAIT
 <td> ✅ 
</tr>
</table>

<img width="1120" alt="image" src="https://github.com/elastic/elastic-ingest-dotnet/assets/245275/b9ad88fe-abb3-44a3-8684-70664ee34a9b">

## default scenario with DropWrite

<table>
<tr>
 <th>Inbound
 <th>Outbound
 <th>Concurrency
 <th>FullMode
 <th>Indexed All
</tr>
<tr>
 <td>100_000 (default)
 <td>1_000 (default)
 <td>default (>1)
 <td>DROPWRITE
 <td> 💥 (only 710_001 docs made it)
</tr>
</table>

<img width="996" alt="image" src="https://github.com/elastic/elastic-ingest-dotnet/assets/245275/6393ec0e-c081-473a-929b-c7e83d1d5d80">

## constraint scenario 

<table>
<tr>
 <th>Inbound
 <th>Outbound
 <th>Concurrency
 <th>FullMode
 <th>Indexed All
</tr>
<tr>
 <td>1_000
 <td>200
 <td>default (>1)
 <td>WAIT
 <td> ✅ 
</tr>
</table>

While successful it takes quite a bit longer to index all million items. 

<img width="1115" alt="image" src="https://github.com/elastic/elastic-ingest-dotnet/assets/245275/be44c782-38f2-4cb9-912a-1b05a67f059e">

## constraint scenario with DropWrite

<table>
<tr>
 <th>Inbound
 <th>Outbound
 <th>Concurrency
 <th>FullMode
 <th>Indexed All
</tr>
<tr>
 <td>1_000
 <td>200
 <td>default (>1)
 <td>DROPWRITE
 <td> 💥 (only 264_601 docs made it)
</tr>
</table>

<img width="480" alt="image" src="https://github.com/elastic/elastic-ingest-dotnet/assets/245275/fde0de34-8d7a-4662-b7cf-0a97b651ca84">







