### PR TITLE
Enrichment: Fix 404 on enrich policy execute

### DIFF
--- a/src/Elastic.Ingest.Elasticsearch/Enrichment/AiEnrichmentOrchestrator.Initialization.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Enrichment/AiEnrichmentOrchestrator.Initialization.cs
@@ -37,7 +37,9 @@ public partial class AiEnrichmentOrchestrator
 			HttpMethod.GET, $"_enrich/policy/{_versionedPolicyName}",
 			cancellationToken: ct).ConfigureAwait(false);
 
-		if (exists.ApiCallDetails.HttpStatusCode == 200)
+		if (exists.ApiCallDetails.HttpStatusCode == 200
+			&& exists.Body is JsonObject root
+			&& root["policies"]?.AsArray() is { Count: > 0 })
 			return false;
 
 		var put = await _transport.RequestAsync<StringResponse>(


### PR DESCRIPTION
## What
Fix `ExecuteEnrichPolicyAsync` failing with HTTP 404 after PR #174's hash-versioned policy names.

## Why
Elasticsearch's `GET /_enrich/policy/<name>` returns HTTP 200 with an empty `policies` array when the named policy doesn't exist. PR #174 simplified the existence check to only inspect the status code, so `EnsureEnrichPolicyAsync` incorrectly skipped policy creation — then the execute call hit a 404.

## How
Restore response-body validation in `EnsureEnrichPolicyAsync`: after a 200 response, verify the `policies` array is non-empty before assuming the policy already exists.

## Test plan
- `dotnet test` passes (76 unit tests)
- The existing mocks use `.SucceedAlways().ReturnResponse(new { })` (empty body), so the fix correctly falls through to the PUT path — matching real Elasticsearch behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)