### PR TITLE
Wire up true SSE streaming for ElasticAgentChatClient

### DIFF
--- a/src/Elastic.AgentBuilder/AgentBuilderClient.Conversations.cs
+++ b/src/Elastic.AgentBuilder/AgentBuilderClient.Conversations.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Collections.Generic;
 using System.Net.ServerSentEvents;
 using System.Runtime.CompilerServices;
@@ -26,10 +27,10 @@ public partial class AgentBuilderClient
 		using var response = await PostStreamAsync("/converse/async", request, Ctx.ConverseRequest, ct)
 			.ConfigureAwait(false);
 
-		await foreach (var item in SseParser.Create(response.Body).EnumerateAsync(ct).ConfigureAwait(false))
+		var parser = SseParser.Create(response.Body, ParseSseEvent);
+		await foreach (var item in parser.EnumerateAsync(ct).ConfigureAwait(false))
 		{
-			var evt = ParseStreamEvent(item.EventType, item.Data);
-			if (evt != null)
+			if (item.Data is { } evt)
 				yield return evt;
 		}
 	}
@@ -46,27 +47,40 @@ public partial class AgentBuilderClient
 	public Task DeleteConversationAsync(string conversationId, CancellationToken ct = default) =>
 		DeleteAsync($"/conversations/{conversationId}", ct);
 
-	private static ConverseStreamEvent? ParseStreamEvent(string eventType, string rawData)
+	/// <summary>
+	/// Parses the raw UTF-8 bytes of an SSE <c>data:</c> line directly into a typed
+	/// <see cref="ConverseStreamEvent"/>. Kibana wraps every event payload in a
+	/// <c>{"data": {…}}</c> envelope, so we use a <see cref="Utf8JsonReader"/> to
+	/// navigate to the inner value and deserialize from there — single pass, zero
+	/// intermediate string allocations, fully AOT-safe.
+	/// </summary>
+	private static ConverseStreamEvent? ParseSseEvent(string eventType, ReadOnlySpan<byte> data)
 	{
-		using var doc = JsonDocument.Parse(rawData);
-		if (!doc.RootElement.TryGetProperty("data", out var dataElement))
+		var reader = new Utf8JsonReader(data);
+
+		if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+			return null;
+		if (!reader.Read() || reader.TokenType != JsonTokenType.PropertyName)
+			return null;
+		if (!reader.ValueTextEquals("data"u8))
 			return null;
 
-		var json = dataElement.GetRawText();
+		reader.Read();
+
 		var ctx = AgentBuilderSerializationContext.Default;
 		return eventType switch
 		{
-			"conversation_id_set" => JsonSerializer.Deserialize(json, ctx.ConversationIdSetEvent),
-			"conversation_created" => JsonSerializer.Deserialize(json, ctx.ConversationCreatedEvent),
-			"conversation_updated" => JsonSerializer.Deserialize(json, ctx.ConversationUpdatedEvent),
-			"reasoning" => JsonSerializer.Deserialize(json, ctx.ReasoningEvent),
-			"tool_call" => JsonSerializer.Deserialize(json, ctx.ToolCallEvent),
-			"tool_progress" => JsonSerializer.Deserialize(json, ctx.ToolProgressEvent),
-			"tool_result" => JsonSerializer.Deserialize(json, ctx.ToolResultEvent),
-			"message_chunk" => JsonSerializer.Deserialize(json, ctx.MessageChunkEvent),
-			"message_complete" => JsonSerializer.Deserialize(json, ctx.MessageCompleteEvent),
-			"thinking_complete" => JsonSerializer.Deserialize(json, ctx.ThinkingCompleteEvent),
-			"round_complete" => JsonSerializer.Deserialize(json, ctx.RoundCompleteEvent),
+			"conversation_id_set" => JsonSerializer.Deserialize(ref reader, ctx.ConversationIdSetEvent),
+			"conversation_created" => JsonSerializer.Deserialize(ref reader, ctx.ConversationCreatedEvent),
+			"conversation_updated" => JsonSerializer.Deserialize(ref reader, ctx.ConversationUpdatedEvent),
+			"reasoning" => JsonSerializer.Deserialize(ref reader, ctx.ReasoningEvent),
+			"tool_call" => JsonSerializer.Deserialize(ref reader, ctx.ToolCallEvent),
+			"tool_progress" => JsonSerializer.Deserialize(ref reader, ctx.ToolProgressEvent),
+			"tool_result" => JsonSerializer.Deserialize(ref reader, ctx.ToolResultEvent),
+			"message_chunk" => JsonSerializer.Deserialize(ref reader, ctx.MessageChunkEvent),
+			"message_complete" => JsonSerializer.Deserialize(ref reader, ctx.MessageCompleteEvent),
+			"thinking_complete" => JsonSerializer.Deserialize(ref reader, ctx.ThinkingCompleteEvent),
+			"round_complete" => JsonSerializer.Deserialize(ref reader, ctx.RoundCompleteEvent),
 			_ => null
 		};
 	}

--- a/src/Elastic.AgentBuilder/AgentBuilderClient.Conversations.cs
+++ b/src/Elastic.AgentBuilder/AgentBuilderClient.Conversations.cs
@@ -2,6 +2,10 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Generic;
+using System.Net.ServerSentEvents;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.AgentBuilder.Conversations;
@@ -14,6 +18,22 @@ public partial class AgentBuilderClient
 	public Task<ConverseResponse> ConverseAsync(ConverseRequest request, CancellationToken ct = default) =>
 		PostAsync("/converse", request, Ctx.ConverseRequest, Ctx.ConverseResponse, ct);
 
+	/// <summary> Send a chat message and receive a stream of typed SSE events. </summary>
+	public async IAsyncEnumerable<ConverseStreamEvent> ConverseStreamAsync(
+		ConverseRequest request,
+		[EnumeratorCancellation] CancellationToken ct = default)
+	{
+		using var response = await PostStreamAsync("/converse/async", request, Ctx.ConverseRequest, ct)
+			.ConfigureAwait(false);
+
+		await foreach (var item in SseParser.Create(response.Body).EnumerateAsync(ct).ConfigureAwait(false))
+		{
+			var evt = ParseStreamEvent(item.EventType, item.Data);
+			if (evt != null)
+				yield return evt;
+		}
+	}
+
 	/// <summary> List all conversations. </summary>
 	public Task<ListConversationsResponse> ListConversationsAsync(CancellationToken ct = default) =>
 		GetAsync("/conversations", Ctx.ListConversationsResponse, ct);
@@ -25,4 +45,29 @@ public partial class AgentBuilderClient
 	/// <summary> Delete a conversation by its ID. </summary>
 	public Task DeleteConversationAsync(string conversationId, CancellationToken ct = default) =>
 		DeleteAsync($"/conversations/{conversationId}", ct);
+
+	private static ConverseStreamEvent? ParseStreamEvent(string eventType, string rawData)
+	{
+		using var doc = JsonDocument.Parse(rawData);
+		if (!doc.RootElement.TryGetProperty("data", out var dataElement))
+			return null;
+
+		var json = dataElement.GetRawText();
+		var ctx = AgentBuilderSerializationContext.Default;
+		return eventType switch
+		{
+			"conversation_id_set" => JsonSerializer.Deserialize(json, ctx.ConversationIdSetEvent),
+			"conversation_created" => JsonSerializer.Deserialize(json, ctx.ConversationCreatedEvent),
+			"conversation_updated" => JsonSerializer.Deserialize(json, ctx.ConversationUpdatedEvent),
+			"reasoning" => JsonSerializer.Deserialize(json, ctx.ReasoningEvent),
+			"tool_call" => JsonSerializer.Deserialize(json, ctx.ToolCallEvent),
+			"tool_progress" => JsonSerializer.Deserialize(json, ctx.ToolProgressEvent),
+			"tool_result" => JsonSerializer.Deserialize(json, ctx.ToolResultEvent),
+			"message_chunk" => JsonSerializer.Deserialize(json, ctx.MessageChunkEvent),
+			"message_complete" => JsonSerializer.Deserialize(json, ctx.MessageCompleteEvent),
+			"thinking_complete" => JsonSerializer.Deserialize(json, ctx.ThinkingCompleteEvent),
+			"round_complete" => JsonSerializer.Deserialize(json, ctx.RoundCompleteEvent),
+			_ => null
+		};
+	}
 }

--- a/src/Elastic.AgentBuilder/AgentBuilderClient.cs
+++ b/src/Elastic.AgentBuilder/AgentBuilderClient.cs
@@ -85,6 +85,20 @@ public partial class AgentBuilderClient
 		return Deserialize(response.Body, responseTypeInfo);
 	}
 
+	private static readonly RequestConfiguration SseRequestConfig = new() { Accept = "application/octet-stream" };
+
+	internal async Task<StreamResponse> PostStreamAsync<TRequest>(
+		string path, TRequest body, JsonTypeInfo<TRequest> requestTypeInfo, CancellationToken ct)
+	{
+		var json = JsonSerializer.Serialize(body, requestTypeInfo);
+		var response = await _transport
+			.RequestAsync<StreamResponse>(HttpMethod.POST, Path(path), PostData.String(json),
+				localConfiguration: SseRequestConfig, cancellationToken: ct)
+			.ConfigureAwait(false);
+		EnsureSuccess(response);
+		return response;
+	}
+
 	private async Task DeleteAsync(string path, CancellationToken ct)
 	{
 		var response = await _transport
@@ -97,12 +111,13 @@ public partial class AgentBuilderClient
 		JsonSerializer.Deserialize(body, typeInfo)
 		?? throw new InvalidOperationException($"Failed to deserialize response as {typeof(TResponse).Name}");
 
-	private static void EnsureSuccess(StringResponse response)
+	private static void EnsureSuccess(TransportResponse response)
 	{
 		if (!response.ApiCallDetails.HasSuccessfulStatusCode)
 		{
+			var body = response is StringResponse sr ? $": {sr.Body}" : string.Empty;
 			throw new AgentBuilderException(
-				$"Agent Builder API returned {response.ApiCallDetails.HttpStatusCode}: {response.Body}",
+				$"Agent Builder API returned {response.ApiCallDetails.HttpStatusCode}{body}",
 				response.ApiCallDetails);
 		}
 	}

--- a/src/Elastic.AgentBuilder/Conversations/ConverseStreamEvents.cs
+++ b/src/Elastic.AgentBuilder/Conversations/ConverseStreamEvents.cs
@@ -1,0 +1,119 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Elastic.AgentBuilder.Conversations;
+
+/// <summary> Base type for all SSE events emitted by the <c>/converse/async</c> endpoint. </summary>
+public abstract record ConverseStreamEvent;
+
+/// <summary> Fired when the conversation ID is assigned. </summary>
+public record ConversationIdSetEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("conversation_id")]
+	public required string ConversationId { get; init; }
+}
+
+/// <summary> Fired when a new conversation is persisted. </summary>
+public record ConversationCreatedEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("conversation_id")]
+	public required string ConversationId { get; init; }
+
+	[JsonPropertyName("title")]
+	public string? Title { get; init; }
+}
+
+/// <summary> Fired when a conversation is updated. </summary>
+public record ConversationUpdatedEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("conversation_id")]
+	public required string ConversationId { get; init; }
+
+	[JsonPropertyName("title")]
+	public string? Title { get; init; }
+}
+
+/// <summary> Agent reasoning content. </summary>
+public record ReasoningEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("reasoning")]
+	public required string Reasoning { get; init; }
+
+	[JsonPropertyName("transient")]
+	public bool Transient { get; init; }
+}
+
+/// <summary> Fired when a tool is invoked. </summary>
+public record ToolCallEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("tool_call_id")]
+	public required string ToolCallId { get; init; }
+
+	[JsonPropertyName("tool_id")]
+	public required string ToolId { get; init; }
+
+	[JsonPropertyName("params")]
+	public JsonElement? Params { get; init; }
+}
+
+/// <summary> Reports progress of a running tool. </summary>
+public record ToolProgressEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("tool_call_id")]
+	public required string ToolCallId { get; init; }
+
+	[JsonPropertyName("message")]
+	public string? Message { get; init; }
+}
+
+/// <summary> Results from a completed tool call. </summary>
+public record ToolResultEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("tool_call_id")]
+	public required string ToolCallId { get; init; }
+
+	[JsonPropertyName("tool_id")]
+	public required string ToolId { get; init; }
+
+	[JsonPropertyName("results")]
+	public IReadOnlyList<JsonElement>? Results { get; init; }
+}
+
+/// <summary> A partial text chunk streamed from the agent. </summary>
+public record MessageChunkEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("message_id")]
+	public string? MessageId { get; init; }
+
+	[JsonPropertyName("text_chunk")]
+	public required string TextChunk { get; init; }
+}
+
+/// <summary> Signals that the full message has been delivered. </summary>
+public record MessageCompleteEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("message_id")]
+	public string? MessageId { get; init; }
+
+	[JsonPropertyName("message_content")]
+	public string? MessageContent { get; init; }
+}
+
+/// <summary> Marks the end of the thinking/reasoning phase. </summary>
+public record ThinkingCompleteEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("time_to_first_token")]
+	public int TimeToFirstToken { get; init; }
+}
+
+/// <summary> Marks the end of one conversation round. </summary>
+public record RoundCompleteEvent : ConverseStreamEvent
+{
+	[JsonPropertyName("round")]
+	public JsonElement? Round { get; init; }
+}

--- a/src/Elastic.AgentBuilder/Elastic.AgentBuilder.csproj
+++ b/src/Elastic.AgentBuilder/Elastic.AgentBuilder.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Elastic.Transport" Version="0.15.1" />
+    <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">

--- a/src/Elastic.AgentBuilder/Serialization/AgentBuilderSerializationContext.cs
+++ b/src/Elastic.AgentBuilder/Serialization/AgentBuilderSerializationContext.cs
@@ -44,6 +44,17 @@ namespace Elastic.AgentBuilder;
 [JsonSerializable(typeof(ConverseStep))]
 [JsonSerializable(typeof(ConverseMessage))]
 [JsonSerializable(typeof(ModelUsage))]
+[JsonSerializable(typeof(ConversationIdSetEvent))]
+[JsonSerializable(typeof(ConversationCreatedEvent))]
+[JsonSerializable(typeof(ConversationUpdatedEvent))]
+[JsonSerializable(typeof(ReasoningEvent))]
+[JsonSerializable(typeof(ToolCallEvent))]
+[JsonSerializable(typeof(ToolProgressEvent))]
+[JsonSerializable(typeof(ToolResultEvent))]
+[JsonSerializable(typeof(MessageChunkEvent))]
+[JsonSerializable(typeof(MessageCompleteEvent))]
+[JsonSerializable(typeof(ThinkingCompleteEvent))]
+[JsonSerializable(typeof(RoundCompleteEvent))]
 [JsonSourceGenerationOptions(
 	PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
 	DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Elastic.Extensions.AI/ElasticAgentChatClient.cs
+++ b/src/Elastic.Extensions.AI/ElasticAgentChatClient.cs
@@ -97,18 +97,46 @@ public class ElasticAgentChatClient : IChatClient
 		ChatOptions? options = null,
 		[EnumeratorCancellation] CancellationToken cancellationToken = default)
 	{
-		var response = await GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false);
+		var messageList = messages?.ToList() ?? throw new ArgumentNullException(nameof(messages));
+		var lastUserMessage = messageList.LastOrDefault(m => m.Role == ChatRole.User);
+		var input = lastUserMessage?.Text ?? string.Empty;
 
-		foreach (var message in response.Messages)
+		var conversationId = options?.ConversationId;
+
+		await foreach (var evt in _client.ConverseStreamAsync(new ConverseRequest
 		{
-			yield return new ChatResponseUpdate
+			Input = input,
+			AgentId = _agentId,
+			ConversationId = conversationId,
+			ConnectorId = _connectorId
+		}, cancellationToken).ConfigureAwait(false))
+		{
+			switch (evt)
 			{
-				Role = message.Role,
-				Contents = message.Contents,
-				FinishReason = response.FinishReason,
-				ConversationId = response.ConversationId,
-				ModelId = response.ModelId,
-			};
+				case ConversationIdSetEvent idSet:
+					conversationId = idSet.ConversationId;
+					break;
+
+				case MessageChunkEvent chunk:
+					yield return new ChatResponseUpdate
+					{
+						Role = ChatRole.Assistant,
+						Contents = [new TextContent(chunk.TextChunk)],
+						ConversationId = conversationId,
+						ModelId = _agentId,
+					};
+					break;
+
+				case MessageCompleteEvent:
+					yield return new ChatResponseUpdate
+					{
+						Role = ChatRole.Assistant,
+						FinishReason = ChatFinishReason.Stop,
+						ConversationId = conversationId,
+						ModelId = _agentId,
+					};
+					break;
+			}
 		}
 	}
 

--- a/src/Elastic.Extensions.AI/ElasticAgentChatClient.cs
+++ b/src/Elastic.Extensions.AI/ElasticAgentChatClient.cs
@@ -99,15 +99,17 @@ public class ElasticAgentChatClient : IChatClient
 	{
 		var response = await GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false);
 
-		var text = response.Messages.FirstOrDefault()?.Text ?? string.Empty;
-		yield return new ChatResponseUpdate
+		foreach (var message in response.Messages)
 		{
-			Role = ChatRole.Assistant,
-			Contents = [new TextContent(text)],
-			FinishReason = response.FinishReason,
-			ConversationId = response.ConversationId,
-			ModelId = response.ModelId,
-		};
+			yield return new ChatResponseUpdate
+			{
+				Role = message.Role,
+				Contents = message.Contents,
+				FinishReason = response.FinishReason,
+				ConversationId = response.ConversationId,
+				ModelId = response.ModelId,
+			};
+		}
 	}
 
 	/// <inheritdoc />

--- a/tests/Elastic.Extensions.AI.IntegrationTests/ChatClientTests.cs
+++ b/tests/Elastic.Extensions.AI.IntegrationTests/ChatClientTests.cs
@@ -60,16 +60,22 @@ public class ChatClientTests(KibanaFixture fixture)
 	{
 		var updates = fixture.ChatClient.GetStreamingResponseAsync("Say hi briefly.");
 
-		var count = 0;
+		var textChunks = 0;
+		ChatFinishReason? finishReason = null;
 		await foreach (var update in updates)
 		{
 			update.Role.Should().Be(ChatRole.Assistant);
-			update.Text.Should().NotBeNullOrWhiteSpace();
 			update.ConversationId.Should().NotBeNullOrWhiteSpace();
-			count++;
+
+			if (!string.IsNullOrWhiteSpace(update.Text))
+				textChunks++;
+
+			if (update.FinishReason is not null)
+				finishReason = update.FinishReason;
 		}
 
-		count.Should().BeGreaterThan(0);
+		textChunks.Should().BeGreaterThan(0, "expected at least one text chunk from the stream");
+		finishReason.Should().Be(ChatFinishReason.Stop);
 	}
 
 	[Test]


### PR DESCRIPTION
## Summary

- **Add `ConverseStreamAsync`** returning `IAsyncEnumerable<ConverseStreamEvent>` backed by `SseParser.Create<T>` with a `Utf8JsonReader`-based parser that deserializes Kibana's `{"data": …}` envelope in a single pass — zero intermediate string allocations, fully AOT-safe via source-generated `JsonTypeInfo<T>`
- **Define typed SSE event hierarchy** (`ConverseStreamEvents.cs`) covering all 11 event types from the `/converse/async` endpoint (`conversation_id_set`, `message_chunk`, `tool_call`, `reasoning`, etc.)
- **Add `PostStreamAsync` transport helper** using `StreamResponse` with `Accept: application/octet-stream` to work around Kibana returning `application/octet-stream` instead of `text/event-stream` (see https://github.com/elastic/kibana/issues/258911)
- **Generalize `EnsureSuccess`** to accept any `TransportResponse`, not just `StringResponse`
- **Rewrite `ElasticAgentChatClient.GetStreamingResponseAsync`** to consume the typed `IAsyncEnumerable` and pattern-match on `MessageChunkEvent` / `MessageCompleteEvent` instead of buffering the full `/converse` response
- **Update integration test** to separately assert text chunks and finish reason

## Related issues

- https://github.com/elastic/elastic-transport-net/issues/202 — `StreamResponse` silently returns `Stream.Null` on content-type mismatch
- https://github.com/elastic/kibana/issues/258911 — `/converse/async` returns wrong `Content-Type`

## Test plan

- [ ] `GetStreamingResponseAsync_YieldsUpdate` integration test passes with a live Kibana agent
- [ ] Verify multiple `message_chunk` updates are yielded (not just one)
- [ ] Verify `FinishReason.Stop` is set on the final update
- [ ] Build succeeds on all four targets (`netstandard2.0`, `netstandard2.1`, `net8.0`, `net10.0`)

Made with [Cursor](https://cursor.com)