### PR TITLE
fix(channels): drain completes when OutChannel has no buffers (zero writes)

### DIFF
--- a/src/Elastic.Channels/BufferedChannelBase.cs
+++ b/src/Elastic.Channels/BufferedChannelBase.cs
@@ -368,6 +368,13 @@ public abstract class BufferedChannelBase<TChannelOptions, TEvent, TResponse>
 			}
 		}
 		await Task.WhenAll(_taskList).ConfigureAwait(false);
+
+		// Empty outbound completion: if TryComplete ran with nothing ever written, OutChannel completes
+		// with no buffers — the inner TryRead loop never runs, so _outBoundChannelConsumed stays false
+		// and WaitForDrainAsync spins until RequestTimeout-scaled max wait with no elastic traffic.
+		if (!_outBoundChannelConsumed && InflightEvents == 0 && InflightExportOperations == 0)
+			_outBoundChannelConsumed = true;
+
 		_exitCancelSource.Cancel();
 		_callbacks.OutboundChannelExitedCallback?.Invoke();
 	}

--- a/tests/Elastic.Channels.Tests/BehaviorTests.cs
+++ b/tests/Elastic.Channels.Tests/BehaviorTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +15,19 @@ namespace Elastic.Channels.Tests;
 
 public class BehaviorTests
 {
+	[Test]
+	public async Task WaitForDrainWithNoWritesReturnsTrueQuickly()
+	{
+		var bufferOptions = new BufferOptions { InboundBufferMaxSize = 1000, OutboundBufferMaxSize = 100 };
+		using var channel = new NoopBufferedChannel(bufferOptions);
+		channel.TryComplete();
+		var sw = Stopwatch.StartNew();
+		var drained = await channel.WaitForDrainAsync(maxWait: TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+		sw.Stop();
+		drained.Should().BeTrue();
+		sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2));
+	}
+
 	[Test] public async Task RespectsPagination()
 	{
 		int totalEvents = 500_000, maxInFlight = totalEvents / 5, bufferSize = maxInFlight / 10;

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/IncrementalSyncOrchestratorTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/IncrementalSyncOrchestratorTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Mapping;
@@ -333,6 +334,19 @@ public class IncrementalSyncOrchestratorTests
 
 		var result = await orchestrator.CompleteAsync(drainMaxWait: TimeSpan.FromSeconds(10));
 		result.Should().BeTrue();
+	}
+
+	[Test]
+	public async Task CompleteAsyncWithNoWritesReturnsTrueQuickly()
+	{
+		using var orchestrator = CreateSimpleOrchestrator(Transport);
+		await orchestrator.StartAsync(BootstrapMethod.Silent);
+		orchestrator.Strategy.Should().Be(IngestSyncStrategy.Multiplex);
+		var sw = Stopwatch.StartNew();
+		var result = await orchestrator.CompleteAsync(drainMaxWait: TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+		sw.Stop();
+		result.Should().BeTrue();
+		sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(8));
 	}
 
 	[Test]


### PR DESCRIPTION
## Problem
If nothing is ever written, `OutChannel` completes without any `TryRead`, so `_outBoundChannelConsumed` stayed false. `WaitForDrainAsync` then spun until a RequestTimeout-scaled wait even though there was no bulk/export work—matching finalize with zero indexed docs and no HTTP in a proxy.

## Change
After `Task.WhenAll(_taskList)`, if there were no outbound buffers consumed yet and `InflightEvents` / `InflightExportOperations` are both zero, set `_outBoundChannelConsumed = true`.

## Tests
- `WaitForDrainWithNoWritesReturnsTrueQuickly` (NoopBufferedChannel: `TryComplete` only)
- `CompleteAsyncWithNoWritesReturnsTrueQuickly` (IncrementalSyncOrchestrator: `StartAsync`, no `TryWrite`, `CompleteAsync`)

Made with [Cursor](https://cursor.com)