### PR TITLE
Add serialization context and enhance channel functionality

### DIFF
--- a/elastic-ingest-dotnet.sln.DotSettings
+++ b/elastic-ingest-dotnet.sln.DotSettings
@@ -427,6 +427,7 @@ See the LICENSE file in the project root for more information</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cgroup/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Consts/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=datastreams/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Elasticsearch/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mountinfo/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nonsampled/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/examples/Elastic.Channels.Continuous/Program.cs
+++ b/examples/Elastic.Channels.Continuous/Program.cs
@@ -27,7 +27,7 @@ var options = new NoopBufferedChannel.NoopChannelOptions
 };
 Console.WriteLine("2");
 var channel = new DiagnosticsBufferedChannel(options);
-Console.WriteLine($"Begin: ({channel.OutboundStarted}) {channel.MaxConcurrency} {channel.BatchExportOperations} -> {channel.InflightEvents}");
+Console.WriteLine($"Begin: ({channel.OutboundStarted}) {channel.MaxConcurrency} {channel.InflightExportOperations} -> {channel.InflightEvents}");
 await Parallel.ForEachAsync(Enumerable.Range(0, int.MaxValue), new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount, CancellationToken = ctxs.Token }, async (i, ctx) =>
 {
 	var e = new NoopBufferedChannel.NoopEvent { Id = i };

--- a/examples/playground/playground.csproj
+++ b/examples/playground/playground.csproj
@@ -1,18 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Elastic.Ingest.Elasticsearch\Elastic.Ingest.Elasticsearch.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Ingest.Elasticsearch\Elastic.Ingest.Elasticsearch.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Elastic.Elasticsearch.Ephemeral" Version="0.5.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Elastic.Elasticsearch.Ephemeral" Version="0.5.0"/>
+  </ItemGroup>
 
 </Project>

--- a/src/Elastic.Channels/Buffers/InboundBuffer.cs
+++ b/src/Elastic.Channels/Buffers/InboundBuffer.cs
@@ -109,6 +109,12 @@ internal class InboundBuffer<TEvent> : IWriteTrackingBuffer, IDisposable
 			_breaker.CancelAfter(-1);
 			return await readTask.ConfigureAwait(false) ? WaitToReadResult.Read : WaitToReadResult.Completed;
 		}
+		catch (OperationCanceledException)
+		{
+			_breaker.Dispose();
+			_breaker = new CancellationTokenSource();
+			return WaitToReadResult.Timeout;
+		}
 		catch (Exception) when (_breaker.IsCancellationRequested)
 		{
 			_breaker.Dispose();

--- a/src/Elastic.Channels/Diagnostics/DiagnosticsBufferedChannel.cs
+++ b/src/Elastic.Channels/Diagnostics/DiagnosticsBufferedChannel.cs
@@ -36,11 +36,11 @@ public class DiagnosticsBufferedChannel : NoopBufferedChannel
 	/// <inheritdoc cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.ExportAsync"/>
 	protected override Task<NoopResponse> ExportAsync(ArraySegment<NoopEvent> buffer, CancellationToken ctx = default)
 	{
-		#if NETSTANDARD2_1
+#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
 		var b = buffer;
-		#else
+#else
 		IList<NoopEvent> b = buffer;
-		#endif
+#endif
 		if (BatchExportSize != buffer.Count)
 			Interlocked.Increment(ref _bufferMismatches);
 

--- a/src/Elastic.Ingest.Elasticsearch/DataStreams/DataStreamChannel.cs
+++ b/src/Elastic.Ingest.Elasticsearch/DataStreams/DataStreamChannel.cs
@@ -30,6 +30,9 @@ public class DataStreamChannel<TEvent> : ElasticsearchChannelBase<TEvent, DataSt
 		_fixedHeader = new CreateOperation();
 	}
 
+	/// <inheritdoc cref="ElasticsearchChannelBase{TEvent,TChannelOptions}.RefreshTargets"/>
+	protected override string RefreshTargets => Options.DataStream.ToString();
+
 	/// <inheritdoc cref="ElasticsearchChannelBase{TEvent,TChannelOptions}.CreateBulkOperationHeader"/>
 	protected override BulkOperationHeader CreateBulkOperationHeader(TEvent @event) => _fixedHeader;
 

--- a/src/Elastic.Ingest.Elasticsearch/Elastic.Ingest.Elasticsearch.csproj
+++ b/src/Elastic.Ingest.Elasticsearch/Elastic.Ingest.Elasticsearch.csproj
@@ -1,12 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>Offers an easy to use ChannelWriter implementation to push data concurrently to Elasticsearch using Elastic.Transport</Description>
     <PackageTags>elastic, channels, elasticsearch, ingest</PackageTags>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>True</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
@@ -104,4 +104,7 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 
 	/// <summary>  </summary>
 	protected class PutComponentTemplateResponse : ElasticsearchResponse { }
+
+	/// <summary>  </summary>
+	protected class RefreshResponse : ElasticsearchResponse { }
 }

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelBase.cs
@@ -69,7 +69,7 @@ public abstract partial class ElasticsearchChannelBase<TEvent, TChannelOptions>
 	protected override Task<BulkResponse> ExportAsync(ITransport transport, ArraySegment<TEvent> page, CancellationToken ctx = default)
 	{
 		ctx = ctx == default ? TokenSource.Token : ctx;
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
 		// Option is obsolete to prevent external users to set it.
 #pragma warning disable CS0618
 		if (Options.UseReadOnlyMemory)

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelOptionsBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelOptionsBase.cs
@@ -42,14 +42,16 @@ public abstract class ElasticsearchChannelOptionsBase<TEvent> : TransportChannel
 
 	private IJsonTypeInfoResolver? _serializerContext;
 
-	/// <summary>
-	/// The JsonSerializerContext to use for serialization.
-	/// </summary>
+	/// <summary> The JsonSerializerContext to use for serialization. </summary>
 	public JsonSerializerContext SerializerContext
 	{
 		set
 		{
-			_serializerContext = JsonTypeInfoResolver.Combine(IngestSerializationContext.Default, value);
+			_serializerContext = JsonTypeInfoResolver.Combine(
+				IngestSerializationContext.Default,
+				Elastic.Transport.Products.Elasticsearch.ErrorSerializerContext.Default,
+				value
+			);
 			_serializerOptions = new JsonSerializerOptions
 			{
 				TypeInfoResolver = _serializerContext,
@@ -59,11 +61,8 @@ public abstract class ElasticsearchChannelOptionsBase<TEvent> : TransportChannel
 		}
 	}
 
-	internal IJsonTypeInfoResolver TypeInfoResolver => _serializerContext ?? IngestSerializationContext.Default;
-
 	private JsonSerializerOptions _serializerOptions = new()
 	{
-		TypeInfoResolver = IngestSerializationContext.Default,
 		DefaultIgnoreCondition = ElasticsearchChannelStatics.SerializerOptions.DefaultIgnoreCondition,
 		Encoder = ElasticsearchChannelStatics.SerializerOptions.Encoder
 	};

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelOptionsBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelOptionsBase.cs
@@ -3,6 +3,10 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Elastic.Ingest.Elasticsearch.Serialization;
 using Elastic.Ingest.Transport;
 using Elastic.Transport;
@@ -36,4 +40,33 @@ public abstract class ElasticsearchChannelOptionsBase<TEvent> : TransportChannel
 	[Obsolete("Temporary exposed expert option, used to evaluate two different approaches to serialization")]
 	public bool UseReadOnlyMemory { get; set; }
 
+	private IJsonTypeInfoResolver? _serializerContext;
+
+	/// <summary>
+	/// The JsonSerializerContext to use for serialization.
+	/// </summary>
+	public JsonSerializerContext SerializerContext
+	{
+		set
+		{
+			_serializerContext = JsonTypeInfoResolver.Combine(IngestSerializationContext.Default, value);
+			_serializerOptions = new JsonSerializerOptions
+			{
+				TypeInfoResolver = _serializerContext,
+				DefaultIgnoreCondition = ElasticsearchChannelStatics.SerializerOptions.DefaultIgnoreCondition,
+				Encoder = ElasticsearchChannelStatics.SerializerOptions.Encoder
+			};
+		}
+	}
+
+	internal IJsonTypeInfoResolver TypeInfoResolver => _serializerContext ?? IngestSerializationContext.Default;
+
+	private JsonSerializerOptions _serializerOptions = new()
+	{
+		TypeInfoResolver = IngestSerializationContext.Default,
+		DefaultIgnoreCondition = ElasticsearchChannelStatics.SerializerOptions.DefaultIgnoreCondition,
+		Encoder = ElasticsearchChannelStatics.SerializerOptions.Encoder
+	};
+
+	internal JsonSerializerOptions SerializerOptions => _serializerOptions;
 }

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelOptionsBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelOptionsBase.cs
@@ -26,7 +26,7 @@ public abstract class ElasticsearchChannelOptionsBase<TEvent> : TransportChannel
 	/// </summary>
 	public IElasticsearchEventWriter<TEvent>? EventWriter { get; set; }
 
-	#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
 	/// <summary>
 	/// Expert option,
 	/// This will eagerly serialize to <see cref="ReadOnlyMemory{TEvent}"/> and use <see cref="PostData.ReadOnlyMemory"/>.

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelStatics.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelStatics.cs
@@ -14,10 +14,10 @@ internal static class ElasticsearchChannelStatics
 {
 	public static readonly byte[] LineFeed = { (byte)'\n' };
 
-	public static readonly byte[] DocUpdateHeaderStart = Encoding.UTF8.GetBytes("{\"doc_as_upsert\": true, \"doc\": ");
-	public static readonly byte[] DocUpdateHeaderEnd = Encoding.UTF8.GetBytes(" }");
+	public static readonly byte[] DocUpdateHeaderStart = "{\"doc_as_upsert\": true, \"doc\": "u8.ToArray();
+	public static readonly byte[] DocUpdateHeaderEnd = " }"u8.ToArray();
 
-	public static readonly HashSet<int> RetryStatusCodes = new(new[] { 502, 503, 504, 429 });
+	public static readonly HashSet<int> RetryStatusCodes = [502, 503, 504, 429];
 
 	public static readonly JsonSerializerOptions SerializerOptions = new ()
 	{

--- a/src/Elastic.Ingest.Elasticsearch/IElasticsearchEventWriter.cs
+++ b/src/Elastic.Ingest.Elasticsearch/IElasticsearchEventWriter.cs
@@ -16,7 +16,7 @@ namespace Elastic.Ingest.Elasticsearch;
 /// </summary>
 public interface IElasticsearchEventWriter<TEvent>
 {
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
 	/// <summary>
 	/// Provide a custom routine to write <typeparamref name="TEvent"/> to an ArrayBufferWriter{T}
 	/// <para>This implementation is only called if <see cref="ElasticsearchChannelOptionsBase{TEvent}.UseReadOnlyMemory"/> is true, defaults to false</para>

--- a/src/Elastic.Ingest.Elasticsearch/Indices/IndexChannel.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Indices/IndexChannel.cs
@@ -39,6 +39,9 @@ public class IndexChannel<TEvent> : ElasticsearchChannelBase<TEvent, IndexChanne
 		TemplateWildcard = string.Format(Options.IndexFormat, "*");
 	}
 
+	/// <inheritdoc cref="ElasticsearchChannelBase{TEvent,TChannelOptions}.RefreshTargets"/>
+	protected override string RefreshTargets => _skipIndexNameOnOperations ? Options.IndexFormat : string.Format(Options.IndexFormat, "*");
+
 	/// <inheritdoc cref="ElasticsearchChannelBase{TEvent, TChannelOptions}.BulkPathAndQuery"/>
 	protected override string BulkPathAndQuery => _url;
 
@@ -67,4 +70,5 @@ public class IndexChannel<TEvent> : ElasticsearchChannelBase<TEvent, IndexChanne
             }}";
 		return (name, indexTemplateBody);
 	}
+
 }

--- a/src/Elastic.Ingest.Elasticsearch/Serialization/BulkOperationHeader.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Serialization/BulkOperationHeader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Elastic.Transport.Products.Elasticsearch;
 
 namespace Elastic.Ingest.Elasticsearch.Serialization;
 
@@ -93,6 +94,6 @@ internal class BulkOperationHeaderConverter<THeader> : JsonConverter<THeader>
 		if (templates is not { Count: > 0 }) return;
 
 		writer.WritePropertyName("dynamic_templates");
-		JsonSerializer.Serialize(writer, templates, options);
+		JsonSerializer.Serialize(writer, templates, IngestSerializationContext.Default.DictionaryStringString);
 	}
 }

--- a/src/Elastic.Ingest.Elasticsearch/Serialization/BulkRequestDataFactory.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Serialization/BulkRequestDataFactory.cs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
 using System.Buffers;
 #else
 using System.Collections.Generic;
@@ -22,7 +22,7 @@ namespace Elastic.Ingest.Elasticsearch.Serialization;
 /// </summary>
 public static class BulkRequestDataFactory
 {
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
 	/// <summary>
 	/// Get the NDJSON request body bytes for a page of <typeparamref name="TEvent"/> events.
 	/// </summary>
@@ -42,7 +42,9 @@ public static class BulkRequestDataFactory
 		foreach (var @event in page.AsSpan())
 		{
 			var indexHeader = createHeaderFactory(@event);
+#pragma warning disable IL2026, IL3050 // SerializerContext is registered.
 			JsonSerializer.Serialize(writer, indexHeader, indexHeader.GetType(), options.SerializerOptions);
+#pragma warning restore IL2026, IL3050 // SerializerContext is registered.
 			bufferWriter.Write(LineFeed);
 			writer.Reset();
 
@@ -55,7 +57,9 @@ public static class BulkRequestDataFactory
 			if (options.EventWriter?.WriteToArrayBuffer != null)
 				options.EventWriter.WriteToArrayBuffer(bufferWriter, @event);
 			else
+#pragma warning disable IL2026, IL3050 // SerializerContext is registered.
 				JsonSerializer.Serialize(writer, @event, options.SerializerOptions);
+#pragma warning restore IL2026, IL3050 // SerializerContext is registered.
 			writer.Reset();
 
 			if (indexHeader is UpdateOperation)
@@ -85,7 +89,7 @@ public static class BulkRequestDataFactory
 		ElasticsearchChannelOptionsBase<TEvent> options, Func<TEvent, BulkOperationHeader> createHeaderFactory,
 		CancellationToken ctx = default)
 	{
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
 		var items = page;
 #else
 			// needs cast prior to netstandard2.0
@@ -100,9 +104,11 @@ public static class BulkRequestDataFactory
 			if (@event == null) continue;
 
 			var indexHeader = createHeaderFactory(@event);
+#pragma warning disable IL2026, IL3050 // SerializerContext is registered.
 			await JsonSerializer.SerializeAsync(stream, indexHeader, indexHeader.GetType(), options.SerializerOptions, ctx)
 				.ConfigureAwait(false);
 			await stream.WriteAsync(LineFeed, 0, 1, ctx).ConfigureAwait(false);
+#pragma warning restore IL2026, IL3050 // SerializerContext is registered.
 
 			if (indexHeader is UpdateOperation)
 				await stream.WriteAsync(DocUpdateHeaderStart, 0, DocUpdateHeaderStart.Length, ctx).ConfigureAwait(false);
@@ -110,8 +116,10 @@ public static class BulkRequestDataFactory
 			if (options.EventWriter?.WriteToStreamAsync != null)
 				await options.EventWriter.WriteToStreamAsync(stream, @event, ctx).ConfigureAwait(false);
 			else
+#pragma warning disable IL2026, IL3050 // SerializerContext is registered.
 				await JsonSerializer.SerializeAsync(stream, @event, options.SerializerOptions, ctx)
 					.ConfigureAwait(false);
+#pragma warning restore IL2026, IL3050 // SerializerContext is registered.
 
 			if (indexHeader is UpdateOperation)
 				await stream.WriteAsync(DocUpdateHeaderEnd, 0, DocUpdateHeaderEnd.Length, ctx).ConfigureAwait(false);

--- a/src/Elastic.Ingest.Elasticsearch/Serialization/BulkResponse.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Serialization/BulkResponse.cs
@@ -48,7 +48,7 @@ internal class ResponseItemsConverter : JsonConverter<IReadOnlyCollection<BulkRe
 		var depth = reader.CurrentDepth;
 		while (reader.Read() && reader.CurrentDepth > depth)
 		{
-			var item = JsonSerializer.Deserialize<BulkResponseItem>(ref reader, options);
+			var item = JsonSerializer.Deserialize<BulkResponseItem>(ref reader, IngestSerializationContext.Default.BulkResponseItem);
 			if (item != null)
 				list.Add(item);
 		}

--- a/src/Elastic.Ingest.Elasticsearch/Serialization/BulkResponseItem.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Serialization/BulkResponseItem.cs
@@ -47,7 +47,7 @@ internal class ItemConverter : JsonConverter<BulkResponseItem>
 					break;
 				case "error":
 					reader.Read();
-					error = JsonSerializer.Deserialize<ErrorCause>(ref reader, options);
+					error = JsonSerializer.Deserialize<ErrorCause>(ref reader, ErrorSerializerContext.Default.ErrorCause);
 					break;
 			}
 		}
@@ -74,7 +74,7 @@ internal class ItemConverter : JsonConverter<BulkResponseItem>
 		if (value.Error != null)
 		{
 			writer.WritePropertyName("error");
-			JsonSerializer.Serialize(writer, value.Error, options);
+			JsonSerializer.Serialize(writer, value.Error, ErrorSerializerContext.Default.ErrorCause);
 		}
 
 		writer.WriteNumber("status", value.Status);

--- a/src/Elastic.Ingest.Elasticsearch/Serialization/IngestSerializationContext.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Serialization/IngestSerializationContext.cs
@@ -2,8 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Elastic.Transport.Products.Elasticsearch;
 
 namespace Elastic.Ingest.Elasticsearch.Serialization;
 
@@ -15,6 +15,7 @@ namespace Elastic.Ingest.Elasticsearch.Serialization;
 [JsonSerializable(typeof(BulkResponseItem))]
 [JsonSerializable(typeof(BulkResponse))]
 [JsonSerializable(typeof(BulkResponseItem))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
 internal partial class IngestSerializationContext : JsonSerializerContext
 {
 	static IngestSerializationContext() =>

--- a/src/Elastic.Ingest.Elasticsearch/Serialization/IngestSerializationContext.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Serialization/IngestSerializationContext.cs
@@ -1,0 +1,22 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Serialization;
+using Elastic.Transport.Products.Elasticsearch;
+
+namespace Elastic.Ingest.Elasticsearch.Serialization;
+
+[JsonSerializable(typeof(BulkOperationHeader))]
+[JsonSerializable(typeof(CreateOperation))]
+[JsonSerializable(typeof(IndexOperation))]
+[JsonSerializable(typeof(DeleteOperation))]
+[JsonSerializable(typeof(UpdateOperation))]
+[JsonSerializable(typeof(BulkResponseItem))]
+[JsonSerializable(typeof(BulkResponse))]
+[JsonSerializable(typeof(BulkResponseItem))]
+internal partial class IngestSerializationContext : JsonSerializerContext
+{
+	static IngestSerializationContext() =>
+		Default = new IngestSerializationContext(ElasticsearchChannelStatics.SerializerOptions);
+}

--- a/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
+++ b/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
@@ -1,12 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Description>Provides components to build a buffer-backed channel for publishing events to distributed systems over HTTP through Elastic.Transport</Description>
     <PackageTags>elastic, transport, ingest, search</PackageTags>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>True</IsPackable>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
+++ b/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Channels\Elastic.Channels.csproj" />
-    <PackageReference Include="Elastic.Transport" Version="0.5.6" />
+    <PackageReference Include="Elastic.Transport" Version="0.7.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
 

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/Elastic.Ingest.Elasticsearch.Tests.csproj
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/Elastic.Ingest.Elasticsearch.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Transport.VirtualizedCluster" Version="0.5.5" />
+    <PackageReference Include="Elastic.Transport.VirtualizedCluster" Version="0.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Introduced `IngestSerializationContext` for improved JSON serialization configuration. Enhanced channel operations with serverless detection, refresh functionality, and inflight buffer management. Updated dependency versions and refined code structure to improve clarity and maintainability.

This also adds a handy `await c.WaitForDrainAsync();` to wait for all operations to be read. Particularly useful if you can't track how many items you write or expect to write.


This now also ensures we do not register ILM templates if we are running against a serverless instance.
