### PR TITLE
Add `ItemDropped` callback to `ChannelOptionsBase`

### DIFF
--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -173,6 +173,13 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 				// DropWrite will make `TryWrite` always return true, which is not what we want.
 				FullMode = BoundedChannelFullMode.Wait
 			});
+
+		//we don't expose the fact TEvent is nullable to the consumer
+		Action<TEvent?>? itemDropped = options.BufferItemDropped is null ? null : e =>
+		{
+			if (e is not null)
+				options.BufferItemDropped?.Invoke(e);
+		};
 		InChannel = Channel.CreateBounded<TEvent?>(new BoundedChannelOptions(maxIn)
 		{
 			SingleReader = false,
@@ -183,11 +190,7 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 			// wait does not block it simply signals that Writer.TryWrite should return false and be retried
 			// DropWrite will make `TryWrite` always return true, which is not what we want.
 			FullMode = options.BufferOptions.BoundedChannelFullMode
-		}, options.BufferItemDropped is null ? null : e =>
-		{
-			if (e is not null)
-				options.BufferItemDropped?.Invoke(e);
-		});
+		}, itemDropped);
 
 		InboundBuffer = new InboundBuffer<TEvent>(BatchExportSize, BufferOptions.OutboundBufferMaxLifetime);
 

--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -183,7 +183,11 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 			// wait does not block it simply signals that Writer.TryWrite should return false and be retried
 			// DropWrite will make `TryWrite` always return true, which is not what we want.
 			FullMode = options.BufferOptions.BoundedChannelFullMode
-		}, options.BufferItemDropped);
+		}, options.BufferItemDropped is null ? null : e =>
+		{
+			if (e is not null)
+				options.BufferItemDropped?.Invoke(e);
+		});
 
 		InboundBuffer = new InboundBuffer<TEvent>(BatchExportSize, BufferOptions.OutboundBufferMaxLifetime);
 

--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -182,7 +182,7 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 			// wait does not block it simply signals that Writer.TryWrite should return false and be retried
 			// DropWrite will make `TryWrite` always return true, which is not what we want.
 			FullMode = options.BufferOptions.BoundedChannelFullMode
-		});
+		}, options.BufferItemDropped);
 
 		InboundBuffer = new InboundBuffer<TEvent>(BatchExportSize, BufferOptions.OutboundBufferMaxLifetime);
 

--- a/src/Elastic.Channels/ChannelOptionsBase.cs
+++ b/src/Elastic.Channels/ChannelOptionsBase.cs
@@ -21,7 +21,7 @@ public abstract class ChannelOptionsBase<TEvent, TResponse> : IChannelCallbacks<
 	public BufferOptions BufferOptions { get; set; } = new();
 
 	/// <summary>
-	/// TBD
+    /// Delegate that will be called when item is being dropped from channel. See <see cref="BufferOptions.BoundedChannelFullMode"/>.
 	/// </summary>
 	public Action<TEvent>? BufferItemDropped { get; set; }
 

--- a/src/Elastic.Channels/ChannelOptionsBase.cs
+++ b/src/Elastic.Channels/ChannelOptionsBase.cs
@@ -20,6 +20,10 @@ public abstract class ChannelOptionsBase<TEvent, TResponse> : IChannelCallbacks<
 	/// <inheritdoc cref="BufferOptions"/>
 	public BufferOptions BufferOptions { get; set; } = new();
 
+	/// <summary>
+	/// TBD
+	/// </summary>
+	public Action<TEvent>? BufferItemDropped { get; set; }
 
 	/// <summary>
 	/// Ensures a <see cref="ChannelDiagnosticsListener{TEvent,TResponse}"/> gets registered so this <see cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}"/>


### PR DESCRIPTION
There is no way to detect when an event is dropped due to `BufferOptions.BoundedChannelFullMode` being set to drop.

Starting with some version of `System.Threading.Channels`, an `itemDropped` callback was added to the `BoundedChannel`. So I added a `BufferItemDropped` callback to the `ChannelOptionsBase`.

This callback would fit better in the `BufferOptions`, but because it requires a `TEvent`, it would also need to be added to the `BufferOptions`. I am not sure if it is affordable, because of how many things depend on `BufferOptions` being without generic parameters.