### PR TITLE
feat: optional _source filtering for PointInTimeSearch

### DIFF
--- a/src/Elastic.Ingest.Elasticsearch/Helpers/PointInTimeSearch.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/PointInTimeSearch.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Channels;
@@ -212,28 +211,8 @@ public sealed class PointInTimeSearch<TDocument> : IAsyncDisposable
 			yield return page;
 	}
 
-	private string BuildSearchBody(string? searchAfter, int? sliceId, int? sliceMax)
-	{
-		var sb = new StringBuilder(256);
-		sb.Append("{\"pit\":{\"id\":\"").Append(EscapeJson(_pitId!)).Append("\",\"keep_alive\":\"").Append(_options.KeepAlive).Append("\"}");
-
-		sb.Append(",\"size\":").Append(_options.Size);
-
-		var sort = _options.Sort ?? "\"_shard_doc\"";
-		sb.Append(",\"sort\":[").Append(sort).Append(']');
-
-		if (_options.QueryBody != null)
-			sb.Append(",\"query\":").Append(_options.QueryBody);
-
-		if (searchAfter != null)
-			sb.Append(",\"search_after\":").Append(searchAfter);
-
-		if (sliceId.HasValue && sliceMax.HasValue)
-			sb.Append(",\"slice\":{\"id\":").Append(sliceId.Value).Append(",\"max\":").Append(sliceMax.Value).Append('}');
-
-		sb.Append('}');
-		return sb.ToString();
-	}
+	private string BuildSearchBody(string? searchAfter, int? sliceId, int? sliceMax) =>
+		PointInTimeSearchRequestBuilder.BuildSearchBody(_pitId!, _options, searchAfter, sliceId, sliceMax);
 
 	[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Callers provide JsonSerializerOptions with appropriate context")]
 	[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "Callers provide JsonSerializerOptions with appropriate context")]

--- a/src/Elastic.Ingest.Elasticsearch/Helpers/PointInTimeSearchOptions.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/PointInTimeSearchOptions.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Generic;
 using Elastic.Mapping;
 
 namespace Elastic.Ingest.Elasticsearch.Helpers;
@@ -34,4 +35,28 @@ public class PointInTimeSearchOptions
 	/// 0 or 1 = no slicing.
 	/// </summary>
 	public int? Slices { get; init; }
+
+	/// <summary>
+	/// Field names to include in each hit’s <c>_source</c>, matching Elasticsearch’s
+	/// <c>_source.includes</c> filtering. When null or empty and <see cref="SourceExcludes"/> is also
+	/// unset or empty, no <c>_source</c> clause is sent and the full stored source is returned.
+	/// </summary>
+	/// <remarks>
+	/// Responses may contain only a subset of JSON properties; <see cref="PointInTimeSearch{TDocument}"/>
+	/// still deserializes each hit’s <c>_source</c> into the document type using
+	/// <see cref="System.Text.Json.JsonSerializer"/>, so members missing from the JSON remain at their
+	/// default values. Use a narrower document type or <see cref="System.Text.Json.JsonElement"/> when
+	/// you only map a few fields.
+	/// </remarks>
+	public IReadOnlyList<string>? SourceIncludes { get; init; }
+
+	/// <summary>
+	/// Field names to exclude from each hit’s <c>_source</c>, matching Elasticsearch’s
+	/// <c>_source.excludes</c> filtering. When null or empty and <see cref="SourceIncludes"/> is also
+	/// unset or empty, no <c>_source</c> clause is sent.
+	/// </summary>
+	/// <remarks>
+	/// See <see cref="SourceIncludes"/> for how partial <c>_source</c> JSON interacts with deserialization.
+	/// </remarks>
+	public IReadOnlyList<string>? SourceExcludes { get; init; }
 }

--- a/src/Elastic.Ingest.Elasticsearch/Helpers/PointInTimeSearchRequestBuilder.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/PointInTimeSearchRequestBuilder.cs
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elastic.Ingest.Elasticsearch.Helpers;
+
+/// <summary>
+/// Builds the JSON body for PIT-based <c>POST /_search</c> requests.
+/// <see cref="PointInTimeSearch{TDocument}"/> uses this; call directly only for custom transports or tests.
+/// </summary>
+public static class PointInTimeSearchRequestBuilder
+{
+	/// <summary>
+	/// Serializes the search request body (PIT, pagination, optional query, slice, and optional <c>_source</c> filter).
+	/// </summary>
+	public static string BuildSearchBody(string pitId, PointInTimeSearchOptions options, string? searchAfter, int? sliceId, int? sliceMax)
+	{
+		var sb = new StringBuilder(256);
+		sb.Append("{\"pit\":{\"id\":\"").Append(EscapeJson(pitId)).Append("\",\"keep_alive\":\"").Append(options.KeepAlive).Append("\"}");
+
+		sb.Append(",\"size\":").Append(options.Size);
+
+		var sort = options.Sort ?? "\"_shard_doc\"";
+		sb.Append(",\"sort\":[").Append(sort).Append(']');
+
+		if (options.QueryBody != null)
+			sb.Append(",\"query\":").Append(options.QueryBody);
+
+		if (searchAfter != null)
+			sb.Append(",\"search_after\":").Append(searchAfter);
+
+		if (sliceId.HasValue && sliceMax.HasValue)
+			sb.Append(",\"slice\":{\"id\":").Append(sliceId.Value).Append(",\"max\":").Append(sliceMax.Value).Append('}');
+
+		AppendSourceFilter(sb, options);
+
+		sb.Append('}');
+		return sb.ToString();
+	}
+
+	private static string EscapeJson(string value) =>
+		value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+	private static void AppendSourceFilter(StringBuilder sb, PointInTimeSearchOptions options)
+	{
+		var hasIncludes = options.SourceIncludes is { Count: > 0 };
+		var hasExcludes = options.SourceExcludes is { Count: > 0 };
+		if (!hasIncludes && !hasExcludes)
+			return;
+
+		sb.Append(",\"_source\":{");
+		if (hasIncludes)
+		{
+			sb.Append("\"includes\":[");
+			AppendJsonStringArray(sb, options.SourceIncludes!);
+			sb.Append(']');
+		}
+		if (hasExcludes)
+		{
+			if (hasIncludes)
+				sb.Append(',');
+			sb.Append("\"excludes\":[");
+			AppendJsonStringArray(sb, options.SourceExcludes!);
+			sb.Append(']');
+		}
+		sb.Append('}');
+	}
+
+	private static void AppendJsonStringArray(StringBuilder sb, IReadOnlyList<string> items)
+	{
+		for (var i = 0; i < items.Count; i++)
+		{
+			if (i > 0)
+				sb.Append(',');
+			sb.Append('"').Append(EscapeJson(items[i])).Append('"');
+		}
+	}
+}

--- a/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/Helpers/PointInTimeSearchTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/Helpers/PointInTimeSearchTests.cs
@@ -42,6 +42,7 @@ namespace Elastic.Ingest.Elasticsearch.IntegrationTests.Helpers;
 public class PointInTimeSearchTests(IngestionCluster cluster) : IntegrationTestBase(cluster)
 {
 	private const string IndexName = "pit-test";
+	private static readonly string[] SkuPriceProjection = ["sku", "price"];
 
 	[Before(Test)]
 	public async Task Setup() => await CleanupPrefixAsync("pit-test");
@@ -113,6 +114,29 @@ public class PointInTimeSearchTests(IngestionCluster cluster) : IntegrationTestB
 			allDocs.Add(doc);
 
 		allDocs.Should().HaveCount(6, "prices 100, 105, 110, 115, 120, 125 match gte:100");
+	}
+
+	[Test]
+	public async Task SourceIncludesReturnsProjectedDocuments()
+	{
+		await SeedDocuments(5);
+
+		await using var pit = new PointInTimeSearch<ProductCatalog>(
+			Transport,
+			new PointInTimeSearchOptions
+			{
+				Index = IndexName,
+				Size = 10,
+				KeepAlive = "1m",
+				SourceIncludes = SkuPriceProjection
+			});
+
+		var allDocs = new List<ProductCatalog>();
+		await foreach (var doc in pit.SearchDocumentsAsync())
+			allDocs.Add(doc);
+
+		allDocs.Should().HaveCount(5);
+		allDocs.Should().OnlyContain(d => d.Sku.StartsWith("PIT-", StringComparison.Ordinal) && d.Price > 0);
 	}
 
 	private async Task SeedDocuments(int count)

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/PointInTimeSearchRequestBuilderTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/PointInTimeSearchRequestBuilderTests.cs
@@ -1,0 +1,100 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using Elastic.Ingest.Elasticsearch.Helpers;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace Elastic.Ingest.Elasticsearch.Tests;
+
+public class PointInTimeSearchRequestBuilderTests
+{
+	[Test]
+	public void OmitsSourceWhenIncludesAndExcludesUnset()
+	{
+		var options = new PointInTimeSearchOptions();
+		var body = PointInTimeSearchRequestBuilder.BuildSearchBody("pit-1", options, searchAfter: null, sliceId: null, sliceMax: null);
+
+		body.Should().Be(
+			"""{"pit":{"id":"pit-1","keep_alive":"5m"},"size":1000,"sort":["_shard_doc"]}""");
+		body.Should().NotContain("_source");
+	}
+
+	[Test]
+	public void OmitsSourceWhenIncludesAndExcludesEmpty()
+	{
+		var options = new PointInTimeSearchOptions
+		{
+			SourceIncludes = Array.Empty<string>(),
+			SourceExcludes = Array.Empty<string>()
+		};
+		var body = PointInTimeSearchRequestBuilder.BuildSearchBody("p", options, null, null, null);
+
+		body.Should().NotContain("_source");
+	}
+
+	[Test]
+	public void IncludesOnlySourceFilter()
+	{
+		var options = new PointInTimeSearchOptions
+		{
+			SourceIncludes = new[] { "url", "hash", "last_updated" }
+		};
+		var body = PointInTimeSearchRequestBuilder.BuildSearchBody("p", options, null, null, null);
+
+		body.Should().EndWith(",\"_source\":{\"includes\":[\"url\",\"hash\",\"last_updated\"]}}");
+	}
+
+	[Test]
+	public void ExcludesOnlySourceFilter()
+	{
+		var options = new PointInTimeSearchOptions
+		{
+			SourceExcludes = new[] { "large_blob" }
+		};
+		var body = PointInTimeSearchRequestBuilder.BuildSearchBody("p", options, null, null, null);
+
+		body.Should().Contain(",\"_source\":{\"excludes\":[\"large_blob\"]}");
+	}
+
+	[Test]
+	public void IncludesAndExcludesSourceFilter()
+	{
+		var options = new PointInTimeSearchOptions
+		{
+			SourceIncludes = new[] { "a", "b" },
+			SourceExcludes = new[] { "c" }
+		};
+		var body = PointInTimeSearchRequestBuilder.BuildSearchBody("p", options, null, null, null);
+
+		body.Should().Contain(",\"_source\":{\"includes\":[\"a\",\"b\"],\"excludes\":[\"c\"]}");
+	}
+
+	[Test]
+	public void WithQuerySliceAndSourceProducesValidJson()
+	{
+		var options = new PointInTimeSearchOptions
+		{
+			QueryBody = """{"match_all":{}}""",
+			SourceIncludes = new[] { "sku" }
+		};
+		var body = PointInTimeSearchRequestBuilder.BuildSearchBody("p", options, searchAfter: "[100]", sliceId: 1, sliceMax: 4);
+
+		body.Should().Be(
+			"""{"pit":{"id":"p","keep_alive":"5m"},"size":1000,"sort":["_shard_doc"],"query":{"match_all":{}},"search_after":[100],"slice":{"id":1,"max":4},"_source":{"includes":["sku"]}}""");
+	}
+
+	[Test]
+	public void EscapesSpecialCharactersInFieldNames()
+	{
+		var options = new PointInTimeSearchOptions
+		{
+			SourceIncludes = new[] { """a"b""" }
+		};
+		var body = PointInTimeSearchRequestBuilder.BuildSearchBody("p", options, null, null, null);
+
+		body.Should().Contain("\"includes\":[\"a\\\"b\"]");
+	}
+}


### PR DESCRIPTION
## Summary

Adds optional `SourceIncludes` and `SourceExcludes` on `PointInTimeSearchOptions`, serialized to Elasticsearch’s `_source` object (`includes` / `excludes`). When both are null or empty, the generated `POST /_search` body is unchanged (no `_source` key).

## Why `IReadOnlyList<string>` instead of a raw JSON fragment

Typed field lists avoid double-encoding mistakes, align with the common projection use case, and map directly to `{"includes":[...],"excludes":[...]}`. Advanced cases (`_source: false`, etc.) can be considered later.

## `PointInTimeSearchRequestBuilder` is public

`Elastic.Ingest.Elasticsearch` is strong-named; `InternalsVisibleTo` the unsigned test project would require a `PublicKey` on the friend assembly. Exposing `PointInTimeSearchRequestBuilder.BuildSearchBody` documents that `PointInTimeSearch` uses it and lets unit tests assert JSON without a friend assembly.

## Tests

- Unit tests cover default body, empty lists, includes-only, excludes-only, combined filters, query + `search_after` + slice + source, and escaping of quotes in field names.
- Integration test: `SourceIncludes` for `sku` and `price` on `ProductCatalog`.

## Other consumers

- `ClientReindex`: unchanged API; set `Source`.`SourceIncludes` / `SourceExcludes` as needed.
- `AiEnrichmentOrchestrator` cleanup could optionally narrow `_source` in a follow-up.

Made with [Cursor](https://cursor.com)