### PR TITLE
Add remaining Agent Builder API endpoints: skills, plugins, consumption, attachments

### DIFF
--- a/src/Elastic.Clients.AgentBuilder/AgentBuilderClient.Agents.cs
+++ b/src/Elastic.Clients.AgentBuilder/AgentBuilderClient.Agents.cs
@@ -29,4 +29,10 @@ public partial class AgentBuilderClient
 	/// <summary> Delete an agent by its ID. </summary>
 	public Task DeleteAgentAsync(string agentId, CancellationToken ct = default) =>
 		DeleteAsync($"/agents/{agentId}", ct);
+
+	/// <summary> Get paginated, per-conversation token consumption data for an agent. </summary>
+	public Task<AgentConsumptionResponse> GetAgentConsumptionAsync(
+		string agentId, AgentConsumptionRequest request, CancellationToken ct = default) =>
+		PostAsync<AgentConsumptionRequest, AgentConsumptionResponse>(
+			$"/agents/{agentId}/consumption", request, ct);
 }

--- a/src/Elastic.Clients.AgentBuilder/AgentBuilderClient.Conversations.cs
+++ b/src/Elastic.Clients.AgentBuilder/AgentBuilderClient.Conversations.cs
@@ -47,6 +47,53 @@ public partial class AgentBuilderClient
 	public Task DeleteConversationAsync(string conversationId, CancellationToken ct = default) =>
 		DeleteAsync($"/conversations/{conversationId}", ct);
 
+	/// <summary> List all attachments for a conversation. </summary>
+	public Task<ListAttachmentsResponse> ListAttachmentsAsync(
+		string conversationId, bool includeDeleted = false, CancellationToken ct = default)
+	{
+		var path = includeDeleted
+			? $"/conversations/{conversationId}/attachments?include_deleted=true"
+			: $"/conversations/{conversationId}/attachments";
+		return GetAsync<ListAttachmentsResponse>(path, ct);
+	}
+
+	/// <summary> Create a new attachment for a conversation. </summary>
+	public Task<Attachment> CreateAttachmentAsync(
+		string conversationId, CreateAttachmentRequest request, CancellationToken ct = default) =>
+		PostAsync<CreateAttachmentRequest, Attachment>(
+			$"/conversations/{conversationId}/attachments", request, ct);
+
+	/// <summary> Update an attachment's content (creates a new version if content changed). </summary>
+	public Task<Attachment> UpdateAttachmentAsync(
+		string conversationId, string attachmentId,
+		UpdateAttachmentRequest request, CancellationToken ct = default) =>
+		PutAsync<UpdateAttachmentRequest, Attachment>(
+			$"/conversations/{conversationId}/attachments/{attachmentId}", request, ct);
+
+	/// <summary> Delete an attachment (soft delete by default). </summary>
+	public Task DeleteAttachmentAsync(
+		string conversationId, string attachmentId,
+		bool permanent = false, CancellationToken ct = default)
+	{
+		var path = permanent
+			? $"/conversations/{conversationId}/attachments/{attachmentId}?permanent=true"
+			: $"/conversations/{conversationId}/attachments/{attachmentId}";
+		return DeleteAsync(path, ct);
+	}
+
+	/// <summary> Restore a soft-deleted attachment. </summary>
+	public Task<Attachment> RestoreAttachmentAsync(
+		string conversationId, string attachmentId, CancellationToken ct = default) =>
+		PostEmptyAsync<Attachment>(
+			$"/conversations/{conversationId}/attachments/{attachmentId}/_restore", ct);
+
+	/// <summary> Update the origin reference for an attachment. </summary>
+	public Task<Attachment> UpdateAttachmentOriginAsync(
+		string conversationId, string attachmentId,
+		UpdateAttachmentOriginRequest request, CancellationToken ct = default) =>
+		PutAsync<UpdateAttachmentOriginRequest, Attachment>(
+			$"/conversations/{conversationId}/attachments/{attachmentId}/origin", request, ct);
+
 	/// <summary>
 	/// Parses the raw UTF-8 bytes of an SSE <c>data:</c> line directly into a typed
 	/// <see cref="ConverseStreamEvent"/>. Kibana wraps every event payload in a

--- a/src/Elastic.Clients.AgentBuilder/AgentBuilderClient.Plugins.cs
+++ b/src/Elastic.Clients.AgentBuilder/AgentBuilderClient.Plugins.cs
@@ -1,0 +1,28 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Clients.AgentBuilder.Plugins;
+
+namespace Elastic.Clients.AgentBuilder;
+
+public partial class AgentBuilderClient
+{
+	/// <summary> List all installed plugins. </summary>
+	public Task<ListPluginsResponse> ListPluginsAsync(CancellationToken ct = default) =>
+		GetAsync<ListPluginsResponse>("/plugins", ct);
+
+	/// <summary> Get a plugin by its ID. </summary>
+	public Task<AgentBuilderPlugin> GetPluginAsync(string pluginId, CancellationToken ct = default) =>
+		GetAsync<AgentBuilderPlugin>($"/plugins/{pluginId}", ct);
+
+	/// <summary> Install a plugin from a URL. </summary>
+	public Task<AgentBuilderPlugin> InstallPluginAsync(InstallPluginRequest request, CancellationToken ct = default) =>
+		PostAsync<InstallPluginRequest, AgentBuilderPlugin>("/plugins/install", request, ct);
+
+	/// <summary> Delete an installed plugin by its ID. </summary>
+	public Task DeletePluginAsync(string pluginId, CancellationToken ct = default) =>
+		DeleteAsync($"/plugins/{pluginId}", ct);
+}

--- a/src/Elastic.Clients.AgentBuilder/AgentBuilderClient.Skills.cs
+++ b/src/Elastic.Clients.AgentBuilder/AgentBuilderClient.Skills.cs
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Clients.AgentBuilder.Skills;
+
+namespace Elastic.Clients.AgentBuilder;
+
+public partial class AgentBuilderClient
+{
+	/// <summary> List all available skills. </summary>
+	public Task<ListSkillsResponse> ListSkillsAsync(CancellationToken ct = default) =>
+		GetAsync<ListSkillsResponse>("/skills", ct);
+
+	/// <summary> Get a skill by its ID. </summary>
+	public Task<AgentBuilderSkill> GetSkillAsync(string skillId, CancellationToken ct = default) =>
+		GetAsync<AgentBuilderSkill>($"/skills/{skillId}", ct);
+
+	/// <summary> Create a new skill. </summary>
+	public Task<AgentBuilderSkill> CreateSkillAsync(CreateSkillRequest request, CancellationToken ct = default) =>
+		PostAsync<CreateSkillRequest, AgentBuilderSkill>("/skills", request, ct);
+
+	/// <summary> Update an existing skill. </summary>
+	public Task<AgentBuilderSkill> UpdateSkillAsync(string skillId, UpdateSkillRequest request, CancellationToken ct = default) =>
+		PutAsync<UpdateSkillRequest, AgentBuilderSkill>($"/skills/{skillId}", request, ct);
+
+	/// <summary> Delete a skill by its ID. </summary>
+	public Task DeleteSkillAsync(string skillId, CancellationToken ct = default) =>
+		DeleteAsync($"/skills/{skillId}", ct);
+}

--- a/src/Elastic.Clients.AgentBuilder/AgentBuilderClient.cs
+++ b/src/Elastic.Clients.AgentBuilder/AgentBuilderClient.cs
@@ -109,6 +109,17 @@ public partial class AgentBuilderClient
 		EnsureSuccess(response);
 	}
 
+	private async Task<TResponse> PostEmptyAsync<TResponse>(string path, CancellationToken ct)
+		where TResponse : TransportResponse, new()
+	{
+		var response = await _transport
+			.RequestAsync<TResponse>(HttpMethod.POST, Path(path),
+				PostData.Empty, cancellationToken: ct)
+			.ConfigureAwait(false);
+		EnsureSuccess(response);
+		return response;
+	}
+
 	private static void EnsureSuccess(TransportResponse response)
 	{
 		if (!response.ApiCallDetails.HasSuccessfulStatusCode)

--- a/src/Elastic.Clients.AgentBuilder/Agents/AgentConsumptionRequest.cs
+++ b/src/Elastic.Clients.AgentBuilder/Agents/AgentConsumptionRequest.cs
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Elastic.Clients.AgentBuilder.Agents;
+
+/// <summary>
+/// Request for paginated, per-conversation token consumption data for an agent.
+/// </summary>
+public record AgentConsumptionRequest
+{
+	[JsonPropertyName("size")]
+	public int? Size { get; init; }
+
+	[JsonPropertyName("sort_field")]
+	public string? SortField { get; init; }
+
+	[JsonPropertyName("sort_order")]
+	public string? SortOrder { get; init; }
+
+	[JsonPropertyName("search")]
+	public string? Search { get; init; }
+
+	[JsonPropertyName("has_warnings")]
+	public bool? HasWarnings { get; init; }
+
+	[JsonPropertyName("usernames")]
+	public IReadOnlyList<string>? Usernames { get; init; }
+
+	[JsonPropertyName("search_after")]
+	public IReadOnlyList<JsonElement>? SearchAfter { get; init; }
+}

--- a/src/Elastic.Clients.AgentBuilder/Agents/AgentConsumptionResponse.cs
+++ b/src/Elastic.Clients.AgentBuilder/Agents/AgentConsumptionResponse.cs
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elastic.Transport;
+
+namespace Elastic.Clients.AgentBuilder.Agents;
+
+/// <summary>
+/// Response containing paginated consumption data for an agent.
+/// </summary>
+public class AgentConsumptionResponse : TransportResponse
+{
+	[JsonPropertyName("results")]
+	public IReadOnlyList<ConversationConsumption> Results { get; set; } = default!;
+
+	[JsonPropertyName("search_after")]
+	public IReadOnlyList<JsonElement>? SearchAfter { get; set; }
+}
+
+/// <summary>
+/// Token consumption data for a single conversation.
+/// </summary>
+public record ConversationConsumption
+{
+	[JsonPropertyName("conversation_id")]
+	public string ConversationId { get; init; } = default!;
+
+	[JsonPropertyName("title")]
+	public string? Title { get; init; }
+
+	[JsonPropertyName("username")]
+	public string? Username { get; init; }
+
+	[JsonPropertyName("input_tokens")]
+	public long InputTokens { get; init; }
+
+	[JsonPropertyName("output_tokens")]
+	public long OutputTokens { get; init; }
+
+	[JsonPropertyName("round_count")]
+	public int RoundCount { get; init; }
+
+	[JsonPropertyName("llm_call_count")]
+	public int LlmCallCount { get; init; }
+
+	[JsonPropertyName("has_warnings")]
+	public bool HasWarnings { get; init; }
+}

--- a/src/Elastic.Clients.AgentBuilder/Conversations/Attachment.cs
+++ b/src/Elastic.Clients.AgentBuilder/Conversations/Attachment.cs
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elastic.Transport;
+
+namespace Elastic.Clients.AgentBuilder.Conversations;
+
+/// <summary>
+/// Represents a conversation attachment as returned by the Agent Builder API.
+/// </summary>
+public class Attachment : TransportResponse
+{
+	[JsonPropertyName("id")]
+	public string Id { get; set; } = default!;
+
+	[JsonPropertyName("type")]
+	public string? Type { get; set; }
+
+	[JsonPropertyName("description")]
+	public string? Description { get; set; }
+
+	[JsonPropertyName("origin")]
+	public string? Origin { get; set; }
+
+	[JsonPropertyName("hidden")]
+	public bool? Hidden { get; set; }
+
+	[JsonPropertyName("deleted")]
+	public bool? Deleted { get; set; }
+
+	[JsonPropertyName("version")]
+	public int? Version { get; set; }
+
+	[JsonPropertyName("data")]
+	public JsonElement? Data { get; set; }
+}
+
+/// <summary>
+/// Response wrapper for listing conversation attachments.
+/// </summary>
+public class ListAttachmentsResponse : TransportResponse
+{
+	[JsonPropertyName("results")]
+	public IReadOnlyList<Attachment> Results { get; set; } = default!;
+}

--- a/src/Elastic.Clients.AgentBuilder/Conversations/AttachmentRequests.cs
+++ b/src/Elastic.Clients.AgentBuilder/Conversations/AttachmentRequests.cs
@@ -1,0 +1,46 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Serialization;
+
+namespace Elastic.Clients.AgentBuilder.Conversations;
+
+/// <summary>
+/// Request to create a new conversation attachment.
+/// </summary>
+public record CreateAttachmentRequest
+{
+	[JsonPropertyName("id")]
+	public string? Id { get; init; }
+
+	[JsonPropertyName("type")]
+	public string? Type { get; init; }
+
+	[JsonPropertyName("description")]
+	public string? Description { get; init; }
+
+	[JsonPropertyName("origin")]
+	public string? Origin { get; init; }
+
+	[JsonPropertyName("hidden")]
+	public bool? Hidden { get; init; }
+}
+
+/// <summary>
+/// Request to update a conversation attachment's content (creates a new version if content changed).
+/// </summary>
+public record UpdateAttachmentRequest
+{
+	[JsonPropertyName("description")]
+	public string? Description { get; init; }
+}
+
+/// <summary>
+/// Request to update the origin reference for an attachment.
+/// </summary>
+public record UpdateAttachmentOriginRequest
+{
+	[JsonPropertyName("origin")]
+	public required string Origin { get; init; }
+}

--- a/src/Elastic.Clients.AgentBuilder/Plugins/AgentBuilderPlugin.cs
+++ b/src/Elastic.Clients.AgentBuilder/Plugins/AgentBuilderPlugin.cs
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Elastic.Transport;
+
+namespace Elastic.Clients.AgentBuilder.Plugins;
+
+/// <summary>
+/// Represents an installed plugin as returned by the Agent Builder API.
+/// </summary>
+public class AgentBuilderPlugin : TransportResponse
+{
+	[JsonPropertyName("id")]
+	public string Id { get; set; } = default!;
+
+	[JsonPropertyName("name")]
+	public string? Name { get; set; }
+
+	[JsonPropertyName("description")]
+	public string? Description { get; set; }
+
+	[JsonPropertyName("url")]
+	public string? Url { get; set; }
+
+	[JsonPropertyName("managed_assets")]
+	public PluginManagedAssets? ManagedAssets { get; set; }
+}
+
+/// <summary>
+/// Assets managed by a plugin (e.g. skills, tools).
+/// </summary>
+public record PluginManagedAssets
+{
+	[JsonPropertyName("skills")]
+	public IReadOnlyList<string>? Skills { get; init; }
+
+	[JsonPropertyName("tools")]
+	public IReadOnlyList<string>? Tools { get; init; }
+}
+
+/// <summary>
+/// Response wrapper for listing plugins.
+/// </summary>
+public class ListPluginsResponse : TransportResponse
+{
+	[JsonPropertyName("results")]
+	public IReadOnlyList<AgentBuilderPlugin> Results { get; set; } = default!;
+}

--- a/src/Elastic.Clients.AgentBuilder/Plugins/InstallPluginRequest.cs
+++ b/src/Elastic.Clients.AgentBuilder/Plugins/InstallPluginRequest.cs
@@ -1,0 +1,19 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Serialization;
+
+namespace Elastic.Clients.AgentBuilder.Plugins;
+
+/// <summary>
+/// Request to install a plugin from a URL.
+/// </summary>
+public record InstallPluginRequest
+{
+	[JsonPropertyName("url")]
+	public required string Url { get; init; }
+
+	[JsonPropertyName("plugin_name")]
+	public string? PluginName { get; init; }
+}

--- a/src/Elastic.Clients.AgentBuilder/Serialization/AgentBuilderSerializationContext.cs
+++ b/src/Elastic.Clients.AgentBuilder/Serialization/AgentBuilderSerializationContext.cs
@@ -6,6 +6,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Elastic.Clients.AgentBuilder.Agents;
 using Elastic.Clients.AgentBuilder.Conversations;
+using Elastic.Clients.AgentBuilder.Plugins;
+using Elastic.Clients.AgentBuilder.Skills;
 using Elastic.Clients.AgentBuilder.Tools;
 
 namespace Elastic.Clients.AgentBuilder;
@@ -37,8 +39,16 @@ namespace Elastic.Clients.AgentBuilder;
 [JsonSerializable(typeof(AgentToolGroup))]
 [JsonSerializable(typeof(CreateAgentRequest))]
 [JsonSerializable(typeof(UpdateAgentRequest))]
+[JsonSerializable(typeof(AgentConsumptionRequest))]
+[JsonSerializable(typeof(AgentConsumptionResponse))]
+[JsonSerializable(typeof(ConversationConsumption))]
 [JsonSerializable(typeof(Conversation))]
 [JsonSerializable(typeof(ListConversationsResponse))]
+[JsonSerializable(typeof(Attachment))]
+[JsonSerializable(typeof(ListAttachmentsResponse))]
+[JsonSerializable(typeof(CreateAttachmentRequest))]
+[JsonSerializable(typeof(UpdateAttachmentRequest))]
+[JsonSerializable(typeof(UpdateAttachmentOriginRequest))]
 [JsonSerializable(typeof(ConverseRequest))]
 [JsonSerializable(typeof(ConverseResponse))]
 [JsonSerializable(typeof(ConverseStep))]
@@ -55,6 +65,15 @@ namespace Elastic.Clients.AgentBuilder;
 [JsonSerializable(typeof(MessageCompleteEvent))]
 [JsonSerializable(typeof(ThinkingCompleteEvent))]
 [JsonSerializable(typeof(RoundCompleteEvent))]
+[JsonSerializable(typeof(AgentBuilderSkill))]
+[JsonSerializable(typeof(ListSkillsResponse))]
+[JsonSerializable(typeof(SkillReferencedContent))]
+[JsonSerializable(typeof(CreateSkillRequest))]
+[JsonSerializable(typeof(UpdateSkillRequest))]
+[JsonSerializable(typeof(AgentBuilderPlugin))]
+[JsonSerializable(typeof(ListPluginsResponse))]
+[JsonSerializable(typeof(PluginManagedAssets))]
+[JsonSerializable(typeof(InstallPluginRequest))]
 [JsonSourceGenerationOptions(
 	PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
 	DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Elastic.Clients.AgentBuilder/Skills/AgentBuilderSkill.cs
+++ b/src/Elastic.Clients.AgentBuilder/Skills/AgentBuilderSkill.cs
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Elastic.Transport;
+
+namespace Elastic.Clients.AgentBuilder.Skills;
+
+/// <summary>
+/// Represents a skill as returned by the Agent Builder API.
+/// </summary>
+public class AgentBuilderSkill : TransportResponse
+{
+	[JsonPropertyName("id")]
+	public string Id { get; set; } = default!;
+
+	[JsonPropertyName("name")]
+	public string Name { get; set; } = default!;
+
+	[JsonPropertyName("description")]
+	public string? Description { get; set; }
+
+	[JsonPropertyName("content")]
+	public string? Content { get; set; }
+
+	[JsonPropertyName("tool_ids")]
+	public IReadOnlyList<string>? ToolIds { get; set; }
+
+	[JsonPropertyName("referenced_content")]
+	public IReadOnlyList<SkillReferencedContent>? ReferencedContent { get; set; }
+
+	[JsonPropertyName("readonly")]
+	public bool Readonly { get; set; }
+}
+
+/// <summary>
+/// A piece of referenced content attached to a skill.
+/// </summary>
+public record SkillReferencedContent
+{
+	[JsonPropertyName("id")]
+	public string? Id { get; init; }
+
+	[JsonPropertyName("title")]
+	public string? Title { get; init; }
+
+	[JsonPropertyName("type")]
+	public string? Type { get; init; }
+}
+
+/// <summary>
+/// Response wrapper for listing skills.
+/// </summary>
+public class ListSkillsResponse : TransportResponse
+{
+	[JsonPropertyName("results")]
+	public IReadOnlyList<AgentBuilderSkill> Results { get; set; } = default!;
+}

--- a/src/Elastic.Clients.AgentBuilder/Skills/CreateSkillRequest.cs
+++ b/src/Elastic.Clients.AgentBuilder/Skills/CreateSkillRequest.cs
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Elastic.Clients.AgentBuilder.Skills;
+
+/// <summary>
+/// Request to create a new skill.
+/// </summary>
+public record CreateSkillRequest
+{
+	[JsonPropertyName("id")]
+	public required string Id { get; init; }
+
+	[JsonPropertyName("name")]
+	public required string Name { get; init; }
+
+	[JsonPropertyName("description")]
+	public string? Description { get; init; }
+
+	[JsonPropertyName("content")]
+	public string? Content { get; init; }
+
+	[JsonPropertyName("tool_ids")]
+	public IReadOnlyList<string>? ToolIds { get; init; }
+
+	[JsonPropertyName("referenced_content")]
+	public IReadOnlyList<SkillReferencedContent>? ReferencedContent { get; init; }
+}

--- a/src/Elastic.Clients.AgentBuilder/Skills/UpdateSkillRequest.cs
+++ b/src/Elastic.Clients.AgentBuilder/Skills/UpdateSkillRequest.cs
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Elastic.Clients.AgentBuilder.Skills;
+
+/// <summary>
+/// Request to update an existing skill.
+/// </summary>
+public record UpdateSkillRequest
+{
+	[JsonPropertyName("name")]
+	public string? Name { get; init; }
+
+	[JsonPropertyName("description")]
+	public string? Description { get; init; }
+
+	[JsonPropertyName("content")]
+	public string? Content { get; init; }
+
+	[JsonPropertyName("tool_ids")]
+	public IReadOnlyList<string>? ToolIds { get; init; }
+
+	[JsonPropertyName("referenced_content")]
+	public IReadOnlyList<SkillReferencedContent>? ReferencedContent { get; init; }
+}

--- a/tests/Elastic.Clients.AgentBuilder.IntegrationTests/AgentConsumptionTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.IntegrationTests/AgentConsumptionTests.cs
@@ -1,0 +1,28 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+using Elastic.Clients.AgentBuilder.Agents;
+using FluentAssertions;
+
+namespace Elastic.Clients.AgentBuilder.IntegrationTests;
+
+public class AgentConsumptionTests : AgentBuilderTestBase
+{
+	[Test]
+	public async Task CanGetConsumptionForAgent()
+	{
+		var agents = await Client.ListAgentsAsync();
+		agents.Results.Should().NotBeEmpty("at least one agent must exist");
+
+		var agentId = agents.Results[0].Id;
+		var response = await Client.GetAgentConsumptionAsync(agentId, new AgentConsumptionRequest
+		{
+			Size = 5
+		});
+
+		response.Should().NotBeNull();
+		response.Results.Should().NotBeNull();
+	}
+}

--- a/tests/Elastic.Clients.AgentBuilder.IntegrationTests/ConversationTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.IntegrationTests/ConversationTests.cs
@@ -1,0 +1,139 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Elastic.Clients.AgentBuilder.Conversations;
+using FluentAssertions;
+
+namespace Elastic.Clients.AgentBuilder.IntegrationTests;
+
+public class ConversationTests : AgentBuilderTestBase
+{
+	private readonly List<string> _conversationIds = [];
+
+	[Test]
+	public async Task CanConverseAndListConversations()
+	{
+		var response = await Client.ConverseAsync(new ConverseRequest
+		{
+			Input = "Say hello in exactly three words."
+		});
+
+		response.Should().NotBeNull();
+		response.ConversationId.Should().NotBeNullOrWhiteSpace();
+		response.Status.Should().Be("completed");
+		response.Response.Should().NotBeNull();
+		response.Response!.Message.Should().NotBeNullOrWhiteSpace();
+		_conversationIds.Add(response.ConversationId);
+
+		var conversations = await Client.ListConversationsAsync();
+		conversations.Should().NotBeNull();
+		conversations.Results.Should().Contain(c => c.ConversationId == response.ConversationId);
+	}
+
+	[Test]
+	public async Task CanConverseGetAndDeleteConversation()
+	{
+		var created = await Client.ConverseAsync(new ConverseRequest
+		{
+			Input = "Reply with the single word 'pong'."
+		});
+		created.ConversationId.Should().NotBeNullOrWhiteSpace();
+		_conversationIds.Add(created.ConversationId);
+
+		var fetched = await Client.GetConversationAsync(created.ConversationId);
+		fetched.Should().NotBeNull();
+		fetched.ConversationId.Should().Be(created.ConversationId);
+		fetched.Rounds.Should().NotBeNullOrEmpty();
+
+		await Client.DeleteConversationAsync(created.ConversationId);
+		_conversationIds.Remove(created.ConversationId);
+
+		Func<Task> act = async () => await Client.GetConversationAsync(created.ConversationId);
+		await act.Should().ThrowAsync<AgentBuilderException>();
+	}
+
+	[Test]
+	public async Task CanContinueConversation()
+	{
+		var first = await Client.ConverseAsync(new ConverseRequest
+		{
+			Input = "Remember the word 'banana'. Reply with just that word."
+		});
+		first.ConversationId.Should().NotBeNullOrWhiteSpace();
+		_conversationIds.Add(first.ConversationId);
+
+		var second = await Client.ConverseAsync(new ConverseRequest
+		{
+			Input = "What word did I ask you to remember? Reply with just that word.",
+			ConversationId = first.ConversationId
+		});
+
+		second.ConversationId.Should().Be(first.ConversationId);
+		second.Response.Should().NotBeNull();
+		second.Response!.Message.Should().NotBeNullOrWhiteSpace();
+
+		var conversation = await Client.GetConversationAsync(first.ConversationId);
+		conversation.Rounds.Should().NotBeNull();
+		conversation.Rounds!.Count.Should().BeGreaterThanOrEqualTo(2);
+	}
+
+	[Test]
+	public async Task CanStreamConversation()
+	{
+		var events = new List<ConverseStreamEvent>();
+		var messageText = new StringBuilder();
+
+		await foreach (var evt in Client.ConverseStreamAsync(new ConverseRequest
+		{
+			Input = "Reply with the single word 'streamed'."
+		}))
+		{
+			events.Add(evt);
+
+			switch (evt)
+			{
+				case ConversationIdSetEvent idSet:
+					_conversationIds.Add(idSet.ConversationId);
+					break;
+				case MessageChunkEvent chunk:
+					messageText.Append(chunk.TextChunk);
+					break;
+			}
+		}
+
+		events.Should().NotBeEmpty();
+		events.OfType<ConversationIdSetEvent>().Should().ContainSingle();
+		events.OfType<MessageCompleteEvent>().Should().ContainSingle();
+		events.OfType<RoundCompleteEvent>().Should().ContainSingle();
+		messageText.Length.Should().BeGreaterThan(0);
+	}
+
+	[Test]
+	public async Task ConverseResponse_IncludesModelUsage()
+	{
+		var response = await Client.ConverseAsync(new ConverseRequest
+		{
+			Input = "Reply with the single word 'usage'."
+		});
+		_conversationIds.Add(response.ConversationId);
+
+		response.ModelUsage.Should().NotBeNull();
+		response.ModelUsage!.InputTokens.Should().BeGreaterThan(0);
+		response.ModelUsage.OutputTokens.Should().BeGreaterThan(0);
+	}
+
+	public override void Dispose()
+	{
+		foreach (var id in _conversationIds)
+		{
+			try { Client.DeleteConversationAsync(id).GetAwaiter().GetResult(); } catch { /* cleanup */ }
+		}
+		base.Dispose();
+	}
+}

--- a/tests/Elastic.Clients.AgentBuilder.IntegrationTests/PluginTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.IntegrationTests/PluginTests.cs
@@ -1,0 +1,19 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace Elastic.Clients.AgentBuilder.IntegrationTests;
+
+public class PluginTests : AgentBuilderTestBase
+{
+	[Test]
+	public async Task CanListPlugins()
+	{
+		var response = await Client.ListPluginsAsync();
+		response.Should().NotBeNull();
+		response.Results.Should().NotBeNull();
+	}
+}

--- a/tests/Elastic.Clients.AgentBuilder.IntegrationTests/SkillCrudTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.IntegrationTests/SkillCrudTests.cs
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Threading.Tasks;
+using Elastic.Clients.AgentBuilder.Skills;
+using FluentAssertions;
+
+namespace Elastic.Clients.AgentBuilder.IntegrationTests;
+
+public class SkillCrudTests : AgentBuilderTestBase
+{
+	private const string TestSkillId = "dotnet-integration-test-skill";
+
+	[Test]
+	public async Task CanListSkills()
+	{
+		var response = await Client.ListSkillsAsync();
+		response.Should().NotBeNull();
+		response.Results.Should().NotBeNull();
+	}
+
+	[Test]
+	public async Task CanCreateGetUpdateDeleteSkill()
+	{
+		try { await Client.DeleteSkillAsync(TestSkillId); } catch { /* cleanup from previous runs */ }
+
+		var created = await Client.CreateSkillAsync(new CreateSkillRequest
+		{
+			Id = TestSkillId,
+			Name = "Integration Test Skill",
+			Description = "A skill created by integration tests",
+			Content = "## Instructions\nHelp the user with testing.",
+			ToolIds = ["platform.core.search"]
+		});
+		created.Id.Should().Be(TestSkillId);
+		created.Name.Should().Be("Integration Test Skill");
+
+		var fetched = await Client.GetSkillAsync(TestSkillId);
+		fetched.Id.Should().Be(TestSkillId);
+		fetched.Description.Should().Be("A skill created by integration tests");
+		fetched.Content.Should().Contain("## Instructions");
+
+		var updated = await Client.UpdateSkillAsync(TestSkillId, new UpdateSkillRequest
+		{
+			Name = "Updated Integration Test Skill",
+			Description = "Updated description",
+			Content = "## Updated Instructions\nNew instructions."
+		});
+		updated.Name.Should().Be("Updated Integration Test Skill");
+
+		await Client.DeleteSkillAsync(TestSkillId);
+
+		Func<Task> act = async () => await Client.GetSkillAsync(TestSkillId);
+		await act.Should().ThrowAsync<AgentBuilderException>();
+	}
+
+	public override void Dispose()
+	{
+		try { Client.DeleteSkillAsync(TestSkillId).GetAwaiter().GetResult(); } catch { /* cleanup */ }
+		base.Dispose();
+	}
+}

--- a/tests/Elastic.Clients.AgentBuilder.Tests/Serialization/AttachmentSerializationTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.Tests/Serialization/AttachmentSerializationTests.cs
@@ -1,0 +1,167 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json;
+using Elastic.Clients.AgentBuilder.Conversations;
+using FluentAssertions;
+
+namespace Elastic.Clients.AgentBuilder.Tests.Serialization;
+
+public class AttachmentSerializationTests
+{
+	private static readonly AgentBuilderSerializationContext Ctx = AgentBuilderSerializationContext.Default;
+
+	[Test]
+	public void CreateAttachmentRequest_SerializesCorrectly()
+	{
+		var request = new CreateAttachmentRequest
+		{
+			Id = "att-123",
+			Type = "text",
+			Description = "My attachment",
+			Origin = "saved-object-abc",
+			Hidden = false
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.CreateAttachmentRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("id").GetString().Should().Be("att-123");
+		root.GetProperty("type").GetString().Should().Be("text");
+		root.GetProperty("description").GetString().Should().Be("My attachment");
+		root.GetProperty("origin").GetString().Should().Be("saved-object-abc");
+		root.GetProperty("hidden").GetBoolean().Should().BeFalse();
+	}
+
+	[Test]
+	public void CreateAttachmentRequest_OmitsNullProperties()
+	{
+		var request = new CreateAttachmentRequest
+		{
+			Type = "esql"
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.CreateAttachmentRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("type").GetString().Should().Be("esql");
+		root.TryGetProperty("id", out _).Should().BeFalse();
+		root.TryGetProperty("description", out _).Should().BeFalse();
+		root.TryGetProperty("origin", out _).Should().BeFalse();
+		root.TryGetProperty("hidden", out _).Should().BeFalse();
+	}
+
+	[Test]
+	public void UpdateAttachmentRequest_SerializesCorrectly()
+	{
+		var request = new UpdateAttachmentRequest
+		{
+			Description = "Updated description"
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.UpdateAttachmentRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("description").GetString().Should().Be("Updated description");
+	}
+
+	[Test]
+	public void UpdateAttachmentOriginRequest_SerializesCorrectly()
+	{
+		var request = new UpdateAttachmentOriginRequest
+		{
+			Origin = "saved-object-xyz"
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.UpdateAttachmentOriginRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("origin").GetString().Should().Be("saved-object-xyz");
+	}
+
+	[Test]
+	public void Attachment_DeserializesFromApi()
+	{
+		var json = """
+		{
+			"id": "att-001",
+			"type": "visualization",
+			"description": "Sales dashboard",
+			"origin": "saved-object-123",
+			"hidden": false,
+			"deleted": false,
+			"version": 3,
+			"data": { "title": "Sales Q1" }
+		}
+		""";
+
+		var attachment = JsonSerializer.Deserialize(json, Ctx.Attachment);
+
+		attachment.Should().NotBeNull();
+		attachment!.Id.Should().Be("att-001");
+		attachment.Type.Should().Be("visualization");
+		attachment.Description.Should().Be("Sales dashboard");
+		attachment.Origin.Should().Be("saved-object-123");
+		attachment.Hidden.Should().BeFalse();
+		attachment.Deleted.Should().BeFalse();
+		attachment.Version.Should().Be(3);
+		attachment.Data.Should().NotBeNull();
+		attachment.Data!.Value.GetProperty("title").GetString().Should().Be("Sales Q1");
+	}
+
+	[Test]
+	public void Attachment_DeserializesDeletedAttachment()
+	{
+		var json = """
+		{
+			"id": "att-deleted",
+			"type": "text",
+			"description": "Removed",
+			"deleted": true,
+			"version": 1
+		}
+		""";
+
+		var attachment = JsonSerializer.Deserialize(json, Ctx.Attachment);
+
+		attachment.Should().NotBeNull();
+		attachment!.Deleted.Should().BeTrue();
+		attachment.Origin.Should().BeNull();
+	}
+
+	[Test]
+	public void ListAttachmentsResponse_DeserializesFromApi()
+	{
+		var json = """
+		{
+			"results": [
+				{
+					"id": "att-a",
+					"type": "text",
+					"description": "First",
+					"version": 1
+				},
+				{
+					"id": "att-b",
+					"type": "esql",
+					"description": "Second",
+					"hidden": true,
+					"version": 2
+				}
+			]
+		}
+		""";
+
+		var response = JsonSerializer.Deserialize(json, Ctx.ListAttachmentsResponse);
+
+		response.Should().NotBeNull();
+		response!.Results.Should().HaveCount(2);
+		response.Results[0].Id.Should().Be("att-a");
+		response.Results[1].Hidden.Should().BeTrue();
+	}
+}

--- a/tests/Elastic.Clients.AgentBuilder.Tests/Serialization/ConsumptionSerializationTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.Tests/Serialization/ConsumptionSerializationTests.cs
@@ -1,0 +1,121 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json;
+using Elastic.Clients.AgentBuilder.Agents;
+using FluentAssertions;
+
+namespace Elastic.Clients.AgentBuilder.Tests.Serialization;
+
+public class ConsumptionSerializationTests
+{
+	private static readonly AgentBuilderSerializationContext Ctx = AgentBuilderSerializationContext.Default;
+
+	[Test]
+	public void AgentConsumptionRequest_SerializesCorrectly()
+	{
+		var request = new AgentConsumptionRequest
+		{
+			Size = 25,
+			SortField = "input_tokens",
+			SortOrder = "desc",
+			Search = "books",
+			HasWarnings = true,
+			Usernames = ["user1", "user2"]
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.AgentConsumptionRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("size").GetInt32().Should().Be(25);
+		root.GetProperty("sort_field").GetString().Should().Be("input_tokens");
+		root.GetProperty("sort_order").GetString().Should().Be("desc");
+		root.GetProperty("search").GetString().Should().Be("books");
+		root.GetProperty("has_warnings").GetBoolean().Should().BeTrue();
+		root.GetProperty("usernames").GetArrayLength().Should().Be(2);
+	}
+
+	[Test]
+	public void AgentConsumptionRequest_OmitsNullProperties()
+	{
+		var request = new AgentConsumptionRequest
+		{
+			Size = 10
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.AgentConsumptionRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("size").GetInt32().Should().Be(10);
+		root.TryGetProperty("sort_field", out _).Should().BeFalse();
+		root.TryGetProperty("search", out _).Should().BeFalse();
+		root.TryGetProperty("has_warnings", out _).Should().BeFalse();
+	}
+
+	[Test]
+	public void AgentConsumptionResponse_DeserializesFromApi()
+	{
+		var json = """
+		{
+			"results": [
+				{
+					"conversation_id": "conv-abc",
+					"title": "Book search conversation",
+					"username": "testuser",
+					"input_tokens": 50000,
+					"output_tokens": 2000,
+					"round_count": 5,
+					"llm_call_count": 12,
+					"has_warnings": true
+				},
+				{
+					"conversation_id": "conv-def",
+					"title": "Simple query",
+					"username": "testuser",
+					"input_tokens": 1000,
+					"output_tokens": 200,
+					"round_count": 1,
+					"llm_call_count": 2,
+					"has_warnings": false
+				}
+			],
+			"search_after": [50000, "conv-abc"]
+		}
+		""";
+
+		var response = JsonSerializer.Deserialize(json, Ctx.AgentConsumptionResponse);
+
+		response.Should().NotBeNull();
+		response!.Results.Should().HaveCount(2);
+
+		var first = response.Results[0];
+		first.ConversationId.Should().Be("conv-abc");
+		first.Title.Should().Be("Book search conversation");
+		first.InputTokens.Should().Be(50000);
+		first.OutputTokens.Should().Be(2000);
+		first.RoundCount.Should().Be(5);
+		first.LlmCallCount.Should().Be(12);
+		first.HasWarnings.Should().BeTrue();
+
+		response.SearchAfter.Should().HaveCount(2);
+	}
+
+	[Test]
+	public void AgentConsumptionResponse_DeserializesWithoutSearchAfter()
+	{
+		var json = """
+		{
+			"results": []
+		}
+		""";
+
+		var response = JsonSerializer.Deserialize(json, Ctx.AgentConsumptionResponse);
+
+		response.Should().NotBeNull();
+		response!.Results.Should().BeEmpty();
+		response.SearchAfter.Should().BeNull();
+	}
+}

--- a/tests/Elastic.Clients.AgentBuilder.Tests/Serialization/PluginSerializationTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.Tests/Serialization/PluginSerializationTests.cs
@@ -1,0 +1,119 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json;
+using Elastic.Clients.AgentBuilder.Plugins;
+using FluentAssertions;
+
+namespace Elastic.Clients.AgentBuilder.Tests.Serialization;
+
+public class PluginSerializationTests
+{
+	private static readonly AgentBuilderSerializationContext Ctx = AgentBuilderSerializationContext.Default;
+
+	[Test]
+	public void InstallPluginRequest_SerializesCorrectly()
+	{
+		var request = new InstallPluginRequest
+		{
+			Url = "https://github.com/example/my-plugin",
+			PluginName = "my-custom-plugin"
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.InstallPluginRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("url").GetString().Should().Be("https://github.com/example/my-plugin");
+		root.GetProperty("plugin_name").GetString().Should().Be("my-custom-plugin");
+	}
+
+	[Test]
+	public void InstallPluginRequest_OmitsNullPluginName()
+	{
+		var request = new InstallPluginRequest
+		{
+			Url = "https://github.com/example/my-plugin"
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.InstallPluginRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("url").GetString().Should().Be("https://github.com/example/my-plugin");
+		root.TryGetProperty("plugin_name", out _).Should().BeFalse();
+	}
+
+	[Test]
+	public void AgentBuilderPlugin_DeserializesFromApi()
+	{
+		var json = """
+		{
+			"id": "example-plugin",
+			"name": "Example Plugin",
+			"description": "An example plugin",
+			"url": "https://github.com/example/plugin",
+			"managed_assets": {
+				"skills": ["skill-from-plugin"],
+				"tools": ["tool-from-plugin"]
+			}
+		}
+		""";
+
+		var plugin = JsonSerializer.Deserialize(json, Ctx.AgentBuilderPlugin);
+
+		plugin.Should().NotBeNull();
+		plugin!.Id.Should().Be("example-plugin");
+		plugin.Name.Should().Be("Example Plugin");
+		plugin.Description.Should().Be("An example plugin");
+		plugin.Url.Should().Be("https://github.com/example/plugin");
+		plugin.ManagedAssets.Should().NotBeNull();
+		plugin.ManagedAssets!.Skills.Should().ContainSingle().Which.Should().Be("skill-from-plugin");
+		plugin.ManagedAssets.Tools.Should().ContainSingle().Which.Should().Be("tool-from-plugin");
+	}
+
+	[Test]
+	public void AgentBuilderPlugin_DeserializesMinimalResponse()
+	{
+		var json = """
+		{
+			"id": "minimal-plugin",
+			"name": "Minimal"
+		}
+		""";
+
+		var plugin = JsonSerializer.Deserialize(json, Ctx.AgentBuilderPlugin);
+
+		plugin.Should().NotBeNull();
+		plugin!.Id.Should().Be("minimal-plugin");
+		plugin.ManagedAssets.Should().BeNull();
+	}
+
+	[Test]
+	public void ListPluginsResponse_DeserializesFromApi()
+	{
+		var json = """
+		{
+			"results": [
+				{
+					"id": "plugin-a",
+					"name": "Plugin A",
+					"managed_assets": { "skills": ["s1", "s2"] }
+				},
+				{
+					"id": "plugin-b",
+					"name": "Plugin B"
+				}
+			]
+		}
+		""";
+
+		var response = JsonSerializer.Deserialize(json, Ctx.ListPluginsResponse);
+
+		response.Should().NotBeNull();
+		response!.Results.Should().HaveCount(2);
+		response.Results[0].ManagedAssets!.Skills.Should().HaveCount(2);
+		response.Results[1].ManagedAssets.Should().BeNull();
+	}
+}

--- a/tests/Elastic.Clients.AgentBuilder.Tests/Serialization/SkillSerializationTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.Tests/Serialization/SkillSerializationTests.cs
@@ -1,0 +1,141 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json;
+using Elastic.Clients.AgentBuilder.Skills;
+using FluentAssertions;
+
+namespace Elastic.Clients.AgentBuilder.Tests.Serialization;
+
+public class SkillSerializationTests
+{
+	private static readonly AgentBuilderSerializationContext Ctx = AgentBuilderSerializationContext.Default;
+
+	[Test]
+	public void CreateSkillRequest_SerializesCorrectly()
+	{
+		var request = new CreateSkillRequest
+		{
+			Id = "my-skill",
+			Name = "Research Skill",
+			Description = "Helps with research tasks",
+			Content = "## Instructions\nUse the search tool to find relevant documents.",
+			ToolIds = ["search-tool", "esql-tool"],
+			ReferencedContent =
+			[
+				new SkillReferencedContent { Id = "ref-1", Title = "Guide", Type = "document" }
+			]
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.CreateSkillRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("id").GetString().Should().Be("my-skill");
+		root.GetProperty("name").GetString().Should().Be("Research Skill");
+		root.GetProperty("description").GetString().Should().Be("Helps with research tasks");
+		root.GetProperty("content").GetString().Should().Contain("## Instructions");
+		root.GetProperty("tool_ids").GetArrayLength().Should().Be(2);
+		root.GetProperty("referenced_content")[0].GetProperty("id").GetString().Should().Be("ref-1");
+	}
+
+	[Test]
+	public void CreateSkillRequest_OmitsNullProperties()
+	{
+		var request = new CreateSkillRequest
+		{
+			Id = "minimal-skill",
+			Name = "Minimal"
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.CreateSkillRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("id").GetString().Should().Be("minimal-skill");
+		root.TryGetProperty("description", out _).Should().BeFalse();
+		root.TryGetProperty("content", out _).Should().BeFalse();
+		root.TryGetProperty("tool_ids", out _).Should().BeFalse();
+	}
+
+	[Test]
+	public void UpdateSkillRequest_SerializesCorrectly()
+	{
+		var request = new UpdateSkillRequest
+		{
+			Name = "Updated Skill",
+			Content = "Updated instructions"
+		};
+
+		var json = JsonSerializer.Serialize(request, Ctx.UpdateSkillRequest);
+		var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		root.GetProperty("name").GetString().Should().Be("Updated Skill");
+		root.GetProperty("content").GetString().Should().Be("Updated instructions");
+		root.TryGetProperty("description", out _).Should().BeFalse();
+	}
+
+	[Test]
+	public void AgentBuilderSkill_DeserializesFromApi()
+	{
+		var json = """
+		{
+			"id": "research-skill",
+			"name": "Research Assistant",
+			"description": "Helps with research",
+			"content": "Use the search tool to find relevant data.",
+			"tool_ids": ["search-tool"],
+			"referenced_content": [
+				{ "id": "ref-1", "title": "Guide", "type": "document" }
+			],
+			"readonly": false
+		}
+		""";
+
+		var skill = JsonSerializer.Deserialize(json, Ctx.AgentBuilderSkill);
+
+		skill.Should().NotBeNull();
+		skill!.Id.Should().Be("research-skill");
+		skill.Name.Should().Be("Research Assistant");
+		skill.Description.Should().Be("Helps with research");
+		skill.Content.Should().Contain("search tool");
+		skill.ToolIds.Should().ContainSingle().Which.Should().Be("search-tool");
+		skill.ReferencedContent.Should().ContainSingle();
+		skill.ReferencedContent![0].Id.Should().Be("ref-1");
+		skill.Readonly.Should().BeFalse();
+	}
+
+	[Test]
+	public void ListSkillsResponse_DeserializesFromApi()
+	{
+		var json = """
+		{
+			"results": [
+				{
+					"id": "builtin-search",
+					"name": "Search",
+					"description": "Built-in search skill",
+					"readonly": true
+				},
+				{
+					"id": "custom-skill",
+					"name": "Custom",
+					"description": "User skill",
+					"content": "Custom instructions",
+					"tool_ids": ["my-tool"],
+					"readonly": false
+				}
+			]
+		}
+		""";
+
+		var response = JsonSerializer.Deserialize(json, Ctx.ListSkillsResponse);
+
+		response.Should().NotBeNull();
+		response!.Results.Should().HaveCount(2);
+		response.Results[0].Readonly.Should().BeTrue();
+		response.Results[1].ToolIds.Should().ContainSingle().Which.Should().Be("my-tool");
+	}
+}


### PR DESCRIPTION
## Summary

- **Skills CRUD** — `ListSkillsAsync`, `GetSkillAsync`, `CreateSkillAsync`, `UpdateSkillAsync`, `DeleteSkillAsync` with typed request/response models and `SkillReferencedContent`
- **Plugins** — `ListPluginsAsync`, `GetPluginAsync`, `InstallPluginAsync`, `DeletePluginAsync` with `AgentBuilderPlugin`, `PluginManagedAssets`, and `InstallPluginRequest`
- **Agent consumption** — `GetAgentConsumptionAsync` returning paginated per-conversation token usage (`AgentConsumptionRequest`/`AgentConsumptionResponse`)
- **Conversation attachments** — `ListAttachmentsAsync` (with `include_deleted`), `CreateAttachmentAsync`, `UpdateAttachmentAsync`, `DeleteAttachmentAsync` (with `permanent`), `RestoreAttachmentAsync`, `UpdateAttachmentOriginAsync`
- **Conversation integration tests** — converse (sync + streaming), multi-turn, get/list/delete, model usage
- All new types registered in `AgentBuilderSerializationContext` for AOT compatibility
- 17 new serialization unit tests (33 total, all pass)
- Integration tests for skills CRUD, plugins list, agent consumption, and full conversation lifecycle

> **Note:** The rename-attachment endpoint (`PATCH`) is not implemented because `Elastic.Transport` 0.15.1's `HttpMethod` enum does not include `PATCH`. A2A and MCP endpoints are intentionally excluded.

## Test plan

- [x] `dotnet test --project tests/Elastic.Clients.AgentBuilder.Tests` — 33 unit tests pass
- [x] `dotnet build` — all four target frameworks (net10.0, net8.0, netstandard2.1, netstandard2.0) compile cleanly
- [ ] Run integration tests against a Kibana instance with Agent Builder enabled


Made with [Cursor](https://cursor.com)