### PR TITLE
Update to latest System.Threading.Channels

### DIFF
--- a/examples/playground/Program.cs
+++ b/examples/playground/Program.cs
@@ -14,7 +14,7 @@ var random = new Random();
 var ctxs = new CancellationTokenSource();
 var parallelOpts = new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount, CancellationToken = ctxs.Token };
 const int numDocs = 1_000_000;
-var bufferOptions = new BufferOptions { InboundBufferMaxSize = 1000, OutboundBufferMaxSize = 100, ExportMaxConcurrency = 1, BoundedChannelFullMode = BoundedChannelFullMode.Wait };
+var bufferOptions = new BufferOptions { BoundedChannelFullMode = BoundedChannelFullMode.Wait };
 var config = new EphemeralClusterConfiguration("8.13.0");
 using var cluster = new EphemeralCluster(config);
 using var channel = SetupElasticsearchChannel();

--- a/src/Elastic.Channels/Elastic.Channels.csproj
+++ b/src/Elastic.Channels/Elastic.Channels.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
+++ b/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Channels\Elastic.Channels.csproj" />
     <PackageReference Include="Elastic.Transport" Version="0.4.18" />
-    <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## before

<img width="1134" alt="image" src="https://github.com/elastic/elastic-ingest-dotnet/assets/245275/8124510f-e772-40a6-9068-54f4f45173b5">

## after

<img width="1134" alt="image" src="https://github.com/elastic/elastic-ingest-dotnet/assets/245275/1a2569d3-77cc-4ff1-813f-3cb4175b3e38">

Not a massive difference. The LOH are byte[] in `System.Net.Sockets.Socket+AwaitableSocketAsyncEventArgs` which might warrant another investigation.
