### PR TITLE
Bump to latest `Elastic.Transport` version

### DIFF
--- a/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
+++ b/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Channels\Elastic.Channels.csproj" />
-    <PackageReference Include="Elastic.Transport" Version="0.5.1" />
+    <PackageReference Include="Elastic.Transport" Version="0.5.5" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
 

--- a/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/Elastic.Ingest.Elasticsearch.IntegrationTests.csproj
+++ b/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/Elastic.Ingest.Elasticsearch.IntegrationTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.1" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.16.1" />
     <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.5.0" />
   </ItemGroup>
 

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/Elastic.Ingest.Elasticsearch.Tests.csproj
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/Elastic.Ingest.Elasticsearch.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Transport.VirtualizedCluster" Version="0.5.1" />
+    <PackageReference Include="Elastic.Transport.VirtualizedCluster" Version="0.5.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updates to Elastic.Transport 0.5.5.
- Updates to Elastic.Clients.Elasticsearch 8.16.1.