### PR TITLE
Use new secret for pushing to nuget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,4 +148,4 @@ jobs:
         subject-path: '${{ github.workspace }}/${{ env.ARTIFACTS }}'
 
     - name: Release to nuget.org
-      run: dotnet nuget push '${{ env.ARTIFACTS }}' -k ${{secrets.NUGET_ORG_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
+      run: dotnet nuget push '${{ env.ARTIFACTS }}' -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols


### PR DESCRIPTION
This will use the new GH secret (managed by observability-github-secrets)

P.S. no changes required for feedz.io, as the secret name stayed the same.