### PR TITLE
Replace PostData.String/StringResponse with transport-native serialization in AgentBuilderClient

### DIFF
--- a/src/Elastic.AgentBuilder/AgentBuilderClient.Agents.cs
+++ b/src/Elastic.AgentBuilder/AgentBuilderClient.Agents.cs
@@ -12,19 +12,19 @@ public partial class AgentBuilderClient
 {
 	/// <summary> List all agents. </summary>
 	public Task<ListAgentsResponse> ListAgentsAsync(CancellationToken ct = default) =>
-		GetAsync("/agents", Ctx.ListAgentsResponse, ct);
+		GetAsync<ListAgentsResponse>("/agents", ct);
 
 	/// <summary> Get an agent by its ID. </summary>
 	public Task<AgentBuilderAgent> GetAgentAsync(string agentId, CancellationToken ct = default) =>
-		GetAsync($"/agents/{agentId}", Ctx.AgentBuilderAgent, ct);
+		GetAsync<AgentBuilderAgent>($"/agents/{agentId}", ct);
 
 	/// <summary> Create a new agent. </summary>
 	public Task<AgentBuilderAgent> CreateAgentAsync(CreateAgentRequest request, CancellationToken ct = default) =>
-		PostAsync("/agents", request, Ctx.CreateAgentRequest, Ctx.AgentBuilderAgent, ct);
+		PostAsync<CreateAgentRequest, AgentBuilderAgent>("/agents", request, ct);
 
 	/// <summary> Update an existing agent. </summary>
 	public Task<AgentBuilderAgent> UpdateAgentAsync(string agentId, UpdateAgentRequest request, CancellationToken ct = default) =>
-		PutAsync($"/agents/{agentId}", request, Ctx.UpdateAgentRequest, Ctx.AgentBuilderAgent, ct);
+		PutAsync<UpdateAgentRequest, AgentBuilderAgent>($"/agents/{agentId}", request, ct);
 
 	/// <summary> Delete an agent by its ID. </summary>
 	public Task DeleteAgentAsync(string agentId, CancellationToken ct = default) =>

--- a/src/Elastic.AgentBuilder/AgentBuilderClient.Conversations.cs
+++ b/src/Elastic.AgentBuilder/AgentBuilderClient.Conversations.cs
@@ -17,14 +17,14 @@ public partial class AgentBuilderClient
 {
 	/// <summary> Send a synchronous chat message to an agent. </summary>
 	public Task<ConverseResponse> ConverseAsync(ConverseRequest request, CancellationToken ct = default) =>
-		PostAsync("/converse", request, Ctx.ConverseRequest, Ctx.ConverseResponse, ct);
+		PostAsync<ConverseRequest, ConverseResponse>("/converse", request, ct);
 
 	/// <summary> Send a chat message and receive a stream of typed SSE events. </summary>
 	public async IAsyncEnumerable<ConverseStreamEvent> ConverseStreamAsync(
 		ConverseRequest request,
 		[EnumeratorCancellation] CancellationToken ct = default)
 	{
-		using var response = await PostStreamAsync("/converse/async", request, Ctx.ConverseRequest, ct)
+		using var response = await PostStreamAsync("/converse/async", request, ct)
 			.ConfigureAwait(false);
 
 		var parser = SseParser.Create(response.Body, ParseSseEvent);
@@ -37,11 +37,11 @@ public partial class AgentBuilderClient
 
 	/// <summary> List all conversations. </summary>
 	public Task<ListConversationsResponse> ListConversationsAsync(CancellationToken ct = default) =>
-		GetAsync("/conversations", Ctx.ListConversationsResponse, ct);
+		GetAsync<ListConversationsResponse>("/conversations", ct);
 
 	/// <summary> Get a conversation by its ID. </summary>
 	public Task<Conversation> GetConversationAsync(string conversationId, CancellationToken ct = default) =>
-		GetAsync($"/conversations/{conversationId}", Ctx.Conversation, ct);
+		GetAsync<Conversation>($"/conversations/{conversationId}", ct);
 
 	/// <summary> Delete a conversation by its ID. </summary>
 	public Task DeleteConversationAsync(string conversationId, CancellationToken ct = default) =>

--- a/src/Elastic.AgentBuilder/AgentBuilderClient.Tools.cs
+++ b/src/Elastic.AgentBuilder/AgentBuilderClient.Tools.cs
@@ -10,47 +10,45 @@ namespace Elastic.AgentBuilder;
 
 public partial class AgentBuilderClient
 {
-	private static readonly AgentBuilderSerializationContext Ctx = AgentBuilderSerializationContext.Default;
-
 	/// <summary> List all available tools. </summary>
 	public Task<ListToolsResponse> ListToolsAsync(CancellationToken ct = default) =>
-		GetAsync("/tools", Ctx.ListToolsResponse, ct);
+		GetAsync<ListToolsResponse>("/tools", ct);
 
 	/// <summary> Get a tool by its ID. </summary>
 	public Task<AgentBuilderTool> GetToolAsync(string toolId, CancellationToken ct = default) =>
-		GetAsync($"/tools/{toolId}", Ctx.AgentBuilderTool, ct);
+		GetAsync<AgentBuilderTool>($"/tools/{toolId}", ct);
 
 	/// <summary> Create an ES|QL tool. </summary>
 	public Task<AgentBuilderTool> CreateToolAsync(CreateEsqlToolRequest request, CancellationToken ct = default) =>
-		PostAsync("/tools", request, Ctx.CreateEsqlToolRequest, Ctx.AgentBuilderTool, ct);
+		PostAsync<CreateEsqlToolRequest, AgentBuilderTool>("/tools", request, ct);
 
 	/// <summary> Create an index search tool. </summary>
 	public Task<AgentBuilderTool> CreateToolAsync(CreateIndexSearchToolRequest request, CancellationToken ct = default) =>
-		PostAsync("/tools", request, Ctx.CreateIndexSearchToolRequest, Ctx.AgentBuilderTool, ct);
+		PostAsync<CreateIndexSearchToolRequest, AgentBuilderTool>("/tools", request, ct);
 
 	/// <summary> Create an MCP tool. </summary>
 	public Task<AgentBuilderTool> CreateToolAsync(CreateMcpToolRequest request, CancellationToken ct = default) =>
-		PostAsync("/tools", request, Ctx.CreateMcpToolRequest, Ctx.AgentBuilderTool, ct);
+		PostAsync<CreateMcpToolRequest, AgentBuilderTool>("/tools", request, ct);
 
 	/// <summary> Create a workflow tool. </summary>
 	public Task<AgentBuilderTool> CreateToolAsync(CreateWorkflowToolRequest request, CancellationToken ct = default) =>
-		PostAsync("/tools", request, Ctx.CreateWorkflowToolRequest, Ctx.AgentBuilderTool, ct);
+		PostAsync<CreateWorkflowToolRequest, AgentBuilderTool>("/tools", request, ct);
 
 	/// <summary> Update an ES|QL tool. </summary>
 	public Task<AgentBuilderTool> UpdateToolAsync(string toolId, UpdateEsqlToolRequest request, CancellationToken ct = default) =>
-		PutAsync($"/tools/{toolId}", request, Ctx.UpdateEsqlToolRequest, Ctx.AgentBuilderTool, ct);
+		PutAsync<UpdateEsqlToolRequest, AgentBuilderTool>($"/tools/{toolId}", request, ct);
 
 	/// <summary> Update an index search tool. </summary>
 	public Task<AgentBuilderTool> UpdateToolAsync(string toolId, UpdateIndexSearchToolRequest request, CancellationToken ct = default) =>
-		PutAsync($"/tools/{toolId}", request, Ctx.UpdateIndexSearchToolRequest, Ctx.AgentBuilderTool, ct);
+		PutAsync<UpdateIndexSearchToolRequest, AgentBuilderTool>($"/tools/{toolId}", request, ct);
 
 	/// <summary> Update an MCP tool. </summary>
 	public Task<AgentBuilderTool> UpdateToolAsync(string toolId, UpdateMcpToolRequest request, CancellationToken ct = default) =>
-		PutAsync($"/tools/{toolId}", request, Ctx.UpdateMcpToolRequest, Ctx.AgentBuilderTool, ct);
+		PutAsync<UpdateMcpToolRequest, AgentBuilderTool>($"/tools/{toolId}", request, ct);
 
 	/// <summary> Update a workflow tool. </summary>
 	public Task<AgentBuilderTool> UpdateToolAsync(string toolId, UpdateWorkflowToolRequest request, CancellationToken ct = default) =>
-		PutAsync($"/tools/{toolId}", request, Ctx.UpdateWorkflowToolRequest, Ctx.AgentBuilderTool, ct);
+		PutAsync<UpdateWorkflowToolRequest, AgentBuilderTool>($"/tools/{toolId}", request, ct);
 
 	/// <summary> Delete a tool by its ID. </summary>
 	public Task DeleteToolAsync(string toolId, CancellationToken ct = default) =>
@@ -58,5 +56,5 @@ public partial class AgentBuilderClient
 
 	/// <summary> Execute a tool with parameters. </summary>
 	public Task<ExecuteToolResponse> ExecuteToolAsync(ExecuteToolRequest request, CancellationToken ct = default) =>
-		PostAsync("/tools/_execute", request, Ctx.ExecuteToolRequest, Ctx.ExecuteToolResponse, ct);
+		PostAsync<ExecuteToolRequest, ExecuteToolResponse>("/tools/_execute", request, ct);
 }

--- a/src/Elastic.AgentBuilder/AgentBuilderClient.cs
+++ b/src/Elastic.AgentBuilder/AgentBuilderClient.cs
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.Text.Json;
-using System.Text.Json.Serialization.Metadata;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Transport;
@@ -54,45 +53,48 @@ public partial class AgentBuilderClient
 
 	private string Path(string relative) => $"{_pathPrefix}{relative}";
 
-	private async Task<TResponse> GetAsync<TResponse>(string path, JsonTypeInfo<TResponse> typeInfo, CancellationToken ct)
+	private async Task<TResponse> GetAsync<TResponse>(string path, CancellationToken ct)
+		where TResponse : TransportResponse, new()
 	{
 		var response = await _transport
-			.RequestAsync<StringResponse>(HttpMethod.GET, Path(path), cancellationToken: ct)
+			.RequestAsync<TResponse>(HttpMethod.GET, Path(path), cancellationToken: ct)
 			.ConfigureAwait(false);
 		EnsureSuccess(response);
-		return Deserialize(response.Body, typeInfo);
+		return response;
 	}
 
 	private async Task<TResponse> PostAsync<TRequest, TResponse>(
-		string path, TRequest body, JsonTypeInfo<TRequest> requestTypeInfo, JsonTypeInfo<TResponse> responseTypeInfo, CancellationToken ct)
+		string path, TRequest body, CancellationToken ct)
+		where TResponse : TransportResponse, new()
 	{
-		var json = JsonSerializer.Serialize(body, requestTypeInfo);
 		var response = await _transport
-			.RequestAsync<StringResponse>(HttpMethod.POST, Path(path), PostData.String(json), cancellationToken: ct)
+			.RequestAsync<TResponse>(HttpMethod.POST, Path(path),
+				PostData.Serializable(body), cancellationToken: ct)
 			.ConfigureAwait(false);
 		EnsureSuccess(response);
-		return Deserialize(response.Body, responseTypeInfo);
+		return response;
 	}
 
 	private async Task<TResponse> PutAsync<TRequest, TResponse>(
-		string path, TRequest body, JsonTypeInfo<TRequest> requestTypeInfo, JsonTypeInfo<TResponse> responseTypeInfo, CancellationToken ct)
+		string path, TRequest body, CancellationToken ct)
+		where TResponse : TransportResponse, new()
 	{
-		var json = JsonSerializer.Serialize(body, requestTypeInfo);
 		var response = await _transport
-			.RequestAsync<StringResponse>(HttpMethod.PUT, Path(path), PostData.String(json), cancellationToken: ct)
+			.RequestAsync<TResponse>(HttpMethod.PUT, Path(path),
+				PostData.Serializable(body), cancellationToken: ct)
 			.ConfigureAwait(false);
 		EnsureSuccess(response);
-		return Deserialize(response.Body, responseTypeInfo);
+		return response;
 	}
 
 	private static readonly RequestConfiguration SseRequestConfig = new() { Accept = "application/octet-stream" };
 
 	internal async Task<StreamResponse> PostStreamAsync<TRequest>(
-		string path, TRequest body, JsonTypeInfo<TRequest> requestTypeInfo, CancellationToken ct)
+		string path, TRequest body, CancellationToken ct)
 	{
-		var json = JsonSerializer.Serialize(body, requestTypeInfo);
 		var response = await _transport
-			.RequestAsync<StreamResponse>(HttpMethod.POST, Path(path), PostData.String(json),
+			.RequestAsync<StreamResponse>(HttpMethod.POST, Path(path),
+				PostData.Serializable(body),
 				localConfiguration: SseRequestConfig, cancellationToken: ct)
 			.ConfigureAwait(false);
 		EnsureSuccess(response);
@@ -102,20 +104,18 @@ public partial class AgentBuilderClient
 	private async Task DeleteAsync(string path, CancellationToken ct)
 	{
 		var response = await _transport
-			.RequestAsync<StringResponse>(HttpMethod.DELETE, Path(path), cancellationToken: ct)
+			.RequestAsync<VoidResponse>(HttpMethod.DELETE, Path(path), cancellationToken: ct)
 			.ConfigureAwait(false);
 		EnsureSuccess(response);
 	}
-
-	private static TResponse Deserialize<TResponse>(string body, JsonTypeInfo<TResponse> typeInfo) =>
-		JsonSerializer.Deserialize(body, typeInfo)
-		?? throw new InvalidOperationException($"Failed to deserialize response as {typeof(TResponse).Name}");
 
 	private static void EnsureSuccess(TransportResponse response)
 	{
 		if (!response.ApiCallDetails.HasSuccessfulStatusCode)
 		{
-			var body = response is StringResponse sr ? $": {sr.Body}" : string.Empty;
+			var body = response.ApiCallDetails.ResponseBodyInBytes is { Length: > 0 } bytes
+				? $": {Encoding.UTF8.GetString(bytes)}"
+				: string.Empty;
 			throw new AgentBuilderException(
 				$"Agent Builder API returned {response.ApiCallDetails.HttpStatusCode}{body}",
 				response.ApiCallDetails);

--- a/src/Elastic.AgentBuilder/AgentTransportConfiguration.cs
+++ b/src/Elastic.AgentBuilder/AgentTransportConfiguration.cs
@@ -29,30 +29,30 @@ public class AgentTransportConfiguration
 	/// The Cloud ID is parsed to resolve the Kibana service URL automatically.
 	/// </summary>
 	public AgentTransportConfiguration(string cloudId, ApiKey credentials) =>
-		_factory = () => new TransportConfigurationDescriptor(cloudId, credentials, CloudService.Kibana)
-			.GlobalHeaders(KibanaHeaders);
+		_factory = () => Descriptor(new CloudNodePool(cloudId, credentials, CloudService.Kibana));
 
 	/// <summary>
 	/// Connect to Kibana via an Elastic Cloud ID with basic credentials.
 	/// </summary>
 	public AgentTransportConfiguration(string cloudId, BasicAuthentication credentials) =>
-		_factory = () => new TransportConfigurationDescriptor(cloudId, credentials, CloudService.Kibana)
-			.GlobalHeaders(KibanaHeaders);
+		_factory = () => Descriptor(new CloudNodePool(cloudId, credentials, CloudService.Kibana));
 
 	/// <summary>
 	/// Connect to a Kibana instance at the given URL with an API key.
 	/// </summary>
 	public AgentTransportConfiguration(Uri kibanaUri, ApiKey credentials) =>
-		_factory = () => new TransportConfigurationDescriptor(new SingleNodePool(kibanaUri))
-			.Authentication(credentials)
-			.GlobalHeaders(KibanaHeaders);
+		_factory = () => Descriptor(new SingleNodePool(kibanaUri))
+			.Authentication(credentials);
 
 	/// <summary>
 	/// Connect to a Kibana instance at the given URL with basic credentials.
 	/// </summary>
 	public AgentTransportConfiguration(Uri kibanaUri, BasicAuthentication credentials) =>
-		_factory = () => new TransportConfigurationDescriptor(new SingleNodePool(kibanaUri))
-			.Authentication(credentials)
+		_factory = () => Descriptor(new SingleNodePool(kibanaUri))
+			.Authentication(credentials);
+
+	private static TransportConfigurationDescriptor Descriptor(NodePool pool) =>
+		new TransportConfigurationDescriptor(pool, null, AgentBuilderSerializer.Instance)
 			.GlobalHeaders(KibanaHeaders);
 
 	internal ITransportConfiguration CreateTransportConfiguration() => _factory();

--- a/src/Elastic.AgentBuilder/Agents/AgentBuilderAgent.cs
+++ b/src/Elastic.AgentBuilder/Agents/AgentBuilderAgent.cs
@@ -4,40 +4,41 @@
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Elastic.Transport;
 
 namespace Elastic.AgentBuilder.Agents;
 
 /// <summary>
 /// Represents an agent as returned by the Agent Builder API.
 /// </summary>
-public record AgentBuilderAgent
+public class AgentBuilderAgent : TransportResponse
 {
 	[JsonPropertyName("id")]
-	public required string Id { get; init; }
+	public string Id { get; set; } = default!;
 
 	[JsonPropertyName("type")]
-	public string? Type { get; init; }
+	public string? Type { get; set; }
 
 	[JsonPropertyName("name")]
-	public required string Name { get; init; }
+	public string Name { get; set; } = default!;
 
 	[JsonPropertyName("description")]
-	public string? Description { get; init; }
+	public string? Description { get; set; }
 
 	[JsonPropertyName("labels")]
-	public IReadOnlyList<string>? Labels { get; init; }
+	public IReadOnlyList<string>? Labels { get; set; }
 
 	[JsonPropertyName("avatar_color")]
-	public string? AvatarColor { get; init; }
+	public string? AvatarColor { get; set; }
 
 	[JsonPropertyName("avatar_symbol")]
-	public string? AvatarSymbol { get; init; }
+	public string? AvatarSymbol { get; set; }
 
 	[JsonPropertyName("configuration")]
-	public AgentConfiguration? Configuration { get; init; }
+	public AgentConfiguration? Configuration { get; set; }
 
 	[JsonPropertyName("readonly")]
-	public bool Readonly { get; init; }
+	public bool Readonly { get; set; }
 }
 
 /// <summary>
@@ -64,8 +65,8 @@ public record AgentToolGroup
 /// <summary>
 /// Response wrapper for listing agents.
 /// </summary>
-public record ListAgentsResponse
+public class ListAgentsResponse : TransportResponse
 {
 	[JsonPropertyName("results")]
-	public required IReadOnlyList<AgentBuilderAgent> Results { get; init; }
+	public IReadOnlyList<AgentBuilderAgent> Results { get; set; } = default!;
 }

--- a/src/Elastic.AgentBuilder/Conversations/Conversation.cs
+++ b/src/Elastic.AgentBuilder/Conversations/Conversation.cs
@@ -5,32 +5,33 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Elastic.Transport;
 
 namespace Elastic.AgentBuilder.Conversations;
 
 /// <summary>
 /// Represents a conversation as returned by the Agent Builder API.
 /// </summary>
-public record Conversation
+public class Conversation : TransportResponse
 {
 	[JsonPropertyName("conversation_id")]
-	public required string ConversationId { get; init; }
+	public string ConversationId { get; set; } = default!;
 
 	[JsonPropertyName("title")]
-	public string? Title { get; init; }
+	public string? Title { get; set; }
 
 	[JsonPropertyName("agent_id")]
-	public string? AgentId { get; init; }
+	public string? AgentId { get; set; }
 
 	[JsonPropertyName("rounds")]
-	public IReadOnlyList<JsonElement>? Rounds { get; init; }
+	public IReadOnlyList<JsonElement>? Rounds { get; set; }
 }
 
 /// <summary>
 /// Response wrapper for listing conversations.
 /// </summary>
-public record ListConversationsResponse
+public class ListConversationsResponse : TransportResponse
 {
 	[JsonPropertyName("results")]
-	public required IReadOnlyList<Conversation> Results { get; init; }
+	public IReadOnlyList<Conversation> Results { get; set; } = default!;
 }

--- a/src/Elastic.AgentBuilder/Conversations/ConverseResponse.cs
+++ b/src/Elastic.AgentBuilder/Conversations/ConverseResponse.cs
@@ -5,31 +5,32 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Elastic.Transport;
 
 namespace Elastic.AgentBuilder.Conversations;
 
 /// <summary>
 /// Synchronous response from the converse API.
 /// </summary>
-public record ConverseResponse
+public class ConverseResponse : TransportResponse
 {
 	[JsonPropertyName("conversation_id")]
-	public required string ConversationId { get; init; }
+	public string ConversationId { get; set; } = default!;
 
 	[JsonPropertyName("round_id")]
-	public string? RoundId { get; init; }
+	public string? RoundId { get; set; }
 
 	[JsonPropertyName("status")]
-	public string? Status { get; init; }
+	public string? Status { get; set; }
 
 	[JsonPropertyName("steps")]
-	public IReadOnlyList<ConverseStep>? Steps { get; init; }
+	public IReadOnlyList<ConverseStep>? Steps { get; set; }
 
 	[JsonPropertyName("model_usage")]
-	public ModelUsage? ModelUsage { get; init; }
+	public ModelUsage? ModelUsage { get; set; }
 
 	[JsonPropertyName("response")]
-	public ConverseMessage? Response { get; init; }
+	public ConverseMessage? Response { get; set; }
 }
 
 /// <summary>

--- a/src/Elastic.AgentBuilder/Serialization/AgentBuilderSerializer.cs
+++ b/src/Elastic.AgentBuilder/Serialization/AgentBuilderSerializer.cs
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Elastic.Transport;
+using Elastic.Transport.Products.Elasticsearch;
+
+namespace Elastic.AgentBuilder;
+
+internal sealed class AgentBuilderSerializer : SystemTextJsonSerializer
+{
+	public static readonly AgentBuilderSerializer Instance = new();
+
+	[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+		Justification = "DefaultJsonTypeInfoResolver is a fallback; all known types are covered by AgentBuilderSerializationContext")]
+	[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+		Justification = "DefaultJsonTypeInfoResolver is a fallback; all known types are covered by AgentBuilderSerializationContext")]
+	public AgentBuilderSerializer() : base(new TransportSerializerOptionsProvider([], null, options =>
+	{
+		options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+		options.TypeInfoResolver = JsonTypeInfoResolver.Combine(
+			AgentBuilderSerializationContext.Default,
+			ElasticsearchTransportSerializerContext.Default,
+			new DefaultJsonTypeInfoResolver()
+		);
+	}))
+	{
+	}
+}

--- a/src/Elastic.AgentBuilder/Tools/AgentBuilderTool.cs
+++ b/src/Elastic.AgentBuilder/Tools/AgentBuilderTool.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Elastic.Transport;
 
 namespace Elastic.AgentBuilder.Tools;
 
@@ -14,28 +15,28 @@ namespace Elastic.AgentBuilder.Tools;
 /// deserialized into the appropriate typed configuration using <see cref="AsEsql"/>,
 /// <see cref="AsIndexSearch"/>, <see cref="AsMcp"/>, or <see cref="AsWorkflow"/>.
 /// </summary>
-public record AgentBuilderTool
+public class AgentBuilderTool : TransportResponse
 {
 	[JsonPropertyName("id")]
-	public required string Id { get; init; }
+	public string Id { get; set; } = default!;
 
 	[JsonPropertyName("type")]
-	public required string Type { get; init; }
+	public string Type { get; set; } = default!;
 
 	[JsonPropertyName("description")]
-	public string? Description { get; init; }
+	public string? Description { get; set; }
 
 	[JsonPropertyName("tags")]
-	public IReadOnlyList<string>? Tags { get; init; }
+	public IReadOnlyList<string>? Tags { get; set; }
 
 	[JsonPropertyName("configuration")]
-	public JsonElement Configuration { get; init; }
+	public JsonElement Configuration { get; set; }
 
 	[JsonPropertyName("readonly")]
-	public bool Readonly { get; init; }
+	public bool Readonly { get; set; }
 
 	[JsonPropertyName("schema")]
-	public JsonElement? Schema { get; init; }
+	public JsonElement? Schema { get; set; }
 
 	/// <summary> Deserialize configuration as an ES|QL tool. </summary>
 	public EsqlToolConfiguration? AsEsql() =>
@@ -57,8 +58,8 @@ public record AgentBuilderTool
 /// <summary>
 /// Response wrapper for listing tools.
 /// </summary>
-public record ListToolsResponse
+public class ListToolsResponse : TransportResponse
 {
 	[JsonPropertyName("results")]
-	public required IReadOnlyList<AgentBuilderTool> Results { get; init; }
+	public IReadOnlyList<AgentBuilderTool> Results { get; set; } = default!;
 }

--- a/src/Elastic.AgentBuilder/Tools/ExecuteToolResponse.cs
+++ b/src/Elastic.AgentBuilder/Tools/ExecuteToolResponse.cs
@@ -5,16 +5,17 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Elastic.Transport;
 
 namespace Elastic.AgentBuilder.Tools;
 
 /// <summary>
 /// Response from executing a tool.
 /// </summary>
-public record ExecuteToolResponse
+public class ExecuteToolResponse : TransportResponse
 {
 	[JsonPropertyName("results")]
-	public required IReadOnlyList<ToolResult> Results { get; init; }
+	public IReadOnlyList<ToolResult> Results { get; set; } = default!;
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- Introduce `AgentBuilderSerializer` (`SystemTextJsonSerializer` subclass) that combines `AgentBuilderSerializationContext` with `ElasticsearchTransportSerializerContext` and `DefaultJsonTypeInfoResolver` via `JsonTypeInfoResolver.Combine`, matching the pattern used by `Elastic.Ingest.Elasticsearch`
- Wire the serializer into `AgentTransportConfiguration` through a shared `Descriptor()` helper that passes it to the `TransportConfigurationDescriptor` constructor
- Convert 8 top-level response types (`AgentBuilderTool`, `ListToolsResponse`, `AgentBuilderAgent`, `ListAgentsResponse`, `Conversation`, `ListConversationsResponse`, `ConverseResponse`, `ExecuteToolResponse`) from `record` to `class : TransportResponse` so the transport deserializes directly into them
- Replace `PostData.String(JsonSerializer.Serialize(...))` with `PostData.Serializable(body)` and `RequestAsync<StringResponse>` + manual deserialization with `RequestAsync<TResponse>` in all client helper methods
- Switch `DeleteAsync` to `VoidResponse` and `EnsureSuccess` to read error bodies from `ApiCallDetails.ResponseBodyInBytes`

## Test plan

- [x] All 12 unit tests pass
- [x] All 3 integration tests pass (including CRUD tool test against live Kibana)
- [x] Builds cleanly across all 4 TFMs (netstandard2.0, netstandard2.1, net8.0, net10.0) with 0 warnings

Made with [Cursor](https://cursor.com)