### PR TITLE
fix(enrichment): handle concurrent enrich policy creation race condition

### DIFF
--- a/src/Elastic.Ingest.Elasticsearch/Enrichment/AiEnrichmentOrchestrator.Initialization.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Enrichment/AiEnrichmentOrchestrator.Initialization.cs
@@ -46,6 +46,11 @@ public partial class AiEnrichmentOrchestrator
 			HttpMethod.PUT, $"_enrich/policy/{_versionedPolicyName}",
 			PostData.String(_infra.EnrichPolicyBody), cancellationToken: ct).ConfigureAwait(false);
 
+		// A 400 "already exists" means a concurrent instance created the policy between our GET and PUT.
+		if (put.ApiCallDetails.HttpStatusCode is 400
+			&& put.Body?.Contains("resource_already_exists_exception") == true)
+			return false;
+
 		if (put.ApiCallDetails.HttpStatusCode is not (200 or 201))
 			throw new Exception(
 				$"Failed to create enrich policy '{_versionedPolicyName}': " +


### PR DESCRIPTION
## What

Handle `HTTP 400 resource_already_exists_exception` from `PUT _enrich/policy/<name>` gracefully instead of throwing, so concurrent `InitializeAsync` calls don't crash.

## Root cause investigation

### The triggering regression

Commit `9c82cc9` (Fix 404 on enrich policy execute, #175) correctly fixed a case where `GET _enrich/policy/<name>` returns **HTTP 200 with an empty `policies` array** when the named policy doesn't exist (rather than 404). The fix added body validation to the existence check in `EnsureEnrichPolicyAsync`:

```csharp
// Before #175 — wrong: 200 with empty body was treated as "exists"
if (exists.ApiCallDetails.HttpStatusCode == 200)
    return false;

// After #175 — correct for the 404 case, but exposed a race window
if (exists.ApiCallDetails.HttpStatusCode == 200
    && exists.Body is JsonObject root
    && root["policies"]?.AsArray() is { Count: > 0 })
    return false;
```

### The race condition

With the stricter check in place, the window between GET and PUT is now reachable by two concurrent instances:

1. Worker A: GET → 200 + empty `policies[]` → falls through to PUT
2. Worker B: GET → 200 + empty `policies[]` → falls through to PUT (same window)
3. Worker A: PUT → 200 ✓ (policy created)
4. Worker B: PUT → **400 `resource_already_exists_exception`** → throws

```
System.Exception: Failed to create enrich policy 'site-public.semantic-prod-ai-cache-ai-policy-42889376209b38f2':
HTTP 400 — {"error":{"root_cause":[{"type":"resource_already_exists_exception",
"reason":"policy [...] already exists"}]...},"status":400}
```

This is exactly what surfaced in [essc CI](https://github.com/elastic/docs-internal-workflows/actions/runs/25724633312/job/75534129297) after upgrading to the latest ingest-dotnet release that included #175.

### Why parallel workers hit this

`InitializeAsync` is called as a pre-bootstrap task. In a multi-worker deployment (or parallel CI jobs sharing the same Elasticsearch cluster), multiple instances race through the same initialization path.

## Fix

Catch the `resource_already_exists_exception` 400 from the PUT and return `false` (policy already exists — no new policy to clean stale ones up for). The policy is now present, which is the desired postcondition:

```csharp
// A 400 "already exists" means a concurrent instance created the policy between our GET and PUT.
if (put.ApiCallDetails.HttpStatusCode is 400
    && put.Body?.Contains("resource_already_exists_exception") == true)
    return false;
```

## Test plan

- [ ] Existing unit and integration tests pass (`dotnet test`)
- [ ] The fix is consistent with the same pattern used in `CleanupStalePoliciesAsync` (best-effort, non-throwing on concurrent state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)