### PR TITLE
Add bootstrap idempotency tests and fix conversation deserialization

### DIFF
--- a/src/Elastic.Clients.AgentBuilder/Conversations/Conversation.cs
+++ b/src/Elastic.Clients.AgentBuilder/Conversations/Conversation.cs
@@ -14,7 +14,7 @@ namespace Elastic.Clients.AgentBuilder.Conversations;
 /// </summary>
 public class Conversation : TransportResponse
 {
-	[JsonPropertyName("conversation_id")]
+	[JsonPropertyName("id")]
 	public string ConversationId { get; set; } = default!;
 
 	[JsonPropertyName("title")]

--- a/tests/Elastic.Clients.AgentBuilder.IntegrationTests/BootstrapTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.IntegrationTests/BootstrapTests.cs
@@ -2,9 +2,12 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Elastic.Clients.AgentBuilder.Agents;
 using Elastic.Clients.AgentBuilder.Tools;
 using FluentAssertions;
 
@@ -12,47 +15,322 @@ namespace Elastic.Clients.AgentBuilder.IntegrationTests;
 
 public class BootstrapTests : AgentBuilderTestBase
 {
-	private const string TestToolId = "dotnet-bootstrap-test-tool";
+	private readonly ConcurrentBag<string> _createdToolIds = new();
+	private readonly ConcurrentBag<string> _createdAgentIds = new();
 
-	[Test]
-	public async Task Bootstrap_CreatesAndSkipsOnSecondRun()
-	{
-		try { await Client.DeleteToolAsync(TestToolId); } catch { /* cleanup from previous runs */ }
+	private static string ToolId([CallerMemberName] string caller = "") =>
+		$"dotnet-bt-{caller}".ToLowerInvariant();
 
-		var bootstrapper = new AgentBuilderBootstrapper(Client);
-		var definition = new BootstrapDefinition
+	private static string AgentId([CallerMemberName] string caller = "") =>
+		$"dotnet-bt-{caller}".ToLowerInvariant();
+
+	private static string GetHashTag(IReadOnlyList<string>? tagsOrLabels) =>
+		tagsOrLabels!.Single(t => t.StartsWith("_hash:", System.StringComparison.Ordinal));
+
+	private static BootstrapDefinition ToolDefinition(
+		string toolId,
+		string description = "Bootstrap test tool",
+		string query = "FROM test | LIMIT 1") =>
+		new()
 		{
 			EsqlTools =
 			[
 				new CreateEsqlToolRequest
 				{
-					Id = TestToolId,
-					Description = "Bootstrap test tool",
+					Id = toolId,
+					Description = description,
 					Configuration = new EsqlToolConfiguration
 					{
-						Query = "FROM test | LIMIT 1",
+						Query = query,
 						Params = new Dictionary<string, EsqlToolParam>()
 					}
 				}
 			]
 		};
 
-		var result1 = await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, definition);
-		result1.Should().BeTrue();
+	private static BootstrapDefinition AgentDefinition(
+		string agentId,
+		string name = "Bootstrap test agent",
+		string? description = "An agent for bootstrap tests",
+		string instructions = "You are a test agent.",
+		IReadOnlyList<string>? toolIds = null) =>
+		new()
+		{
+			Agents =
+			[
+				new CreateAgentRequest
+				{
+					Id = agentId,
+					Name = name,
+					Description = description,
+					Configuration = new AgentConfiguration
+					{
+						Instructions = instructions,
+						Tools = [new AgentToolGroup { ToolIds = toolIds ?? [] }]
+					}
+				}
+			]
+		};
 
-		var tool = await Client.GetToolAsync(TestToolId);
-		tool.Tags.Should().NotBeNull();
-		tool.Tags!.Any(t => t.StartsWith("_hash:", System.StringComparison.Ordinal)).Should().BeTrue();
+	// ── Tool idempotency ───────────────────────────────────────────────
 
-		var result2 = await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, definition);
-		result2.Should().BeTrue();
+	[Test]
+	public async Task Tool_SecondBootstrapWithSameDefinition_DoesNotUpdate()
+	{
+		var id = ToolId();
+		_createdToolIds.Add(id);
+		await CleanupToolAsync(id);
 
-		await Client.DeleteToolAsync(TestToolId);
+		var bootstrapper = new AgentBuilderBootstrapper(Client);
+		var definition = ToolDefinition(id);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, definition);
+
+		var after1 = await Client.GetToolAsync(id);
+		var hash1 = GetHashTag(after1.Tags);
+
+		// Tamper the description directly; keep hash tag intact so the
+		// bootstrapper should see a matching hash and skip the update.
+		await Client.UpdateToolAsync(id, new UpdateEsqlToolRequest
+		{
+			Description = "tampered",
+			Tags = after1.Tags,
+			Configuration = after1.AsEsql()
+		});
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, definition);
+
+		var after2 = await Client.GetToolAsync(id);
+		after2.Description.Should().Be("tampered",
+			"bootstrapper should skip update when the hash matches");
+		GetHashTag(after2.Tags).Should().Be(hash1);
+	}
+
+	// ── Tool update on description change ──────────────────────────────
+
+	[Test]
+	public async Task Tool_ChangedDescription_TriggersUpdate()
+	{
+		var id = ToolId();
+		_createdToolIds.Add(id);
+		await CleanupToolAsync(id);
+
+		var bootstrapper = new AgentBuilderBootstrapper(Client);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, ToolDefinition(id));
+		var hash1 = GetHashTag((await Client.GetToolAsync(id)).Tags);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure,
+			ToolDefinition(id, description: "Updated description"));
+
+		var after = await Client.GetToolAsync(id);
+		after.Description.Should().Be("Updated description");
+		GetHashTag(after.Tags).Should().NotBe(hash1,
+			"a new hash should be written when the definition changes");
+	}
+
+	// ── Tool update on query change ────────────────────────────────────
+
+	[Test]
+	public async Task Tool_ChangedQuery_TriggersUpdate()
+	{
+		var id = ToolId();
+		_createdToolIds.Add(id);
+		await CleanupToolAsync(id);
+
+		var bootstrapper = new AgentBuilderBootstrapper(Client);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, ToolDefinition(id));
+		var hash1 = GetHashTag((await Client.GetToolAsync(id)).Tags);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure,
+			ToolDefinition(id, query: "FROM test | LIMIT 99"));
+
+		var after = await Client.GetToolAsync(id);
+		after.AsEsql()!.Query.Should().Be("FROM test | LIMIT 99");
+		GetHashTag(after.Tags).Should().NotBe(hash1);
+	}
+
+	// ── Agent idempotency ──────────────────────────────────────────────
+
+	[Test]
+	public async Task Agent_SecondBootstrapWithSameDefinition_DoesNotUpdate()
+	{
+		var id = AgentId();
+		_createdAgentIds.Add(id);
+		await CleanupAgentAsync(id);
+
+		var bootstrapper = new AgentBuilderBootstrapper(Client);
+		var definition = AgentDefinition(id);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, definition);
+
+		var after1 = await Client.GetAgentAsync(id);
+		var hash1 = GetHashTag(after1.Labels);
+
+		// Tamper the name directly; keep hash label intact.
+		await Client.UpdateAgentAsync(id, new UpdateAgentRequest
+		{
+			Name = "tampered",
+			Description = after1.Description,
+			Labels = after1.Labels,
+			Configuration = after1.Configuration
+		});
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, definition);
+
+		var after2 = await Client.GetAgentAsync(id);
+		after2.Name.Should().Be("tampered",
+			"bootstrapper should skip update when the hash matches");
+		GetHashTag(after2.Labels).Should().Be(hash1);
+	}
+
+	// ── Agent update on prompt (instructions) change ───────────────────
+
+	[Test]
+	public async Task Agent_ChangedInstructions_TriggersUpdate()
+	{
+		var id = AgentId();
+		_createdAgentIds.Add(id);
+		await CleanupAgentAsync(id);
+
+		var bootstrapper = new AgentBuilderBootstrapper(Client);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, AgentDefinition(id));
+		var hash1 = GetHashTag((await Client.GetAgentAsync(id)).Labels);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure,
+			AgentDefinition(id, instructions: "You are a different test agent."));
+
+		var after = await Client.GetAgentAsync(id);
+		after.Configuration!.Instructions.Should().Be("You are a different test agent.");
+		GetHashTag(after.Labels).Should().NotBe(hash1);
+	}
+
+	// ── Agent update on description change ─────────────────────────────
+
+	[Test]
+	public async Task Agent_ChangedDescription_TriggersUpdate()
+	{
+		var id = AgentId();
+		_createdAgentIds.Add(id);
+		await CleanupAgentAsync(id);
+
+		var bootstrapper = new AgentBuilderBootstrapper(Client);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, AgentDefinition(id));
+		var hash1 = GetHashTag((await Client.GetAgentAsync(id)).Labels);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure,
+			AgentDefinition(id, description: "Changed agent description"));
+
+		var after = await Client.GetAgentAsync(id);
+		after.Description.Should().Be("Changed agent description");
+		GetHashTag(after.Labels).Should().NotBe(hash1);
+	}
+
+	// ── Agent update on tool list change ───────────────────────────────
+
+	[Test]
+	public async Task Agent_AddedTool_TriggersUpdate()
+	{
+		var toolId = ToolId();
+		var agentId = AgentId();
+		_createdToolIds.Add(toolId);
+		_createdAgentIds.Add(agentId);
+		await CleanupToolAsync(toolId);
+		await CleanupAgentAsync(agentId);
+
+		var bootstrapper = new AgentBuilderBootstrapper(Client);
+
+		// Create the tool so the API can resolve the reference.
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, ToolDefinition(toolId));
+
+		// Bootstrap agent with no tools.
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, AgentDefinition(agentId));
+		var hash1 = GetHashTag((await Client.GetAgentAsync(agentId)).Labels);
+
+		// Re-bootstrap with the tool added.
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure,
+			AgentDefinition(agentId, toolIds: [toolId]));
+
+		var after = await Client.GetAgentAsync(agentId);
+		after.Configuration!.Tools.Should().ContainSingle()
+			.Which.ToolIds.Should().Contain(toolId);
+		GetHashTag(after.Labels).Should().NotBe(hash1,
+			"adding a tool should change the hash and trigger an update");
+	}
+
+	[Test]
+	public async Task Agent_RemovedTool_TriggersUpdate()
+	{
+		var toolId = ToolId();
+		var agentId = AgentId();
+		_createdToolIds.Add(toolId);
+		_createdAgentIds.Add(agentId);
+		await CleanupToolAsync(toolId);
+		await CleanupAgentAsync(agentId);
+
+		var bootstrapper = new AgentBuilderBootstrapper(Client);
+
+		// Create the tool so the API can resolve the reference.
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, ToolDefinition(toolId));
+
+		// Bootstrap agent with the tool assigned.
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure,
+			AgentDefinition(agentId, toolIds: [toolId]));
+		var hash1 = GetHashTag((await Client.GetAgentAsync(agentId)).Labels);
+
+		// Re-bootstrap with the tool removed.
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, AgentDefinition(agentId));
+
+		var after = await Client.GetAgentAsync(agentId);
+		after.Configuration!.Tools.Should().ContainSingle()
+			.Which.ToolIds.Should().BeEmpty();
+		GetHashTag(after.Labels).Should().NotBe(hash1,
+			"removing a tool should change the hash and trigger an update");
+	}
+
+	// ── Agent update on metadata (name/description) change ─────────────
+
+	[Test]
+	public async Task Agent_ChangedName_TriggersUpdate()
+	{
+		var id = AgentId();
+		_createdAgentIds.Add(id);
+		await CleanupAgentAsync(id);
+
+		var bootstrapper = new AgentBuilderBootstrapper(Client);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure, AgentDefinition(id));
+		var hash1 = GetHashTag((await Client.GetAgentAsync(id)).Labels);
+
+		await bootstrapper.BootstrapAsync(BootstrapMethod.Failure,
+			AgentDefinition(id, name: "Renamed agent"));
+
+		var after = await Client.GetAgentAsync(id);
+		after.Name.Should().Be("Renamed agent");
+		GetHashTag(after.Labels).Should().NotBe(hash1);
+	}
+
+	// ── Cleanup helpers ────────────────────────────────────────────────
+
+	private async Task CleanupToolAsync(string toolId)
+	{
+		try { await Client.DeleteToolAsync(toolId); } catch { /* not found */ }
+	}
+
+	private async Task CleanupAgentAsync(string agentId)
+	{
+		try { await Client.DeleteAgentAsync(agentId); } catch { /* not found */ }
 	}
 
 	public override void Dispose()
 	{
-		try { Client.DeleteToolAsync(TestToolId).GetAwaiter().GetResult(); } catch { /* cleanup */ }
+		foreach (var id in _createdToolIds)
+			try { Client.DeleteToolAsync(id).GetAwaiter().GetResult(); } catch { /* cleanup */ }
+		foreach (var id in _createdAgentIds)
+			try { Client.DeleteAgentAsync(id).GetAwaiter().GetResult(); } catch { /* cleanup */ }
 		base.Dispose();
 	}
 }

--- a/tests/Elastic.Clients.AgentBuilder.IntegrationTests/PluginTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.IntegrationTests/PluginTests.cs
@@ -12,8 +12,15 @@ public class PluginTests : AgentBuilderTestBase
 	[Test]
 	public async Task CanListPlugins()
 	{
-		var response = await Client.ListPluginsAsync();
-		response.Should().NotBeNull();
-		response.Results.Should().NotBeNull();
+		try
+		{
+			var response = await Client.ListPluginsAsync();
+			response.Should().NotBeNull();
+			response.Results.Should().NotBeNull();
+		}
+		catch (AgentBuilderException ex) when (ex.ApiCallDetails.HttpStatusCode == 404)
+		{
+			Skip.Test("Plugins API not available (requires Kibana 9.4.0+)");
+		}
 	}
 }

--- a/tests/Elastic.Clients.AgentBuilder.IntegrationTests/SkillCrudTests.cs
+++ b/tests/Elastic.Clients.AgentBuilder.IntegrationTests/SkillCrudTests.cs
@@ -16,15 +16,28 @@ public class SkillCrudTests : AgentBuilderTestBase
 	[Test]
 	public async Task CanListSkills()
 	{
-		var response = await Client.ListSkillsAsync();
-		response.Should().NotBeNull();
-		response.Results.Should().NotBeNull();
+		try
+		{
+			var response = await Client.ListSkillsAsync();
+			response.Should().NotBeNull();
+			response.Results.Should().NotBeNull();
+		}
+		catch (AgentBuilderException ex) when (ex.ApiCallDetails.HttpStatusCode == 404)
+		{
+			Skip.Test("Skills API not available (requires Kibana 9.4.0+)");
+		}
 	}
 
 	[Test]
 	public async Task CanCreateGetUpdateDeleteSkill()
 	{
-		try { await Client.DeleteSkillAsync(TestSkillId); } catch { /* cleanup from previous runs */ }
+		try { await Client.DeleteSkillAsync(TestSkillId); }
+		catch (AgentBuilderException ex) when (ex.ApiCallDetails.HttpStatusCode == 404)
+		{
+			Skip.Test("Skills API not available (requires Kibana 9.4.0+)");
+			return;
+		}
+		catch { /* cleanup from previous runs */ }
 
 		var created = await Client.CreateSkillAsync(new CreateSkillRequest
 		{


### PR DESCRIPTION
## Summary

- **Bootstrap idempotency tests**: Validates the hash-based skip/update logic for both tools and agents. Uses a tamper-and-verify strategy — after bootstrapping, a field is modified directly via the API while preserving the hash tag, then re-bootstrapping with the original definition proves the bootstrapper correctly skips the update. Separate tests verify that changing description, query, instructions, name, or tool list forces an update with a new hash.
- **Conversation deserialization fix**: The `Conversation` model mapped `ConversationId` to `conversation_id`, but the Kibana GET/LIST conversation endpoints return `id` (confirmed from the OpenAPI spec). Changed the `JsonPropertyName` to `id`.
- **Skills/Plugins version tolerance**: These APIs require Kibana 9.4.0+ (Technical Preview). Tests now skip gracefully with `Skip.Test(...)` when the server returns 404.

## Test plan

- [x] All 9 bootstrap tests pass (tool idempotency ×3, agent idempotency ×6 including add/remove tool)
- [x] All 5 conversation tests pass after the `id` fix
- [x] Skills/plugins tests skip cleanly on Kibana < 9.4.0
- [x] 33 unit tests still pass with no regressions
- [x] Final result: 20 integration tests (17 passed, 3 skipped), 33 unit tests (all passed)

Made with [Cursor](https://cursor.com)