### PR TITLE
feat: ISyncOrchestrator<TEvent> — common interface for orchestrator interchangeability

### DIFF
--- a/src/Elastic.Ingest.Elasticsearch/DeltaOrchestratorContext.cs
+++ b/src/Elastic.Ingest.Elasticsearch/DeltaOrchestratorContext.cs
@@ -44,7 +44,7 @@ public class RolloverBackfillProgress
 /// Context returned by <see cref="DeltaSyncOrchestrator{TEvent}.StartAsync"/> and passed
 /// to <see cref="DeltaSyncOrchestrator{TEvent}.OnPostComplete"/> hooks.
 /// </summary>
-public class DeltaOrchestratorContext<TEvent> where TEvent : class
+public class DeltaOrchestratorContext<TEvent> : ISyncOrchestratorContext where TEvent : class
 {
 	/// <summary>The resolved ingest strategy (Reindex or Multiplex). Diagnostic; auto-resolved.</summary>
 	public IngestSyncStrategy Strategy { get; init; }
@@ -58,10 +58,10 @@ public class DeltaOrchestratorContext<TEvent> where TEvent : class
 	/// <summary>The resolved secondary write alias.</summary>
 	public string SecondaryWriteAlias { get; init; } = null!;
 
-	/// <summary>The resolved primary read target.</summary>
+	/// <summary>The resolved primary read target (read alias or fallback to write alias).</summary>
 	public string PrimaryReadAlias { get; init; } = null!;
 
-	/// <summary>The resolved secondary read target.</summary>
+	/// <summary>The resolved secondary read target (read alias or fallback to write alias).</summary>
 	public string SecondaryReadAlias { get; init; } = null!;
 
 	/// <summary>Rollover decision details for the primary index.</summary>

--- a/src/Elastic.Ingest.Elasticsearch/DeltaSyncOrchestrator.cs
+++ b/src/Elastic.Ingest.Elasticsearch/DeltaSyncOrchestrator.cs
@@ -34,7 +34,7 @@ namespace Elastic.Ingest.Elasticsearch;
 /// noop when no rollover occurred.
 /// </para>
 /// </summary>
-public class DeltaSyncOrchestrator<TEvent> : IBufferedChannel<TEvent>, IDisposable
+public class DeltaSyncOrchestrator<TEvent> : ISyncOrchestrator<TEvent>
 	where TEvent : class
 {
 	private readonly ITransport _transport;
@@ -148,7 +148,7 @@ public class DeltaSyncOrchestrator<TEvent> : IBufferedChannel<TEvent>, IDisposab
 	/// <summary>
 	/// Adds a task that runs before channel bootstrap (e.g., creating synonym sets or query rules).
 	/// </summary>
-	public DeltaSyncOrchestrator<TEvent> AddPreBootstrapTask(
+	public ISyncOrchestrator<TEvent> AddPreBootstrapTask(
 		Func<ITransport, CancellationToken, Task> task)
 	{
 		_preBootstrapTasks.Add(task);
@@ -162,7 +162,7 @@ public class DeltaSyncOrchestrator<TEvent> : IBufferedChannel<TEvent>, IDisposab
 	/// completed (via <see cref="BackfillRolledOverIndicesAsync"/>) before calling
 	/// <see cref="TryWrite"/>.
 	/// </summary>
-	public async Task<DeltaOrchestratorContext<TEvent>> StartAsync(
+	public async Task<ISyncOrchestratorContext> StartAsync(
 		BootstrapMethod method, CancellationToken ctx = default)
 	{
 		foreach (var task in _preBootstrapTasks)

--- a/src/Elastic.Ingest.Elasticsearch/ISyncOrchestrator.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ISyncOrchestrator.cs
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Channels;
+using Elastic.Transport;
+
+namespace Elastic.Ingest.Elasticsearch;
+
+/// <summary>
+/// Common context returned by <see cref="ISyncOrchestrator{TEvent}.StartAsync"/>.
+/// Concrete orchestrators return a richer subtype; callers using the interface
+/// receive this view.
+/// </summary>
+public interface ISyncOrchestratorContext
+{
+	/// <summary> The resolved ingest strategy (Reindex or Multiplex). </summary>
+	IngestSyncStrategy Strategy { get; }
+
+	/// <summary> The batch timestamp stamped on every document in this run. </summary>
+	DateTimeOffset BatchTimestamp { get; }
+
+	/// <summary> The resolved primary write alias. </summary>
+	string PrimaryWriteAlias { get; }
+
+	/// <summary> The resolved secondary write alias. </summary>
+	string SecondaryWriteAlias { get; }
+
+	/// <summary> The resolved primary read target (read alias or fallback to write alias). </summary>
+	string PrimaryReadAlias { get; }
+
+	/// <summary> The resolved secondary read target (read alias or fallback to write alias). </summary>
+	string SecondaryReadAlias { get; }
+
+	/// <summary> Rollover decision details for the primary index. </summary>
+	IndexRolloverInfo? PrimaryRollover { get; }
+
+	/// <summary> Rollover decision details for the secondary index. </summary>
+	IndexRolloverInfo? SecondaryRollover { get; }
+}
+
+/// <summary>
+/// Shared lifecycle interface for orchestrators that synchronise a document type
+/// across a primary and secondary Elasticsearch index pair.
+/// <para>
+/// Callers that need to work with either <see cref="IncrementalSyncOrchestrator{TEvent}"/>
+/// or <see cref="DeltaSyncOrchestrator{TEvent}"/> interchangeably should target this
+/// interface. Orchestrator-specific setup (e.g.
+/// <c>DeltaSyncOrchestrator.BackfillRolledOverIndicesAsync</c>) is performed against
+/// the concrete type before handing off to code that targets this interface.
+/// </para>
+/// </summary>
+public interface ISyncOrchestrator<TEvent> : IBufferedChannel<TEvent>, IDisposable
+	where TEvent : class
+{
+	/// <summary>
+	/// Creates channels, runs bootstrap, and resolves the ingest strategy.
+	/// Must be called before <see cref="IBufferedChannel{TEvent}.TryWrite"/> or
+	/// <see cref="CompleteAsync"/>.
+	/// </summary>
+	Task<ISyncOrchestratorContext> StartAsync(BootstrapMethod method, CancellationToken ctx = default);
+
+	/// <summary>
+	/// Drains buffered writes, propagates changes to the secondary index, and applies
+	/// alias updates. The exact completion steps differ per implementation:
+	/// <see cref="IncrementalSyncOrchestrator{TEvent}"/> reaps stale documents;
+	/// <see cref="DeltaSyncOrchestrator{TEvent}"/> does not.
+	/// </summary>
+	Task<bool> CompleteAsync(TimeSpan? drainMaxWait = null, CancellationToken ctx = default);
+
+	/// <summary>
+	/// Registers a task that runs before channel bootstrap (e.g. creating synonym sets).
+	/// Returns <c>this</c> for chaining.
+	/// </summary>
+	ISyncOrchestrator<TEvent> AddPreBootstrapTask(Func<ITransport, CancellationToken, Task> task);
+
+	/// <summary> The batch timestamp assigned when the orchestrator was created. </summary>
+	DateTimeOffset BatchTimestamp { get; }
+
+	/// <summary> The resolved ingest strategy after <see cref="StartAsync"/> completes. </summary>
+	IngestSyncStrategy Strategy { get; }
+}

--- a/src/Elastic.Ingest.Elasticsearch/IncrementalSyncOrchestrator.cs
+++ b/src/Elastic.Ingest.Elasticsearch/IncrementalSyncOrchestrator.cs
@@ -30,7 +30,7 @@ public record IndexRolloverInfo(string Label, string LocalHash, string RemoteHas
 /// Context returned by <see cref="IncrementalSyncOrchestrator{TEvent}.StartAsync"/> and passed
 /// to <see cref="IncrementalSyncOrchestrator{TEvent}.OnPostComplete"/> hooks.
 /// </summary>
-public class OrchestratorContext<TEvent> where TEvent : class
+public class OrchestratorContext<TEvent> : ISyncOrchestratorContext where TEvent : class
 {
 	/// <summary> The resolved ingest strategy (Reindex or Multiplex). </summary>
 	public IngestSyncStrategy Strategy { get; init; }
@@ -65,7 +65,7 @@ public class OrchestratorContext<TEvent> where TEvent : class
 /// has changed, a new backing index is created and all data is reindexed from primary.
 /// Multiplex (write to both) is only used when creating entirely new backing indices.
 /// </summary>
-public class IncrementalSyncOrchestrator<TEvent> : IBufferedChannel<TEvent>, IDisposable
+public class IncrementalSyncOrchestrator<TEvent> : ISyncOrchestrator<TEvent>
 	where TEvent : class
 {
 	private readonly ITransport _transport;
@@ -170,7 +170,7 @@ public class IncrementalSyncOrchestrator<TEvent> : IBufferedChannel<TEvent>, IDi
 	/// <summary>
 	/// Adds a task that runs before channel bootstrap (e.g., creating synonym sets or query rules).
 	/// </summary>
-	public IncrementalSyncOrchestrator<TEvent> AddPreBootstrapTask(
+	public ISyncOrchestrator<TEvent> AddPreBootstrapTask(
 		Func<ITransport, CancellationToken, Task> task)
 	{
 		_preBootstrapTasks.Add(task);
@@ -184,7 +184,7 @@ public class IncrementalSyncOrchestrator<TEvent> : IBufferedChannel<TEvent>, IDi
 	/// hash changed, a new backing index is created and all data is reindexed from primary.
 	/// Multiplex (write to both) is only used when creating entirely new backing indices.
 	/// </summary>
-	public async Task<OrchestratorContext<TEvent>> StartAsync(BootstrapMethod method, CancellationToken ctx = default)
+	public async Task<ISyncOrchestratorContext> StartAsync(BootstrapMethod method, CancellationToken ctx = default)
 	{
 		// 1. Run pre-bootstrap tasks
 		foreach (var task in _preBootstrapTasks)
@@ -453,6 +453,8 @@ public class IncrementalSyncOrchestrator<TEvent> : IBufferedChannel<TEvent>, IDi
 		_secondaryChannel?.Dispose();
 		GC.SuppressFinalize(this);
 	}
+
+	// ── Private helpers ───────────────────────────────────────────────────
 
 	private void StampDocument(TEvent item)
 	{

--- a/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/Orchestration/IncrementalToDeltaHandoffTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.IntegrationTests/Orchestration/IncrementalToDeltaHandoffTests.cs
@@ -95,7 +95,7 @@ public class IncrementalToDeltaHandoffTests(IngestionCluster cluster)
 			TestMappingContext.HashableArticleDeltaPrimary,
 			TestMappingContext.HashableArticleDeltaSecondary))
 		{
-			var ctx2 = await orch2.StartAsync(BootstrapMethod.Failure);
+			var ctx2 = (DeltaOrchestratorContext<HashableArticle>)await orch2.StartAsync(BootstrapMethod.Failure);
 			ctx2.Strategy.Should().Be(IngestSyncStrategy.Reindex,
 				"Phase 2: secondary already exists + no mapping change → Reindex");
 			ctx2.PendingRolloverBackfills.Should().BeEmpty(
@@ -142,7 +142,7 @@ public class IncrementalToDeltaHandoffTests(IngestionCluster cluster)
 			TestMappingContext.HashableArticleV2DeltaPrimaryV2,
 			TestMappingContext.HashableArticleV2DeltaSecondaryV2))
 		{
-			var ctx3 = await orch3.StartAsync(BootstrapMethod.Failure);
+			var ctx3 = (DeltaOrchestratorContext<HashableArticleV2>)await orch3.StartAsync(BootstrapMethod.Failure);
 			ctx3.PendingRolloverBackfills.Should().NotBeEmpty(
 				"V2 mapping hash differs from V1 → at least one index rolled over → backfill required");
 			ctx3.PendingRolloverBackfills.Should().OnlyContain(

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/DeltaSyncOrchestratorTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/DeltaSyncOrchestratorTests.cs
@@ -137,8 +137,10 @@ public class DeltaSyncOrchestratorTests
 			CreateBatchContext("delta-primary"),
 			CreateBatchContext("delta-secondary"));
 
-		await orchestrator.StartAsync(BootstrapMethod.Silent);
-		// PendingRolloverBackfills is on the concrete context — verify indirectly via the guard
+		var ctx = (DeltaOrchestratorContext<TestDocument>)await orchestrator.StartAsync(BootstrapMethod.Silent);
+		ctx.PendingRolloverBackfills.Should().NotBeEmpty(
+			"_cat returned a previous index so rollover should be detected");
+
 		var act = () => orchestrator.TryWrite(new TestDocument { Timestamp = DateTimeOffset.UtcNow });
 		act.Should().Throw<InvalidOperationException>()
 			.WithMessage("*BackfillRolledOverIndicesAsync*");
@@ -152,7 +154,8 @@ public class DeltaSyncOrchestratorTests
 			CreateBatchContext("delta-primary"),
 			CreateBatchContext("delta-secondary"));
 
-		await orchestrator.StartAsync(BootstrapMethod.Silent);
+		var ctx = (DeltaOrchestratorContext<TestDocument>)await orchestrator.StartAsync(BootstrapMethod.Silent);
+		ctx.PendingRolloverBackfills.Should().NotBeEmpty();
 
 		var act = async () => await orchestrator.WaitToWriteAsync(new TestDocument { Timestamp = DateTimeOffset.UtcNow });
 		await act.Should().ThrowAsync<InvalidOperationException>()

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/DeltaSyncOrchestratorTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/DeltaSyncOrchestratorTests.cs
@@ -137,10 +137,8 @@ public class DeltaSyncOrchestratorTests
 			CreateBatchContext("delta-primary"),
 			CreateBatchContext("delta-secondary"));
 
-		var ctx = await orchestrator.StartAsync(BootstrapMethod.Silent);
-		ctx.PendingRolloverBackfills.Should().NotBeEmpty(
-			"_cat returned a previous index so rollover should be detected");
-
+		await orchestrator.StartAsync(BootstrapMethod.Silent);
+		// PendingRolloverBackfills is on the concrete context — verify indirectly via the guard
 		var act = () => orchestrator.TryWrite(new TestDocument { Timestamp = DateTimeOffset.UtcNow });
 		act.Should().Throw<InvalidOperationException>()
 			.WithMessage("*BackfillRolledOverIndicesAsync*");
@@ -154,8 +152,7 @@ public class DeltaSyncOrchestratorTests
 			CreateBatchContext("delta-primary"),
 			CreateBatchContext("delta-secondary"));
 
-		var ctx = await orchestrator.StartAsync(BootstrapMethod.Silent);
-		ctx.PendingRolloverBackfills.Should().NotBeEmpty();
+		await orchestrator.StartAsync(BootstrapMethod.Silent);
 
 		var act = async () => await orchestrator.WaitToWriteAsync(new TestDocument { Timestamp = DateTimeOffset.UtcNow });
 		await act.Should().ThrowAsync<InvalidOperationException>()


### PR DESCRIPTION
## What

Introduces `ISyncOrchestrator<TEvent>` and `ISyncOrchestratorContext`, a thin shared contract that both `IncrementalSyncOrchestrator` and `DeltaSyncOrchestrator` (added in #182) implement.

## Why

Code that drives the sync loop — iterating documents, calling `TryWrite`, calling `CompleteAsync` — is identical regardless of which orchestrator is in use. Without an interface, every such helper would need to be duplicated or would need to know the concrete type. With the interface, the common sync path can be written once and work with either.

## Design

The interface covers the shared lifecycle:

```
StartAsync(BootstrapMethod)
    ↓ returns ISyncOrchestratorContext
    
TryWrite / WaitToWriteAsync / TryWriteMany / WaitToWriteManyAsync
    (inherited from IBufferedChannel<TEvent>)

CompleteAsync(drainMaxWait?)

AddPreBootstrapTask(...)   ← fluent, returns ISyncOrchestrator<TEvent>
```

`BackfillRolledOverIndicesAsync` is deliberately **not** on the interface — it is specific to `DeltaSyncOrchestrator` and belongs in the delta-specific setup phase before handing off to interface-based sync code:

```csharp
// Delta-specific setup — uses concrete type
var orchestrator = new DeltaSyncOrchestrator<T>(transport, primary, secondary);
await orchestrator.StartAsync(BootstrapMethod.Failure);
await foreach (var p in orchestrator.BackfillRolledOverIndicesAsync()) { ... }

// Common sync path — targets the interface
ISyncOrchestrator<T> orch = orchestrator;
await RunSync(orch, documents);

// Works identically with snapshot mode
ISyncOrchestrator<T> orch = new IncrementalSyncOrchestrator<T>(transport, primary, secondary);
await RunSync(orch, documents);
```

### `ISyncOrchestratorContext`

`StartAsync` returns `ISyncOrchestratorContext`, which covers everything the common sync path needs: `Strategy`, `BatchTimestamp`, both write and read aliases, and both rollover decisions.

`PendingRolloverBackfills` (delta-specific) is not on the interface. Callers with the concrete `DeltaSyncOrchestrator` type can cast to `DeltaOrchestratorContext<T>` in the setup phase if they need it.

### No explicit interface implementations needed

Both `StartAsync` methods return `ISyncOrchestratorContext` directly — in an async method you can return any concrete type that implements the declared return type. `AddPreBootstrapTask` returns `ISyncOrchestrator<TEvent>` (the concrete class satisfies this). No boilerplate bridge methods required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)