### PR TITLE
github-action: enable provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: build
+        path: build/output
 
     - uses: github-early-access/generate-build-provenance@main
       with:
@@ -130,9 +131,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+
     - uses: actions/download-artifact@v4
       with:
         name: build
+        path: build/output
+
     - name: Generate release notes for tag
       run: ./build.sh generatereleasenotes -s true --token ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,7 @@ on:
       - "*.*.*"
 
 permissions:
-  contents: write
-  packages: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   test-windows:
@@ -63,7 +60,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-          global-json-file: ./global.json
+        global-json-file: ./global.json
         
     - name: Build
       run: ./build.sh build -s true
@@ -80,27 +77,56 @@ jobs:
     - name: "Inspect public API changes"
       run: ./build.sh generateapichanges -s true
 
+    - uses: actions/upload-artifact@v4
+      with:
+        name: build
+        path: build/output/
+
+  release-canary:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
+    needs: [ build ]
+    permissions:
+      contents: write
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: build
+
     - name: publish canary packages github package repository
       shell: bash
       timeout-minutes: 2
       continue-on-error: true
-      if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
       run: |
         until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols -s https://nuget.pkg.github.com/elastic/index.json; do echo "Retrying"; sleep 1; done;
 
     # Github packages requires authentication, this is likely going away in the future so for now we publish to feedz.io
     - name: Publish canary packages to feedz.io
       run: dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.FEEDZ_IO_API_KEY}} -s https://f.feedz.io/elastic/all/nuget/index.json --skip-duplicate --no-symbols
-      if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
 
+  release:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
+    needs: [ build ]
+    permissions:
+      contents: write
+      issues: write
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - uses: actions/download-artifact@v4
+      with:
+        name: build
     - name: Generate release notes for tag
       run: ./build.sh generatereleasenotes -s true --token ${{secrets.GITHUB_TOKEN}}
-      if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
 
     - name: Create or update release for tag on github
       run: ./build.sh createreleaseongithub -s true --token ${{secrets.GITHUB_TOKEN}}
-      if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
 
     - name: Release to nuget.org
       run: dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.NUGET_ORG_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
-      if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
 permissions:
   contents: read
 
+env:
+  ARTIFACTS: 'build/output/*.nupkg'
+
 jobs:
   test-windows:
     runs-on: windows-latest
@@ -87,7 +90,9 @@ jobs:
     if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
     needs: [ build ]
     permissions:
+      attestations: write
       contents: write
+      id-token: write
       packages: write
     steps:
     - uses: actions/checkout@v4
@@ -96,23 +101,29 @@ jobs:
       with:
         name: build
 
+    - uses: github-early-access/generate-build-provenance@main
+      with:
+        subject-path: '${{ github.workspace }}/${{ env.ARTIFACTS }}'
+
     - name: publish canary packages github package repository
       shell: bash
       timeout-minutes: 2
       continue-on-error: true
       run: |
-        until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols -s https://nuget.pkg.github.com/elastic/index.json; do echo "Retrying"; sleep 1; done;
+        until dotnet nuget push '${{ env.ARTIFACTS }}' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols -s https://nuget.pkg.github.com/elastic/index.json; do echo "Retrying"; sleep 1; done;
 
     # Github packages requires authentication, this is likely going away in the future so for now we publish to feedz.io
     - name: Publish canary packages to feedz.io
-      run: dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.FEEDZ_IO_API_KEY}} -s https://f.feedz.io/elastic/all/nuget/index.json --skip-duplicate --no-symbols
+      run: dotnet nuget push '${{ env.ARTIFACTS }}' -k ${{secrets.FEEDZ_IO_API_KEY}} -s https://f.feedz.io/elastic/all/nuget/index.json --skip-duplicate --no-symbols
 
   release:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
     needs: [ build ]
     permissions:
+      attestations: write
       contents: write
+      id-token: write
       issues: write
       packages: write
     steps:
@@ -128,5 +139,9 @@ jobs:
     - name: Create or update release for tag on github
       run: ./build.sh createreleaseongithub -s true --token ${{secrets.GITHUB_TOKEN}}
 
+    - uses: github-early-access/generate-build-provenance@main
+      with:
+        subject-path: '${{ github.workspace }}/${{ env.ARTIFACTS }}'
+
     - name: Release to nuget.org
-      run: dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.NUGET_ORG_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
+      run: dotnet nuget push '${{ env.ARTIFACTS }}' -k ${{secrets.NUGET_ORG_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols


### PR DESCRIPTION
## What does this pull request do?

Use https://github.com/github-early-access/generate-build-provenance to create build attestations

## Implementation details

I refactored the `ci.yml` workflow to separate the two different releases:
- canary
- release

Those new jobs depend on `build`.



## Test

I created a feature branch based on these changes to test the canary-release:
- https://github.com/elastic/elastic-ingest-dotnet/actions/runs/8831137548

Then, the attestations will be created in https://github.com/elastic/elastic-ingest-dotnet/attestations