### PR TITLE
Fix against TimeSpan.Zero for max lifetime

### DIFF
--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkIngestionBenchmarks.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkIngestionBenchmarks.cs
@@ -70,6 +70,6 @@ public class BulkIngestionBenchmarks
 		channel.TryWriteMany(_data);
 		channel.TryComplete();
 
-		_waitHandle.WaitOne();
+		//	_waitHandle.WaitOne();
 	}
 }

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkIngestionBenchmarks.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Benchmarks/BulkIngestionBenchmarks.cs
@@ -70,6 +70,6 @@ public class BulkIngestionBenchmarks
 		channel.TryWriteMany(_data);
 		channel.TryComplete();
 
-		//	_waitHandle.WaitOne();
+		_waitHandle.WaitOne();
 	}
 }

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Program.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Program.cs
@@ -14,8 +14,29 @@ using BenchmarkDotNet.Running;
 using System.Globalization;
 using Elastic.Ingest.Elasticsearch.Benchmarks.Benchmarks;
 
+#if DEBUG
+// MANUALLY RUN A BENCHMARKED METHOD DURING DEBUGGING
+
+//var bm = new BulkIngestion();
+//bm.Setup();
+//await bm.BulkAllAsync()
+//Console.WriteLine("DONE");
+
+var bm = new BulkRequestCreationWithFixedIndexNameBenchmarks();
+bm.Setup();
+await bm.WriteToStreamAsync();
+
+var length = bm.MemoryStream.Length;
+
+bm.MemoryStream.Position = 0;
+var sr = new StreamReader(bm.MemoryStream);
+var json = sr.ReadToEnd();
+
+Console.ReadKey();
+#else
 var config = ManualConfig.Create(DefaultConfig.Instance);
 config.SummaryStyle = new SummaryStyle(CultureInfo.CurrentCulture, true, BenchmarkDotNet.Columns.SizeUnit.B, null!, ratioStyle: BenchmarkDotNet.Columns.RatioStyle.Percentage);
 config.AddDiagnoser(MemoryDiagnoser.Default);
 
-BenchmarkRunner.Run<BulkIngestionBenchmarks>(config);
+BenchmarkRunner.Run<BulkRequestCreationWithTemplatedIndexNameBenchmarks>(config);
+#endif

--- a/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Program.cs
+++ b/benchmarks/Elastic.Ingest.Elasticsearch.Benchmarks/Program.cs
@@ -14,29 +14,8 @@ using BenchmarkDotNet.Running;
 using System.Globalization;
 using Elastic.Ingest.Elasticsearch.Benchmarks.Benchmarks;
 
-#if DEBUG
-// MANUALLY RUN A BENCHMARKED METHOD DURING DEBUGGING
-
-//var bm = new BulkIngestion();
-//bm.Setup();
-//await bm.BulkAllAsync();
-//Console.WriteLine("DONE");
-
-var bm = new BulkRequestCreationWithFixedIndexNameBenchmarks();
-bm.Setup();
-await bm.WriteToStreamAsync();
-
-var length = bm.MemoryStream.Length;
-
-bm.MemoryStream.Position = 0;
-var sr = new StreamReader(bm.MemoryStream);
-var json = sr.ReadToEnd();
-
-Console.ReadKey();
-#else
 var config = ManualConfig.Create(DefaultConfig.Instance);
 config.SummaryStyle = new SummaryStyle(CultureInfo.CurrentCulture, true, BenchmarkDotNet.Columns.SizeUnit.B, null!, ratioStyle: BenchmarkDotNet.Columns.RatioStyle.Percentage);
 config.AddDiagnoser(MemoryDiagnoser.Default);
 
-BenchmarkRunner.Run<BulkRequestCreationWithTemplatedIndexNameBenchmarks>(config);
-#endif
+BenchmarkRunner.Run<BulkIngestionBenchmarks>(config);

--- a/elastic-ingest-dotnet.sln.DotSettings
+++ b/elastic-ingest-dotnet.sln.DotSettings
@@ -122,7 +122,7 @@ See the LICENSE file in the project root for more information</s:String>
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Kind Is="Member" /&gt;&#xD;
-        &lt;Name Is="Enter Pattern Here" /&gt;&#xD;
+        &lt;Name  /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Readonly Fields"&gt;&#xD;
@@ -140,7 +140,7 @@ See the LICENSE file in the project root for more information</s:String>
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Access /&gt;&#xD;
         &lt;Readonly /&gt;&#xD;
-        &lt;Name Is="Enter Pattern Here" /&gt;&#xD;
+        &lt;Name  /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Constructors"&gt;&#xD;
@@ -415,6 +415,7 @@ See the LICENSE file in the project root for more information</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002EMemberReordering_002EMigrations_002ECSharpFileLayoutPatternRemoveIsAttributeUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/HighlightingManager/HighlightingEnabledByDefault/@EntryValue">False</s:Boolean>

--- a/examples/Elastic.Channels.Continuous/Program.cs
+++ b/examples/Elastic.Channels.Continuous/Program.cs
@@ -1,5 +1,4 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
-// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// Licensed to Elasticsearch B.V under one or more agreements. // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
 using System.Threading.Channels;
@@ -14,20 +13,31 @@ Console.CancelKeyPress += (sender, eventArgs) => {
 
 var options = new NoopBufferedChannel.NoopChannelOptions
 {
+	//TrackConcurrency = true,
 	BufferOptions = new BufferOptions
 	{
-		OutboundBufferMaxLifetime = TimeSpan.Zero
+		OutboundBufferMaxLifetime = TimeSpan.Zero,
+		InboundBufferMaxSize = 1_000_000,
+		OutboundBufferMaxSize = 1_000_000
 	},
 	ExportBufferCallback = () => Console.Write("."),
-	ExportExceptionCallback = e => Console.Write("!"),
-	PublishToInboundChannelFailureCallback  = () => Console.Write("I"),
-	PublishToOutboundChannelFailureCallback  = () => Console.Write("O"),
+	ExportExceptionCallback = e => Console.Write("!")
 
 };
+Console.WriteLine("2");
 var channel = new DiagnosticsBufferedChannel(options);
+Console.WriteLine($"Begin: ({channel.OutboundStarted}) {channel.MaxConcurrency} {channel.BatchExportOperations} -> {channel.InflightEvents}");
 await Parallel.ForEachAsync(Enumerable.Range(0, int.MaxValue), new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount, CancellationToken = ctxs.Token }, async (i, ctx) =>
 {
 	var e = new NoopBufferedChannel.NoopEvent { Id = i };
-	if (!await channel.WaitToWriteAsync(e))
-		Console.WriteLine($" {channel.MaxConcurrency} {channel.OngoingExportOperations} -> {channel.OutstandingOperations}");
+	if (await channel.WaitToWriteAsync(e))
+	{
+
+	}
+
+	if (i % 10_000 == 0)
+	{
+		Console.Clear();
+		Console.WriteLine(channel);
+	}
 });

--- a/examples/Elastic.Channels.Continuous/Program.cs
+++ b/examples/Elastic.Channels.Continuous/Program.cs
@@ -14,7 +14,7 @@ Console.CancelKeyPress += (sender, eventArgs) => {
 
 var options = new NoopBufferedChannel.NoopChannelOptions
 {
-	BufferOptions = new BufferOptions()
+	BufferOptions = new BufferOptions
 	{
 		OutboundBufferMaxLifetime = TimeSpan.Zero
 	},
@@ -29,5 +29,5 @@ await Parallel.ForEachAsync(Enumerable.Range(0, int.MaxValue), new ParallelOptio
 {
 	var e = new NoopBufferedChannel.NoopEvent { Id = i };
 	if (!await channel.WaitToWriteAsync(e))
-		Console.WriteLine(channel.OutstandingOperations);
+		Console.WriteLine($" {channel.MaxConcurrency} {channel.OngoingExportOperations} -> {channel.OutstandingOperations}");
 });

--- a/examples/Elastic.Channels.Continuous/Program.cs
+++ b/examples/Elastic.Channels.Continuous/Program.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements. // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
 using System.Threading.Channels;

--- a/src/Elastic.Channels/BufferOptions.cs
+++ b/src/Elastic.Channels/BufferOptions.cs
@@ -25,13 +25,22 @@ public class BufferOptions
 	/// </summary>
 	public int OutboundBufferMaxSize { get; set; } = 1_000;
 
+	private TimeSpan _outboundBufferMaxLifetime = TimeSpan.FromSeconds(5);
+	private readonly TimeSpan _outboundBufferMinLifetime = TimeSpan.FromSeconds(1);
+
+
 	/// <summary>
 	/// The maximum lifetime of a buffer to export to <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.ExportAsync"/>.
 	/// If a buffer is older then the configured <see cref="OutboundBufferMaxLifetime"/> it will be flushed to
 	/// <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.ExportAsync"/> regardless of it's current size
 	/// <para>Defaults to <c>5 seconds</c></para>
+	/// <para>Any value less than <c>1 second</c> will be rounded back up to <c>1 second</c></para>
 	/// </summary>
-	public TimeSpan OutboundBufferMaxLifetime { get; set; } = TimeSpan.FromSeconds(5);
+	public TimeSpan OutboundBufferMaxLifetime
+	{
+		get => _outboundBufferMaxLifetime;
+		set => _outboundBufferMaxLifetime = value >= _outboundBufferMinLifetime ? value : _outboundBufferMaxLifetime;
+	}
 
 	/// <summary>
 	/// The maximum number of consumers allowed to poll for new events on the channel.

--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -209,7 +209,7 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 	public override async ValueTask<bool> WaitToWriteAsync(CancellationToken ctx = default)
 	{
 		if (BufferOptions.BoundedChannelFullMode == BoundedChannelFullMode.Wait && _inflightEvents >= BufferOptions.InboundBufferMaxSize - DrainSize)
-			while (_inflightEvents >= (BufferOptions.InboundBufferMaxSize - DrainSize))
+			for (var i = 0; i < 10 && _inflightEvents >= BufferOptions.InboundBufferMaxSize - DrainSize; i++)
 				await Task.Delay(TimeSpan.FromMilliseconds(100), ctx).ConfigureAwait(false);
 		return await InChannel.Writer.WaitToWriteAsync(ctx).ConfigureAwait(false);
 	}

--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -192,7 +192,6 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 		if (BufferOptions.BoundedChannelFullMode == BoundedChannelFullMode.Wait
 			&& OngoingExportOperations >= MaxConcurrency)
 			await _throttleOutboundPublishes.WaitAsync(TokenSource.Token).ConfigureAwait(false);
-			//_throttleExportTasks.AvailableWaitHandle.WaitOne(TimeSpan.FromSeconds(1));
 
 		return await InChannel.Writer.WaitToWriteAsync(ctx).ConfigureAwait(false);
 	}

--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -424,9 +424,9 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 	/// <inheritdoc cref="object.ToString"/>>
 	public override string ToString()
 	{
+		if (DiagnosticsListener == null) return base.ToString();
 		var sb = new StringBuilder();
-		if (DiagnosticsListener != null)
-			sb.AppendLine(DiagnosticsListener.ToString());
+		sb.AppendLine(DiagnosticsListener.ToString());
 		sb.AppendLine($"{nameof(InflightEvents)}: {InflightEvents:N0}");
 		sb.AppendLine($"{nameof(BufferOptions.InboundBufferMaxSize)}: {BufferOptions.InboundBufferMaxSize:N0}");
 		sb.AppendLine($"{nameof(BatchExportOperations)}: {BatchExportOperations:N0}");

--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -60,15 +61,65 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 {
 	private readonly Task _inTask;
 	private readonly Task _outTask;
-	private readonly int _maxConcurrency;
 	private readonly SemaphoreSlim _throttleExportTasks;
-	private readonly SemaphoreSlim _throttleOutboundPublishes;
 	private readonly CountdownEvent? _signal;
 
 	private readonly ChannelCallbackInvoker<TEvent, TResponse> _callbacks;
 
 	/// <inheritdoc cref="IChannelDiagnosticsListener"/>
 	public IChannelDiagnosticsListener? DiagnosticsListener { get; }
+
+	/// <summary>The channel options currently in use</summary>
+	public TChannelOptions Options { get; }
+
+	/// <summary> An overall cancellation token that may be externally provided </summary>
+	protected CancellationTokenSource TokenSource { get; }
+
+	/// <summary>Internal cancellation token for signalling that all publishing activity has completed.</summary>
+	private readonly CancellationTokenSource _exitCancelSource = new();
+
+	private Channel<IOutboundBuffer<TEvent>> OutChannel { get; }
+	private Channel<TEvent> InChannel { get; }
+	private BufferOptions BufferOptions => Options.BufferOptions;
+
+	private long _inflightEvents;
+	/// <summary> The number of inflight events </summary>
+	public long InflightEvents => _inflightEvents;
+
+	/// <summary> Current number of tasks handling exporting the events </summary>
+	public int ExportTasks => _taskList.Count;
+
+	/// <summary>
+	/// The effective concurrency.
+	/// <para>Either the  configured concurrency <see cref="Channels.BufferOptions.ExportMaxConcurrency"/> or the calculated concurrency.</para>
+	/// </summary>
+	public int MaxConcurrency { get; }
+
+	/// <summary>
+	/// The effective batch export size .
+	/// <para>Either the  configured concurrency <see cref="Channels.BufferOptions.OutboundBufferMaxSize"/> or the calculated size.</para>
+	/// <para>If the configured <see cref="Channels.BufferOptions.OutboundBufferMaxSize"/> exceeds (<see cref="Channels.BufferOptions.InboundBufferMaxSize"/> / <see cref="MaxConcurrency"/>)</para>
+	/// <para>the batch export size will be lowered to (<see cref="Channels.BufferOptions.InboundBufferMaxSize"/> / <see cref="MaxConcurrency"/>) to ensure we saturate <see cref="MaxConcurrency"/></para>
+	/// </summary>
+	public int BatchExportSize { get; }
+
+	/// <summary>
+	/// If <see cref="Channels.BufferOptions.BoundedChannelFullMode"/> is set to <see cref="BoundedChannelFullMode.Wait"/>
+	/// and <see cref="InflightEvents"/> approaches <see cref="Channels.BufferOptions.InboundBufferMaxSize"/>
+	/// <see cref="WaitToWriteAsync(System.Threading.CancellationToken)"/> will block until <see cref="InflightEvents"/> drops with atleast this size
+	/// </summary>
+	public int DrainSize { get; }
+
+	private int _ongoingExportOperations;
+	/// <summary> Outstanding export operations </summary>
+	public int BatchExportOperations => _ongoingExportOperations;
+	private readonly CountdownEvent _waitForOutboundRead;
+	private List<Task> _taskList;
+
+	/// <summary> </summary>
+	public bool OutboundStarted  => _waitForOutboundRead.IsSet;
+
+	internal InboundBuffer<TEvent> InboundBuffer { get; }
 
 	/// <inheritdoc cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}"/>
 	protected BufferedChannelBase(TChannelOptions options) : this(options, null) { }
@@ -94,18 +145,33 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 		}
 		_callbacks = new ChannelCallbackInvoker<TEvent, TResponse>(listeners);
 
-		var maxIn = Math.Max(1, BufferOptions.InboundBufferMaxSize);
-		// The minimum out buffer the max of (1 or OutboundBufferMaxSize) as long as it does not exceed InboundBufferMaxSize
-		var maxOut = Math.Min(BufferOptions.InboundBufferMaxSize, Math.Max(1, BufferOptions.OutboundBufferMaxSize));
-		var defaultMaxConcurrency = (int)Math.Ceiling(maxIn / (double)maxOut);
-		_maxConcurrency =
-			BufferOptions.ExportMaxConcurrency.HasValue
-				? BufferOptions.ExportMaxConcurrency.Value
-				: Math.Min(defaultMaxConcurrency, Environment.ProcessorCount * 2);
+		var maxIn = Math.Max(Math.Max(1, BufferOptions.InboundBufferMaxSize), BufferOptions.OutboundBufferMaxSize);
+		var defaultMaxOut = Math.Max(1, BufferOptions.OutboundBufferMaxSize);
+		var calculatedConcurrency = (int)Math.Ceiling(maxIn / (double)defaultMaxOut);
+		var defaultConcurrency = Environment.ProcessorCount * 2;
+		MaxConcurrency = BufferOptions.ExportMaxConcurrency ?? Math.Min(calculatedConcurrency, defaultConcurrency);
 
-		_throttleOutboundPublishes = new SemaphoreSlim(_maxConcurrency, _maxConcurrency);
-		_throttleExportTasks = new SemaphoreSlim(_maxConcurrency, _maxConcurrency);
+		// The minimum out buffer the max of (1 or OutboundBufferMaxSize) as long as it does not exceed InboundBufferMaxSize / (MaxConcurrency * 2)
+		BatchExportSize = Math.Min(BufferOptions.InboundBufferMaxSize / (MaxConcurrency), Math.Max(1, BufferOptions.OutboundBufferMaxSize));
+		DrainSize = Math.Min(100_000, Math.Min(BatchExportSize * 2, maxIn / 2));
+
+		_taskList = new List<Task>(MaxConcurrency * 2);
+
+		_throttleExportTasks = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
 		_signal = options.BufferOptions.WaitHandle;
+		_waitForOutboundRead = new CountdownEvent(1);
+		OutChannel = Channel.CreateBounded<IOutboundBuffer<TEvent>>(
+			new BoundedChannelOptions(MaxConcurrency * 4)
+			{
+				SingleReader = false,
+				SingleWriter = true,
+				// Stephen Toub comment: https://github.com/dotnet/runtime/issues/26338#issuecomment-393720727
+				// AFAICT this is fine since we run in a dedicated long running task.
+				AllowSynchronousContinuations = true,
+				// wait does not block it simply signals that Writer.TryWrite should return false and be retried
+				// DropWrite will make `TryWrite` always return true, which is not what we want.
+				FullMode = BoundedChannelFullMode.Wait
+			});
 		InChannel = Channel.CreateBounded<TEvent>(new BoundedChannelOptions(maxIn)
 		{
 			SingleReader = false,
@@ -117,20 +183,8 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 			// DropWrite will make `TryWrite` always return true, which is not what we want.
 			FullMode = options.BufferOptions.BoundedChannelFullMode
 		});
-		OutChannel = Channel.CreateBounded<IOutboundBuffer<TEvent>>(
-			new BoundedChannelOptions(_maxConcurrency * 2)
-			{
-				SingleReader = false,
-				SingleWriter = true,
-				// Stephen Toub comment: https://github.com/dotnet/runtime/issues/26338#issuecomment-393720727
-				// AFAICT this is fine since we run in a dedicated long running task.
-				AllowSynchronousContinuations = true,
-				// wait does not block it simply signals that Writer.TryWrite should return false and be retried
-				// DropWrite will make `TryWrite` always return true, which is not what we want.
-				FullMode = BoundedChannelFullMode.Wait
-			});
 
-		InboundBuffer = new InboundBuffer<TEvent>(maxOut, BufferOptions.OutboundBufferMaxLifetime);
+		InboundBuffer = new InboundBuffer<TEvent>(BatchExportSize, BufferOptions.OutboundBufferMaxLifetime);
 
 		_outTask = Task.Factory.StartNew(async () =>
 				await ConsumeOutboundEventsAsync().ConfigureAwait(false),
@@ -139,7 +193,7 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 			TaskScheduler.Default);
 
 		_inTask = Task.Factory.StartNew(async () =>
-				await ConsumeInboundEventsAsync(maxOut, BufferOptions.OutboundBufferMaxLifetime).ConfigureAwait(false),
+				await ConsumeInboundEventsAsync(BatchExportSize, BufferOptions.OutboundBufferMaxLifetime).ConfigureAwait(false),
 			CancellationToken.None,
 			TaskCreationOptions.LongRunning | TaskCreationOptions.PreferFairness,
 			TaskScheduler.Default);
@@ -151,48 +205,12 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 	/// </summary>
 	protected abstract Task<TResponse> ExportAsync(ArraySegment<TEvent> buffer, CancellationToken ctx = default);
 
-	/// <summary>The channel options currently in use</summary>
-	public TChannelOptions Options { get; }
-
-	/// <summary> An overall cancellation token that may be externally provided </summary>
-	protected CancellationTokenSource TokenSource { get; }
-
-	/// <summary>Internal cancellation token for signalling that all publishing activity has completed.</summary>
-	private readonly CancellationTokenSource _exitCancelSource = new CancellationTokenSource();
-
-	private Channel<IOutboundBuffer<TEvent>> OutChannel { get; }
-	private Channel<TEvent> InChannel { get; }
-	private BufferOptions BufferOptions => Options.BufferOptions;
-
-	private long _outstandingOperations;
-
-	/// <summary>
-	///
-	/// </summary>
-	public long OutstandingOperations => _outstandingOperations;
-
-	/// <summary>
-	/// The effective concurrency.
-	/// <para>Either the  configured concurrency <see cref="Channels.BufferOptions.ExportMaxConcurrency"/>
-	/// or the calculated concurrency.</para>
-	/// </summary>
-	public int MaxConcurrency => _maxConcurrency;
-
-	/// <summary> Outstanding export operations </summary>
-	public int OngoingExportOperations => _throttleExportTasks.CurrentCount;
-
-	internal InboundBuffer<TEvent> InboundBuffer { get; }
-
 	/// <inheritdoc cref="ChannelWriter{T}.WaitToWriteAsync"/>
 	public override async ValueTask<bool> WaitToWriteAsync(CancellationToken ctx = default)
 	{
-		//provides an interop allowing sufficient drain of export tasks in cases where
-		//data is produced in a tight loop and might otherwise thread steal from
-		//export tasks
-		if (BufferOptions.BoundedChannelFullMode == BoundedChannelFullMode.Wait
-			&& OngoingExportOperations >= MaxConcurrency)
-			await _throttleOutboundPublishes.WaitAsync(TokenSource.Token).ConfigureAwait(false);
-
+		if (BufferOptions.BoundedChannelFullMode == BoundedChannelFullMode.Wait && _inflightEvents >= BufferOptions.InboundBufferMaxSize - DrainSize)
+			while (_inflightEvents >= (BufferOptions.InboundBufferMaxSize - DrainSize))
+				await Task.Delay(TimeSpan.FromMilliseconds(100), ctx).ConfigureAwait(false);
 		return await InChannel.Writer.WaitToWriteAsync(ctx).ConfigureAwait(false);
 	}
 
@@ -204,7 +222,7 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 	{
 		if (InChannel.Writer.TryWrite(item))
 		{
-			Interlocked.Increment(ref _outstandingOperations);
+			Interlocked.Increment(ref _inflightEvents);
 			_callbacks.PublishToInboundChannelCallback?.Invoke();
 			return true;
 		}
@@ -247,7 +265,7 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 
 		if (await WaitToWriteAsync(ctx).ConfigureAwait(false) && InChannel.Writer.TryWrite(item))
 		{
-			Interlocked.Increment(ref _outstandingOperations);
+			Interlocked.Increment(ref _inflightEvents);
 			_callbacks.PublishToInboundChannelCallback?.Invoke();
 			return true;
 		}
@@ -260,19 +278,19 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 	/// Subclasses may override this to yield items from <typeparamref name="TResponse"/> that can be retried.
 	/// <para>The default implementation of this simply always returns an empty collection</para>
 	/// </summary>
-	protected virtual ArraySegment<TEvent> RetryBuffer(TResponse response,
-		ArraySegment<TEvent> currentBuffer,
-		IWriteTrackingBuffer statistics
-	) => EmptyArraySegments<TEvent>.Empty;
+	protected virtual ArraySegment<TEvent> RetryBuffer(TResponse response, ArraySegment<TEvent> currentBuffer, IWriteTrackingBuffer statistics) =>
+		EmptyArraySegments<TEvent>.Empty;
 
 	private async Task ConsumeOutboundEventsAsync()
 	{
 		_callbacks.OutboundChannelStartedCallback?.Invoke();
 
-		var taskList = new List<Task>(_maxConcurrency);
+		_taskList = new List<Task>(MaxConcurrency * 2);
 
 		while (await OutChannel.Reader.WaitToReadAsync().ConfigureAwait(false))
 		{
+			if (_waitForOutboundRead is { IsSet: false })
+				_waitForOutboundRead.Signal();
 			if (TokenSource.Token.IsCancellationRequested) break;
 			if (_signal is { IsSet: true }) break;
 
@@ -281,23 +299,24 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 				var items = buffer.GetArraySegment();
 				await _throttleExportTasks.WaitAsync(TokenSource.Token).ConfigureAwait(false);
 				var t = ExportBufferAsync(items, buffer);
-				taskList.Add(t);
+				_taskList.Add(t);
 
-				if (taskList.Count >= _maxConcurrency)
+				if (_taskList.Count >= MaxConcurrency)
 				{
-					var completedTask = await Task.WhenAny(taskList).ConfigureAwait(false);
-					taskList.Remove(completedTask);
+					var completedTask = await Task.WhenAny(_taskList).ConfigureAwait(false);
+					_taskList.Remove(completedTask);
 				}
 				_throttleExportTasks.Release();
 			}
 		}
-		await Task.WhenAll(taskList).ConfigureAwait(false);
+		await Task.WhenAll(_taskList).ConfigureAwait(false);
 		_exitCancelSource.Cancel();
 		_callbacks.OutboundChannelExitedCallback?.Invoke();
 	}
 
 	private async Task ExportBufferAsync(ArraySegment<TEvent> items, IOutboundBuffer<TEvent> buffer)
 	{
+		Interlocked.Increment(ref _ongoingExportOperations);
 		using var outboundBuffer = buffer;
 		var maxRetries = Options.BufferOptions.ExportMaxRetries;
 		for (var i = 0; i <= maxRetries && items.Count > 0; i++)
@@ -334,10 +353,11 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 				await Task.Delay(Options.BufferOptions.ExportBackoffPeriod(i), TokenSource.Token).ConfigureAwait(false);
 				_callbacks.ExportRetryCallback?.Invoke(items);
 			}
-			// otherwise if retryable items still exist and the user wants to be notified notify the user
+			// otherwise if retryable items still exist and the user wants to be notified
 			else if (items.Count > 0 && atEndOfRetries)
 				_callbacks.ExportMaxRetriesCallback?.Invoke(items);
 		}
+		Interlocked.Decrement(ref _ongoingExportOperations);
 		_callbacks.ExportBufferCallback?.Invoke();
 		if (_signal is { IsSet: false })
 			_signal.Signal();
@@ -355,13 +375,11 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 			while (InboundBuffer.Count < maxQueuedMessages && InChannel.Reader.TryRead(out var item))
 			{
 				InboundBuffer.Add(item);
-				Interlocked.Decrement(ref _outstandingOperations);
+				Interlocked.Decrement(ref _inflightEvents);
 
 				if (InboundBuffer.DurationSinceFirstWaitToRead >= maxInterval)
 					break;
 			}
-
-			_throttleOutboundPublishes.Release();
 
 			if (InboundBuffer.ThresholdsHit)
 				await FlushBufferAsync().ConfigureAwait(false);
@@ -404,8 +422,20 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 	}
 
 	/// <inheritdoc cref="object.ToString"/>>
-	public override string ToString() =>
-		DiagnosticsListener != null ? DiagnosticsListener.ToString() : base.ToString();
+	public override string ToString()
+	{
+		var sb = new StringBuilder();
+		if (DiagnosticsListener != null)
+			sb.AppendLine(DiagnosticsListener.ToString());
+		sb.AppendLine($"{nameof(InflightEvents)}: {InflightEvents:N0}");
+		sb.AppendLine($"{nameof(BufferOptions.InboundBufferMaxSize)}: {BufferOptions.InboundBufferMaxSize:N0}");
+		sb.AppendLine($"{nameof(BatchExportOperations)}: {BatchExportOperations:N0}");
+		sb.AppendLine($"{nameof(BatchExportSize)}: {BatchExportSize:N0}");
+		sb.AppendLine($"{nameof(DrainSize)}: {DrainSize:N0}");
+		sb.AppendLine($"{nameof(MaxConcurrency)}: {MaxConcurrency:N0}");
+		sb.AppendLine($"{nameof(ExportTasks)}: {ExportTasks:N0}");
+		return sb.ToString();
+	}
 
 	/// <inheritdoc cref="IDisposable.Dispose"/>
 	public virtual void Dispose()

--- a/src/Elastic.Channels/Diagnostics/DiagnosticsBufferedChannel.cs
+++ b/src/Elastic.Channels/Diagnostics/DiagnosticsBufferedChannel.cs
@@ -41,15 +41,8 @@ public class DiagnosticsBufferedChannel : NoopBufferedChannel
 		#else
 		IList<NoopEvent> b = buffer;
 		#endif
-		if (Options.BufferOptions.OutboundBufferMaxSize != buffer.Count)
-		{
+		if (BatchExportSize != buffer.Count)
 			Interlocked.Increment(ref _bufferMismatches);
-		}
-		else if (b.Count > 0 && b[0].Id.HasValue)
-		{
-			if (b[0].Id % Options.BufferOptions.OutboundBufferMaxSize != 0)
-				Interlocked.Increment(ref _bufferMismatches);
-		}
 
 		return base.ExportAsync(buffer, ctx);
 	}

--- a/src/Elastic.Channels/Diagnostics/NoopBufferedChannel.cs
+++ b/src/Elastic.Channels/Diagnostics/NoopBufferedChannel.cs
@@ -67,7 +67,7 @@ public class NoopBufferedChannel
 		if (!Options.TrackConcurrency) return new NoopResponse();
 
 		var max = Interlocked.Increment(ref _currentMax);
-		await Task.Delay(TimeSpan.FromMilliseconds(1), ctx).ConfigureAwait(false);
+		await Task.Delay(TimeSpan.FromMilliseconds(100), ctx).ConfigureAwait(false);
 		Interlocked.Decrement(ref _currentMax);
 		if (max > ObservedConcurrency) ObservedConcurrency = max;
 		return new NoopResponse();

--- a/tests/Elastic.Channels.Tests/BehaviorTests.cs
+++ b/tests/Elastic.Channels.Tests/BehaviorTests.cs
@@ -61,7 +61,7 @@ public class BehaviorTests : IDisposable
 			WaitHandle = new CountdownEvent(1),
 			InboundBufferMaxSize = maxInFlight,
 			OutboundBufferMaxSize = bufferSize,
-			OutboundBufferMaxLifetime = TimeSpan.FromMilliseconds(500)
+			OutboundBufferMaxLifetime = TimeSpan.FromSeconds(1)
 		};
 
 		var channel = new NoopBufferedChannel(bufferOptions);
@@ -72,7 +72,7 @@ public class BehaviorTests : IDisposable
 			if (await channel.WaitToWriteAsync(e))
 				written++;
 		}
-		var signalled = bufferOptions.WaitHandle.Wait(TimeSpan.FromSeconds(1));
+		var signalled = bufferOptions.WaitHandle.Wait(TimeSpan.FromSeconds(2));
 		signalled.Should().BeTrue("The channel was not drained in the expected time");
 		written.Should().Be(100);
 		channel.ExportedBuffers.Should().Be(1);

--- a/tests/Elastic.Channels.Tests/BehaviorTests.cs
+++ b/tests/Elastic.Channels.Tests/BehaviorTests.cs
@@ -153,13 +153,13 @@ public class BehaviorTests : IDisposable
 	[Fact] public async Task SlowlyPushEvents()
 	{
 		int totalEvents = 50_000_000, maxInFlight = totalEvents / 5, bufferSize = maxInFlight / 10;
-		var expectedSentBuffers = totalEvents / bufferSize;
+		var expectedSentBuffers = totalEvents / 10_000;
 		var bufferOptions = new BufferOptions
 		{
 			WaitHandle = new CountdownEvent(expectedSentBuffers),
 			InboundBufferMaxSize = maxInFlight,
 			OutboundBufferMaxSize = 10_000,
-			OutboundBufferMaxLifetime = TimeSpan.FromMilliseconds(100)
+			OutboundBufferMaxLifetime = TimeSpan.FromMilliseconds(1000)
 		};
 		using var channel = new DiagnosticsBufferedChannel(bufferOptions, name: $"Slow push channel");
 		await Task.Delay(TimeSpan.FromMilliseconds(200));
@@ -175,7 +175,7 @@ public class BehaviorTests : IDisposable
 			}
 		}, TaskCreationOptions.LongRunning);
 		// wait for some work to have progressed
-		bufferOptions.WaitHandle.Wait(TimeSpan.FromMilliseconds(500));
+		bufferOptions.WaitHandle.Wait(TimeSpan.FromMilliseconds(2000));
 		//Ensure we written to the channel but not enough to satisfy OutboundBufferMaxSize
 		written.Should().BeGreaterThan(0).And.BeLessThan(10_000);
 		//even though OutboundBufferMaxSize was not hit we should still observe an invocation to Export()

--- a/tests/Elastic.Channels.Tests/BehaviorTests.cs
+++ b/tests/Elastic.Channels.Tests/BehaviorTests.cs
@@ -15,7 +15,13 @@ namespace Elastic.Channels.Tests;
 
 public class BehaviorTests : IDisposable
 {
-	public BehaviorTests(ITestOutputHelper testOutput) => XunitContext.Register(testOutput);
+	private readonly ITestOutputHelper _testOutput;
+
+	public BehaviorTests(ITestOutputHelper testOutput)
+	{
+		_testOutput = testOutput;
+		XunitContext.Register(testOutput);
+	}
 
 	void IDisposable.Dispose() => XunitContext.Flush();
 
@@ -74,7 +80,7 @@ public class BehaviorTests : IDisposable
 
 	[Fact] public async Task ConcurrencyIsApplied()
 	{
-		int totalEvents = 5_000, maxInFlight = 5_000, bufferSize = 500;
+		int totalEvents = 50_000, maxInFlight = 50_000, bufferSize = 5000;
 		var expectedPages = totalEvents / bufferSize;
 		var bufferOptions = new BufferOptions
 		{
@@ -85,7 +91,9 @@ public class BehaviorTests : IDisposable
 		};
 
 		var channel = new NoopBufferedChannel(bufferOptions, observeConcurrency: true);
+		channel.MaxConcurrency.Should().BeGreaterThan(1);
 
+		_testOutput.WriteLine($"{channel.MaxConcurrency}");
 		var written = 0;
 		for (var i = 0; i < totalEvents; i++)
 		{

--- a/tests/Elastic.Channels.Tests/CalculatedPropertyTests.cs
+++ b/tests/Elastic.Channels.Tests/CalculatedPropertyTests.cs
@@ -48,7 +48,7 @@ public class CalculatedPropertyTests : IDisposable
 		else
 			channel.BatchExportSize.Should().Be(maxInFlight / expectedConcurrency);
 
-		// drain size is max'ed out at 100_000
+		// drain size is maxed out at 100_000
 		channel.DrainSize.Should().Be(Math.Min(100_000, drainSize));
 
 	}

--- a/tests/Elastic.Channels.Tests/CalculatedPropertyTests.cs
+++ b/tests/Elastic.Channels.Tests/CalculatedPropertyTests.cs
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Channels.Diagnostics;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.Channels.Tests;
+
+public class CalculatedPropertyTests : IDisposable
+{
+	private readonly ITestOutputHelper _testOutput;
+
+	public CalculatedPropertyTests(ITestOutputHelper testOutput)
+	{
+		_testOutput = testOutput;
+		XunitContext.Register(testOutput);
+	}
+
+	void IDisposable.Dispose() => XunitContext.Flush();
+
+	[Theory]
+	[InlineData(500_000, 50_000, 100_000)]
+	[InlineData(10_00_000, 50_000, 100_000)]
+	[InlineData(50_000, 50_000, 25_000)]
+	[InlineData(10_000, 50_000, 20_000)]
+	[InlineData(10_00_000, 1_000, 2_000)]
+	public void BatchExportSizeAndDrainSizeConstraints(int maxInFlight, int bufferSize, int drainSize)
+	{
+		var bufferOptions = new BufferOptions
+		{
+			InboundBufferMaxSize = maxInFlight,
+			OutboundBufferMaxSize = bufferSize,
+		};
+		var channel = new NoopBufferedChannel(bufferOptions);
+
+		var expectedConcurrency =
+			Math.Max(1, Math.Min(maxInFlight / bufferSize, Environment.ProcessorCount * 2));
+		channel.MaxConcurrency.Should().Be(expectedConcurrency);
+		if (maxInFlight >= bufferSize)
+			channel.BatchExportSize.Should().Be(bufferSize);
+		else
+			channel.BatchExportSize.Should().Be(maxInFlight / expectedConcurrency);
+
+		// drain size is max'ed out at 100_000
+		channel.DrainSize.Should().Be(Math.Min(100_000, drainSize));
+
+	}
+
+}


### PR DESCRIPTION
Ensure we never allow `TimeSpan.Zero` since it effectively will behave as `OutboundBufferMaxSize = 1`. 

This also stabilises `WaitToWriteAsync` when using `BoundedChannelFullMode.Wait` to ensure the InboundChannel is sufficiently drained before pumping messages into inbound channel again. 

Fixes a similar problem as: https://github.com/dotnet/runtime/issues/66281