### PR TITLE
simplify our WaitToReadAsync implementation and reuse waitToReadTasks in case of timeouts

### DIFF
--- a/examples/playground/Program.cs
+++ b/examples/playground/Program.cs
@@ -22,7 +22,6 @@ var bufferOptions = new BufferOptions
 {
 	InboundBufferMaxSize = 1_000_000,
 	OutboundBufferMaxSize = 5_000,
-	ExportMaxConcurrency = Environment.ProcessorCount,
 	BoundedChannelFullMode = BoundedChannelFullMode.Wait
 };
 

--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -419,7 +419,7 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 		_callbacks.InboundChannelStartedCallback?.Invoke();
 
 		WaitToReadResult result;
-		while ((result = await InboundBuffer.WaitToReadAsync(InChannel.Reader).ConfigureAwait(false)) != WaitToReadResult.Completed)
+		while ((result = await InboundBuffer.WaitToReadAsync(InChannel.Reader, TokenSource.Token).ConfigureAwait(false)) != WaitToReadResult.Completed)
 		{
 			if (TokenSource.Token.IsCancellationRequested) break;
 			if (_signal is { IsSet: true }) break;

--- a/src/Elastic.Channels/Buffers/InboundBuffer.cs
+++ b/src/Elastic.Channels/Buffers/InboundBuffer.cs
@@ -14,36 +14,25 @@ namespace Elastic.Channels.Buffers;
 /// <see cref="InboundBuffer{TEvent}"/> is a buffer that will block <see cref="WaitToReadAsync"/> until
 /// sufficient items have been added to it or <see cref="DurationSinceFirstWrite"/> exceeds the buffer's maximum lifespan.
 /// </summary>
-internal class InboundBuffer<TEvent> : IWriteTrackingBuffer, IDisposable
+internal class InboundBuffer<TEvent>(int maxBufferSize, TimeSpan forceFlushAfter) : IWriteTrackingBuffer, IDisposable
 {
-	private readonly int _maxBufferSize;
-	private readonly TimeSpan _forceFlushAfter;
+	private TEvent[] Buffer { get; set; } = ArrayPool<TEvent>.Shared.Rent(maxBufferSize);
 
-	private CancellationTokenSource _breaker = new();
-
-	private TEvent[] Buffer { get; set; }
-
-	/// <summary>The time that the first event is read from the channel and added to the buffer, from first read or after the buffer is reset.</summary>
+	/// <summary>The point in time that the first event is read from the channel and added to the buffer,
+	/// from the first read or after the buffer is reset.</summary>
 	private DateTimeOffset? TimeOfFirstWrite { get; set; }
+
 	private DateTimeOffset? TimeOfFirstWaitToRead { get; set; }
 
-	private int _count = 0;
+	private int _count;
 	public int Count => _count;
 	public TimeSpan? DurationSinceFirstWrite => DateTimeOffset.UtcNow - TimeOfFirstWrite;
 	public TimeSpan? DurationSinceFirstWaitToRead => DateTimeOffset.UtcNow - TimeOfFirstWaitToRead;
 
 	public bool NoThresholdsHit => Count == 0
-		|| (Count < _maxBufferSize && DurationSinceFirstWaitToRead <= _forceFlushAfter);
+		|| (Count < maxBufferSize && DurationSinceFirstWaitToRead <= forceFlushAfter);
 
 	public bool ThresholdsHit => !NoThresholdsHit;
-
-	public InboundBuffer(int maxBufferSize, TimeSpan forceFlushAfter)
-	{
-		_maxBufferSize = maxBufferSize;
-		_forceFlushAfter = forceFlushAfter;
-		Buffer = ArrayPool<TEvent>.Shared.Rent(maxBufferSize);
-		TimeOfFirstWrite = null;
-	}
 
 	// not thread safe, buffer is guarded by a single consumer on the inbound channel
 	public void Add(TEvent item)
@@ -55,11 +44,11 @@ internal class InboundBuffer<TEvent> : IWriteTrackingBuffer, IDisposable
 
 	public TEvent[] Reset()
 	{
+		var bufferRef = Buffer;
 		_count = 0;
 		TimeOfFirstWrite = null;
 		TimeOfFirstWaitToRead = null;
-		var bufferRef = Buffer;
-		Buffer = ArrayPool<TEvent>.Shared.Rent(_maxBufferSize);
+		Buffer = ArrayPool<TEvent>.Shared.Rent(maxBufferSize);
 		return bufferRef;
 	}
 
@@ -67,68 +56,57 @@ internal class InboundBuffer<TEvent> : IWriteTrackingBuffer, IDisposable
 	{
 		get
 		{
-			if (!DurationSinceFirstWaitToRead.HasValue) return _forceFlushAfter;
+			if (!DurationSinceFirstWaitToRead.HasValue) return forceFlushAfter;
 
 			var d = DurationSinceFirstWaitToRead.Value;
-			return d < _forceFlushAfter ? _forceFlushAfter - d : _forceFlushAfter;
+			return d < forceFlushAfter ? forceFlushAfter - d : forceFlushAfter;
 		}
 	}
 
-	/// <summary>
-	/// Call <see cref="ChannelReader{T}.WaitToReadAsync"/> with a timeout to force a flush to happen every
-	/// <see cref="_forceFlushAfter"/>. This tries to avoid allocation too many <see cref="CancellationTokenSource"/>'s
-	/// needlessly and reuses them if possible.
-	/// </summary>
-	public async Task<WaitToReadResult> WaitToReadAsync(ChannelReader<TEvent?> reader)
+	private Task<bool>? _cachedWaitToRead;
+	/// Call <see cref="ChannelReader{T}.WaitToReadAsync"/> with a timeout to force a flush to happen every <see cref="Wait"/>.
+	public async Task<WaitToReadResult> WaitToReadAsync(ChannelReader<TEvent?> reader, CancellationToken ctx)
 	{
 		TimeOfFirstWaitToRead ??= DateTimeOffset.UtcNow;
-		if (_breaker.IsCancellationRequested)
-		{
-			_breaker.Dispose();
-			_breaker = new CancellationTokenSource();
-		}
 
 		try
 		{
 			// https://github.com/dotnet/runtime/issues/761
 			// cancellation tokens may not be unrooted properly by design if cancellation occurs.
-			// by checking explicitly which task ends up being completed we can uncover when
+			// by checking explicitly which task ends up being completed, we can uncover when
 
 			// We accept the possibility of several pending tasks blocking on WaitToReadAsync()
 			// These will all unblock and free up when a new message gets pushed.
-			// To aid with cleaning these tasks up we write `default` to the channel when this task returns TimeOut
+			// To aid with cleaning these tasks up, we write `default` to the channel when this task returns TimeOut
 
-			_breaker.CancelAfter(Wait);
-			var readTask = reader.WaitToReadAsync().AsTask();
-			var delayTask = Task.Delay(Timeout.Infinite, _breaker.Token);
+			var readTask = _cachedWaitToRead ?? reader.WaitToReadAsync(ctx).AsTask();
+			_cachedWaitToRead = null;
+			var delayTask = Task.Delay(Wait, ctx);
 			var completedTask = await Task.WhenAny(readTask, delayTask).ConfigureAwait(false);
 
 			if (completedTask == delayTask)
-				throw new OperationCanceledException(_breaker.Token);
+			{
+				_cachedWaitToRead = readTask;
+				return WaitToReadResult.Timeout;
+			}
 
-			_breaker.CancelAfter(-1);
 			return await readTask.ConfigureAwait(false) ? WaitToReadResult.Read : WaitToReadResult.Completed;
 		}
 		catch (OperationCanceledException)
 		{
-			_breaker.Dispose();
-			_breaker = new CancellationTokenSource();
 			return WaitToReadResult.Timeout;
 		}
-		catch (Exception) when (_breaker.IsCancellationRequested)
+		catch (Exception) when (ctx.IsCancellationRequested)
 		{
-			_breaker.Dispose();
-			_breaker = new CancellationTokenSource();
 			return WaitToReadResult.Timeout;
 		}
 		catch (Exception)
 		{
-			_breaker.CancelAfter(Wait);
 			return WaitToReadResult.Read;
 		}
 	}
 
-	public void Dispose() => _breaker.Dispose();
+	public void Dispose() {}
 }
 
 /// <summary>

--- a/src/Elastic.Channels/Buffers/OutboundBuffer.cs
+++ b/src/Elastic.Channels/Buffers/OutboundBuffer.cs
@@ -20,21 +20,13 @@ public interface IOutboundBuffer<TEvent> : IWriteTrackingBuffer, IDisposable
 	ArraySegment<TEvent> GetArraySegment();
 }
 
-internal class OutboundBuffer<TEvent> : IOutboundBuffer<TEvent>
+internal class OutboundBuffer<TEvent>(InboundBuffer<TEvent> buffer) : IOutboundBuffer<TEvent>
 {
-	//public IReadOnlyCollection<TEvent> Items { get; }
-	private TEvent[] ArrayItems { get; }
+	public int Count { get; } = buffer.Count;
 
-	public int Count { get; }
-	public TimeSpan? DurationSinceFirstWrite { get; }
+	public TimeSpan? DurationSinceFirstWrite { get; } = buffer.DurationSinceFirstWrite;
 
-	public OutboundBuffer(InboundBuffer<TEvent> buffer)
-	{
-		Count = buffer.Count;
-		DurationSinceFirstWrite = buffer.DurationSinceFirstWrite;
-		// create a shallow copied collection to hand to consumers.
-		ArrayItems = buffer.Reset();
-	}
+	private TEvent[] ArrayItems { get; } = buffer.Reset();
 
 	public ArraySegment<TEvent> GetArraySegment() => new(ArrayItems, 0, Count);
 

--- a/tests/Elastic.Channels.Tests/BehaviorTests.cs
+++ b/tests/Elastic.Channels.Tests/BehaviorTests.cs
@@ -72,10 +72,10 @@ public class BehaviorTests : IDisposable
 			if (await channel.WaitToWriteAsync(e))
 				written++;
 		}
-		var signalled = bufferOptions.WaitHandle.Wait(TimeSpan.FromSeconds(2));
-		signalled.Should().BeTrue("The channel was not drained in the expected time");
 		written.Should().Be(100);
+		var signalled = bufferOptions.WaitHandle.Wait(TimeSpan.FromSeconds(2));
 		channel.ExportedBuffers.Should().Be(1);
+		signalled.Should().BeTrue("The channel was not drained in the expected time");
 	}
 
 	[Fact] public async Task ConcurrencyIsApplied()


### PR DESCRIPTION
This PR improves our `WaitToReadAsync()` implementation to reuse existing waitToReadTasks to ensure we do not leak `CancellationTokenSource+CallbackNode` in those cases.

Similar fix as https://github.com/serilog/serilog-sinks-periodicbatching/issues/76

This adds to our fix for leaking if data was trickling in very slowly #85

These all relate to https://github.com/dotnet/runtime/issues/761#issuecomment-564566525 and it intentially keeping a linked lists of cancellation tokens which could be considered a bit of a trappy / dangerous API.

<img width="988" alt="image" src="https://github.com/user-attachments/assets/6a30d8b0-713e-4b69-9450-77bd8dcb997d" />

Here we can see it keeping up with the unbounded queue and finally draining it completely. 
