### PR TITLE
Refactor `WaitToReadAsync` to improve cancellation handling.

### DIFF
--- a/src/Elastic.Channels/ResponseItemsBufferedChannelBase.cs
+++ b/src/Elastic.Channels/ResponseItemsBufferedChannelBase.cs
@@ -30,6 +30,7 @@ public abstract class ResponseItemsBufferedChannelBase<TChannelOptions, TEvent, 
 	: BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 	where TChannelOptions : ResponseItemsChannelOptionsBase<TEvent, TResponse, TBulkResponseItem>
 	where TResponse : class, new()
+	where TEvent : class
 {
 	/// <inheritdoc cref="ResponseItemsBufferedChannelBase{TChannelOptions,TEvent,TResponse,TBulkResponseItem}"/>
 	protected ResponseItemsBufferedChannelBase(TChannelOptions options, ICollection<IChannelCallbacks<TEvent, TResponse>>? callbackListeners)

--- a/src/Elastic.Ingest.Elasticsearch/DataStreams/DataStreamChannel.cs
+++ b/src/Elastic.Ingest.Elasticsearch/DataStreams/DataStreamChannel.cs
@@ -12,6 +12,7 @@ namespace Elastic.Ingest.Elasticsearch.DataStreams;
 
 /// <summary> A channel to push messages to Elasticsearch data streams </summary>
 public class DataStreamChannel<TEvent> : ElasticsearchChannelBase<TEvent, DataStreamChannelOptions<TEvent>>
+	where TEvent : class
 {
 	private readonly CreateOperation _fixedHeader;
 	private readonly string _url;

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.Bootstrap.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.Bootstrap.cs
@@ -10,6 +10,8 @@ using Elastic.Transport;
 namespace Elastic.Ingest.Elasticsearch;
 
 public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
+	where TChannelOptions : ElasticsearchChannelOptionsBase<TEvent>
+	where TEvent : class
 {
 	/// <summary> The index template name <see cref="BootstrapElasticsearch"/> should register.</summary>
 	protected abstract string TemplateName { get; }

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
@@ -26,6 +26,7 @@ namespace Elastic.Ingest.Elasticsearch;
 public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 	: TransportChannelBase<TChannelOptions, TEvent, BulkResponse, BulkResponseItem>
 	where TChannelOptions : ElasticsearchChannelOptionsBase<TEvent>
+	where TEvent : class
 {
 	/// <inheritdoc cref="ElasticsearchChannelBase{TEvent,TChannelOptions}"/>
 	protected ElasticsearchChannelBase(TChannelOptions options, ICollection<IChannelCallbacks<TEvent, BulkResponse>>? callbackListeners)

--- a/src/Elastic.Ingest.Elasticsearch/Indices/IndexChannel.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Indices/IndexChannel.cs
@@ -14,6 +14,7 @@ namespace Elastic.Ingest.Elasticsearch.Indices;
 /// <para>If unsure prefer to use <see cref="DataStreamChannel{TEvent}"/></para>
 /// </summary>
 public class IndexChannel<TEvent> : ElasticsearchChannelBase<TEvent, IndexChannelOptions<TEvent>>
+	where TEvent : class
 {
 	private readonly bool _skipIndexNameOnOperations = false;
 	private readonly string _url;

--- a/src/Elastic.Ingest.Transport/TransportChannelBase.cs
+++ b/src/Elastic.Ingest.Transport/TransportChannelBase.cs
@@ -21,6 +21,7 @@ public abstract class TransportChannelBase<TChannelOptions, TEvent, TResponse, T
 	ResponseItemsBufferedChannelBase<TChannelOptions, TEvent, TResponse, TBulkResponseItem>
 	where TChannelOptions : TransportChannelOptionsBase<TEvent, TResponse, TBulkResponseItem>
 	where TResponse : TransportResponse, new()
+	where TEvent : class
 {
 	/// <inheritdoc cref="TransportChannelBase{TChannelOptions,TEvent,TResponse,TBulkResponseItem}"/>
 	protected TransportChannelBase(TChannelOptions options, ICollection<IChannelCallbacks<TEvent, TResponse>>? callbackListeners)


### PR DESCRIPTION
Introduce `WaitToReadResult` enum to better communicate outcomes of `WaitToReadAsync`, including timeout and completion. Update channels to handle potential timeouts by writing nulls and resetting states, addressing `Task` cleanup issues in long-running scenarios.


This addresses #84 
