### PR TITLE
feat(mapping): explicit AddField/AddProperty for dotted-path container intent

### DIFF
--- a/src/Elastic.Mapping.Generator/Analysis/AddPropertyFieldMisuseParser.cs
+++ b/src/Elastic.Mapping.Generator/Analysis/AddPropertyFieldMisuseParser.cs
@@ -1,0 +1,117 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Immutable;
+using Elastic.Mapping.Generator.Model;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Elastic.Mapping.Generator.Analysis;
+
+/// <summary>
+/// Walks the body of a <c>ConfigureMappings</c> method and reports misuse of
+/// <c>AddField</c> (used on an object/nested parent) or <c>AddProperty</c>
+/// (used on a leaf parent) where the parent type is statically known from model attributes.
+/// </summary>
+internal static class AddPropertyFieldMisuseParser
+{
+	// Methods we validate (user-facing only; generated AddPropertyField/AddFieldDirect are excluded)
+	private static readonly HashSet<string> ValidatedMethods = ["AddField", "AddProperty"];
+
+	/// <summary>
+	/// Parses a <c>ConfigureMappings</c> method and returns any misuse findings.
+	/// </summary>
+	/// <param name="method">The resolved method symbol for <c>ConfigureMappings</c>.</param>
+	/// <param name="fieldNameToType">
+	/// Map from Elasticsearch field name → Elasticsearch field type, derived from the document model's properties.
+	/// </param>
+	/// <param name="ct">Cancellation token.</param>
+	public static ImmutableArray<MappingMisuseFinding> Parse(
+		IMethodSymbol method,
+		IReadOnlyDictionary<string, string> fieldNameToType,
+		CancellationToken ct)
+	{
+		ct.ThrowIfCancellationRequested();
+
+		var syntaxRef = method.DeclaringSyntaxReferences.FirstOrDefault();
+		if (syntaxRef == null)
+			return ImmutableArray<MappingMisuseFinding>.Empty;
+
+		var methodSyntax = syntaxRef.GetSyntax(ct);
+		var findings = ImmutableArray.CreateBuilder<MappingMisuseFinding>();
+
+		foreach (var invocation in methodSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
+		{
+			ct.ThrowIfCancellationRequested();
+
+			if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+				continue;
+
+			var methodName = memberAccess.Name.Identifier.Text;
+			if (!ValidatedMethods.Contains(methodName))
+				continue;
+
+			var args = invocation.ArgumentList.Arguments;
+			if (args.Count < 1)
+				continue;
+
+			var firstArgExpr = args[0].Expression;
+			var pathLiteral = ExtractStringLiteral(firstArgExpr);
+
+			// Non-constant or non-dotted path → nothing to validate
+			if (pathLiteral == null || !pathLiteral.Contains('.'))
+				continue;
+
+			var dotIndex = pathLiteral.IndexOf('.');
+			var parentFieldName = pathLiteral.Substring(0, dotIndex);
+			var childSegment = pathLiteral.Substring(dotIndex + 1);
+
+			// Parent not in the model → cannot validate
+			if (!fieldNameToType.TryGetValue(parentFieldName, out var parentFieldType))
+				continue;
+
+			var isObjectLike = FieldTypes.IsObjectLike(parentFieldType);
+
+			string? diagnosticId = null;
+			if (methodName == "AddField" && isObjectLike)
+				diagnosticId = "EMAP001";
+			else if (methodName == "AddProperty" && !isObjectLike)
+				diagnosticId = "EMAP002";
+
+			if (diagnosticId == null)
+				continue;
+
+			var span = firstArgExpr.Span;
+			findings.Add(new MappingMisuseFinding(
+				diagnosticId,
+				parentFieldName,
+				pathLiteral,
+				childSegment,
+				parentFieldType,
+				syntaxRef.SyntaxTree.FilePath,
+				span.Start,
+				span.Length));
+		}
+
+		return findings.ToImmutable();
+	}
+
+	internal static string? ExtractStringLiteral(ExpressionSyntax expression)
+	{
+		// Simple string literal: "name"
+		if (expression is LiteralExpressionSyntax
+			{
+				RawKind: (int)Microsoft.CodeAnalysis.CSharp.SyntaxKind.StringLiteralExpression
+			} literal)
+			return literal.Token.ValueText;
+
+		// Interpolated string with no interpolations: $"name"
+		if (expression is InterpolatedStringExpressionSyntax interpolated &&
+			interpolated.Contents.Count == 1 &&
+			interpolated.Contents[0] is InterpolatedStringTextSyntax textContent)
+			return textContent.TextToken.ValueText;
+
+		return null;
+	}
+}

--- a/src/Elastic.Mapping.Generator/AnalyzerReleases.Unshipped.md
+++ b/src/Elastic.Mapping.Generator/AnalyzerReleases.Unshipped.md
@@ -3,3 +3,5 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 ELASTIC001 | Elastic.Mapping | Error | Only one [AiEnrichment<T>] is allowed per entity type across all mapping contexts.
+EMAP001 | Elastic.Mapping | Error | AddField used on an object/nested parent field; use AddProperty instead.
+EMAP002 | Elastic.Mapping | Error | AddProperty used on a leaf parent field; use AddField instead.

--- a/src/Elastic.Mapping.Generator/Diagnostics/MappingDiagnostics.cs
+++ b/src/Elastic.Mapping.Generator/Diagnostics/MappingDiagnostics.cs
@@ -1,0 +1,34 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Microsoft.CodeAnalysis;
+
+namespace Elastic.Mapping.Generator.Diagnostics;
+
+internal static class MappingDiagnostics
+{
+	/// <summary>
+	/// EMAP001: <c>AddField</c> used on a property whose type is object or nested.
+	/// The developer should use <c>AddProperty</c> instead.
+	/// </summary>
+	public static readonly DiagnosticDescriptor AddFieldOnObjectParent = new(
+		"EMAP001",
+		"Use AddProperty for object/nested sub-properties",
+		"'{0}' is an object/nested field. Use AddProperty(\"{1}\", ...) instead of AddField to add sub-property '{2}'.",
+		"Elastic.Mapping",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true);
+
+	/// <summary>
+	/// EMAP002: <c>AddProperty</c> used on a property whose type is a leaf (text, keyword, etc.).
+	/// The developer should use <c>AddField</c> instead.
+	/// </summary>
+	public static readonly DiagnosticDescriptor AddPropertyOnLeafParent = new(
+		"EMAP002",
+		"Use AddField for multi-fields on leaf fields",
+		"'{0}' is a '{3}' (leaf) field. Use AddField(\"{1}\", ...) instead of AddProperty to add multi-field '{2}'.",
+		"Elastic.Mapping",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true);
+}

--- a/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
+++ b/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
@@ -4,11 +4,13 @@
 
 using System.Collections.Immutable;
 using Elastic.Mapping.Generator.Analysis;
+using Elastic.Mapping.Generator.Diagnostics;
 using Elastic.Mapping.Generator.Emitters;
 using Elastic.Mapping.Generator.Model;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Elastic.Mapping.Generator;
 
@@ -514,6 +516,11 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		if (resolvedConfigClassName == null && entityImplementsInterface)
 			resolvedConfigClassName = targetType.ToDisplayString();
 
+		// --- Detect AddField/AddProperty misuse in ConfigureMappings ---
+		var misuseFindings = DetectMappingMisuse(
+			typeModel, targetType, contextConfigureMappings, configTypeSymbol,
+			configClassImplementsInterface, configClassMappings, entityImplementsInterface, ct);
+
 		return new TypeRegistration(
 			targetType.Name,
 			targetType.ToDisplayString(),
@@ -528,8 +535,74 @@ public class MappingSourceGenerator : IIncrementalGenerator
 			contextConfigureMappingsRef,
 			analysisComponents,
 			variant,
-			indexSettingsRef
+			indexSettingsRef,
+			misuseFindings
 		);
+	}
+
+	/// <summary>
+	/// Builds a field-name → field-type map from the top-level properties of the type model
+	/// and runs the misuse parser against the applicable ConfigureMappings method(s).
+	/// </summary>
+	private static ImmutableArray<MappingMisuseFinding> DetectMappingMisuse(
+		TypeMappingModel typeModel,
+		INamedTypeSymbol targetType,
+		IMethodSymbol? contextConfigureMappings,
+		INamedTypeSymbol? configTypeSymbol,
+		bool configClassImplementsInterface,
+		IMethodSymbol? configClassMappings,
+		bool entityImplementsInterface,
+		CancellationToken ct)
+	{
+		// Build the field-name → field-type map from known model properties.
+		var fieldNameToType = new Dictionary<string, string>(StringComparer.Ordinal);
+		foreach (var prop in typeModel.Properties)
+		{
+			if (!prop.IsIgnored)
+				fieldNameToType[prop.FieldName] = prop.FieldType;
+		}
+
+		if (fieldNameToType.Count == 0)
+			return ImmutableArray<MappingMisuseFinding>.Empty;
+
+		var allFindings = ImmutableArray.CreateBuilder<MappingMisuseFinding>();
+
+		// Context-level static method (Priority 1)
+		if (contextConfigureMappings != null)
+		{
+			allFindings.AddRange(AddPropertyFieldMisuseParser.Parse(contextConfigureMappings, fieldNameToType, ct));
+			return allFindings.ToImmutable();
+		}
+
+		// Configuration class via interface (Priority 2a)
+		if (configClassImplementsInterface && configTypeSymbol != null)
+		{
+			var method = configTypeSymbol.GetMembers("ConfigureMappings")
+				.OfType<IMethodSymbol>()
+				.FirstOrDefault(m => m.Parameters.Length == 1);
+			if (method != null)
+				allFindings.AddRange(AddPropertyFieldMisuseParser.Parse(method, fieldNameToType, ct));
+			return allFindings.ToImmutable();
+		}
+
+		// Configuration class legacy static method (Priority 2b)
+		if (configClassMappings != null)
+		{
+			allFindings.AddRange(AddPropertyFieldMisuseParser.Parse(configClassMappings, fieldNameToType, ct));
+			return allFindings.ToImmutable();
+		}
+
+		// Entity type via interface (Priority 3)
+		if (entityImplementsInterface)
+		{
+			var method = targetType.GetMembers("ConfigureMappings")
+				.OfType<IMethodSymbol>()
+				.FirstOrDefault(m => m.Parameters.Length == 1);
+			if (method != null)
+				allFindings.AddRange(AddPropertyFieldMisuseParser.Parse(method, fieldNameToType, ct));
+		}
+
+		return allFindings.ToImmutable();
 	}
 
 	private static AnalysisComponentsModel ParseAnalysisFromConfigureMethod(INamedTypeSymbol typeSymbol, CancellationToken ct)
@@ -580,6 +653,37 @@ public class MappingSourceGenerator : IIncrementalGenerator
 				else
 				{
 					aiEnrichmentTypes[docFqn] = model.ContextTypeName;
+				}
+			}
+		}
+
+		// Report EMAP001 / EMAP002: AddField/AddProperty misuse in ConfigureMappings
+		foreach (var model in models)
+		{
+			foreach (var reg in model.TypeRegistrations)
+			{
+				foreach (var finding in reg.MisuseFindings)
+				{
+					var descriptor = finding.DiagnosticId == "EMAP001"
+						? MappingDiagnostics.AddFieldOnObjectParent
+						: MappingDiagnostics.AddPropertyOnLeafParent;
+
+					// Reconstruct the source location from the serialised span so the IDE
+					// can point at the string-literal argument in the ConfigureMappings method.
+					var location = !string.IsNullOrEmpty(finding.FilePath)
+						? Location.Create(
+							finding.FilePath,
+							new TextSpan(finding.SpanStart, finding.SpanLength),
+							new LinePositionSpan())
+						: Location.None;
+
+					context.ReportDiagnostic(Diagnostic.Create(
+						descriptor,
+						location,
+						finding.ParentFieldName,
+						finding.FullPath,
+						finding.ChildSegment,
+						finding.ParentFieldType));
 				}
 			}
 		}

--- a/src/Elastic.Mapping.Generator/Model/ContextMappingModel.cs
+++ b/src/Elastic.Mapping.Generator/Model/ContextMappingModel.cs
@@ -38,7 +38,12 @@ internal sealed record TypeRegistration(
 	string? ContextConfigureMappingsReference,
 	AnalysisComponentsModel AnalysisComponents,
 	string? Variant = null,
-	string? IndexSettingsReference = null
+	string? IndexSettingsReference = null,
+	/// <summary>
+	/// Compile-time misuse findings for AddField/AddProperty in ConfigureMappings.
+	/// Reported as EMAP001 / EMAP002 diagnostics.
+	/// </summary>
+	ImmutableArray<MappingMisuseFinding> MisuseFindings = default
 )
 {
 	/// <summary>

--- a/src/Elastic.Mapping.Generator/Model/MappingMisuseFinding.cs
+++ b/src/Elastic.Mapping.Generator/Model/MappingMisuseFinding.cs
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Mapping.Generator.Model;
+
+/// <summary>
+/// An equatable (string/value-type only) record of a detected misuse of
+/// <c>AddField</c> or <c>AddProperty</c> inside a <c>ConfigureMappings</c> method.
+/// Carried through the incremental generator pipeline without breaking caching.
+/// </summary>
+internal sealed record MappingMisuseFinding(
+	/// <summary>Diagnostic ID: EMAP001 or EMAP002.</summary>
+	string DiagnosticId,
+	/// <summary>Parent field name (the first path segment).</summary>
+	string ParentFieldName,
+	/// <summary>Full dotted path as written in the source (e.g. "title.semantic_text").</summary>
+	string FullPath,
+	/// <summary>Leaf segment (e.g. "semantic_text").</summary>
+	string ChildSegment,
+	/// <summary>Elasticsearch field type of the parent (e.g. "text", "object").</summary>
+	string ParentFieldType,
+	/// <summary>Source file path for reconstructing the diagnostic location.</summary>
+	string FilePath,
+	/// <summary>Start offset of the string-literal argument in the source file.</summary>
+	int SpanStart,
+	/// <summary>Length of the string-literal argument in the source file.</summary>
+	int SpanLength
+);

--- a/src/Elastic.Mapping.Generator/Model/PropertyMappingModel.cs
+++ b/src/Elastic.Mapping.Generator/Model/PropertyMappingModel.cs
@@ -44,6 +44,9 @@ internal sealed record PropertyMappingModel(
 /// </summary>
 internal static class FieldTypes
 {
+	/// <summary>Returns true if the field type is object-like (object or nested).</summary>
+	public static bool IsObjectLike(string fieldType) =>
+		fieldType == Object || fieldType == Nested;
 	public const string Keyword = "keyword";
 	public const string Text = "text";
 	public const string Long = "long";

--- a/src/Elastic.Mapping/Mappings/FieldContainer.cs
+++ b/src/Elastic.Mapping/Mappings/FieldContainer.cs
@@ -1,0 +1,35 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Mapping.Mappings;
+
+/// <summary>
+/// Controls which container a dotted-path leaf field is merged into.
+/// </summary>
+public enum FieldContainer
+{
+	/// <summary>
+	/// Infer from the parent field's type: multi-field (<c>fields</c>) for leaf types (text, keyword, etc.),
+	/// sub-property (<c>properties</c>) for object/nested types.
+	/// Used by generated property methods and nested builders to preserve existing inference behaviour.
+	/// </summary>
+	Auto,
+
+	/// <summary>
+	/// Always place the leaf under the parent's <c>"fields"</c> (multi-field).
+	/// Only valid when the parent is a leaf type (text, keyword, date, etc.).
+	/// Throws at merge time if the parent is an object or nested type — use <see cref="Property"/> instead.
+	/// Throws if the parent is not defined at all (no base attribute and no sibling <c>AddField/AddProperty</c>
+	/// call for the parent path).
+	/// </summary>
+	Field,
+
+	/// <summary>
+	/// Always place the leaf under the parent's <c>"properties"</c> (sub-property).
+	/// Only valid when the parent is an object or nested type.
+	/// Throws at merge time if the parent is a leaf type — use <see cref="Field"/> instead.
+	/// Creates a new <c>type: object</c> parent when no parent is defined yet.
+	/// </summary>
+	Property
+}

--- a/src/Elastic.Mapping/Mappings/MappingOverrides.cs
+++ b/src/Elastic.Mapping/Mappings/MappingOverrides.cs
@@ -23,14 +23,19 @@ public sealed class MappingOverrides
 	/// <summary>The configured dynamic templates.</summary>
 	public IReadOnlyList<DynamicTemplateDefinition> DynamicTemplates { get; }
 
+	/// <summary>The container intent per field path (internal; not part of the public contract).</summary>
+	internal IReadOnlyDictionary<string, FieldContainer> FieldContainers { get; }
+
 	internal MappingOverrides(
 		IReadOnlyDictionary<string, IFieldDefinition> fields,
 		IReadOnlyDictionary<string, RuntimeFieldDefinition> runtimeFields,
-		IReadOnlyList<DynamicTemplateDefinition> dynamicTemplates)
+		IReadOnlyList<DynamicTemplateDefinition> dynamicTemplates,
+		IReadOnlyDictionary<string, FieldContainer>? fieldContainers = null)
 	{
 		Fields = fields;
 		RuntimeFields = runtimeFields;
 		DynamicTemplates = dynamicTemplates;
+		FieldContainers = fieldContainers ?? new Dictionary<string, FieldContainer>();
 	}
 
 	/// <summary>Returns true if any mapping overrides are configured.</summary>
@@ -42,6 +47,11 @@ public sealed class MappingOverrides
 	/// <summary>
 	/// Merges these mapping overrides into an existing mappings JSON string.
 	/// </summary>
+	/// <exception cref="InvalidOperationException">
+	/// Thrown when a field's <see cref="FieldContainer"/> intent contradicts the known parent type,
+	/// e.g. <see cref="FieldContainer.Field"/> on an object/nested parent, or
+	/// <see cref="FieldContainer.Property"/> on a leaf parent.
+	/// </exception>
 	public string MergeIntoMappings(string mappingsJson)
 	{
 		if (!HasConfiguration)
@@ -59,8 +69,13 @@ public sealed class MappingOverrides
 				node["properties"] = properties;
 			}
 
-			foreach (var kvp in Fields)
-				MergeFieldAtPath(properties, kvp.Key, kvp.Value);
+			// Sort by depth ascending so parent fields are always merged before their children,
+			// making explicit-intent merges order-independent regardless of declaration order.
+			foreach (var kvp in Fields.OrderBy(f => f.Key.Count(c => c == '.')))
+			{
+				var container = FieldContainers.TryGetValue(kvp.Key, out var c) ? c : FieldContainer.Auto;
+				MergeFieldAtPath(properties, kvp.Key, kvp.Value, container);
+			}
 		}
 
 		// Merge runtime fields
@@ -96,7 +111,7 @@ public sealed class MappingOverrides
 
 	private static readonly HashSet<string> ObjectTypes = ["object", "nested"];
 
-	private static void MergeFieldAtPath(JsonObject properties, string path, IFieldDefinition definition)
+	private static void MergeFieldAtPath(JsonObject properties, string path, IFieldDefinition definition, FieldContainer intent)
 	{
 		var parts = path.Split('.');
 		var current = properties;
@@ -105,28 +120,99 @@ public sealed class MappingOverrides
 		{
 			var part = parts[i];
 			var next = current[part]?.AsObject();
+			var isTerminalParent = i == parts.Length - 2;
 
 			if (next == null)
 			{
+				if (isTerminalParent && intent == FieldContainer.Field)
+				{
+					// Cannot attach a multi-field to a non-existent parent.
+					// Silently creating type:object would be wrong and reproduce the bug.
+					throw new InvalidOperationException(
+						$"Cannot add '{parts[parts.Length - 1]}' as a multi-field of '{string.Join(".", parts, 0, parts.Length - 1)}': " +
+						$"the parent field is not defined. " +
+						$"Define the parent field first, or use AddProperty(\"{path}\", ...) if you intended a sub-property.");
+				}
+
+				// Property intent or intermediate segment: create an object parent.
 				next = new JsonObject { ["type"] = "object" };
 				current[part] = next;
 			}
 
 			var parentType = next["type"]?.GetValue<string>();
-			var isLeafType = parentType != null && !ObjectTypes.Contains(parentType);
-			var containerKey = isLeafType ? "fields" : "properties";
+			var isObjectLike = parentType == null || ObjectTypes.Contains(parentType);
 
-			var container = next[containerKey]?.AsObject();
-			if (container == null)
+			if (isTerminalParent)
 			{
-				container = [];
-				next[containerKey] = container;
-			}
+				string containerKey;
+				switch (intent)
+				{
+					case FieldContainer.Field:
+						if (!isObjectLike)
+						{
+							// Leaf parent — correct for Field intent. Container = fields.
+							containerKey = "fields";
+						}
+						else if (parentType != null)
+						{
+							// Known object/nested — contradiction.
+							throw new InvalidOperationException(
+								$"Cannot add '{parts[parts.Length - 1]}' as a multi-field of '{string.Join(".", parts, 0, parts.Length - 1)}' " +
+								$"(type: {parentType}): object and nested fields use sub-properties. " +
+								$"Use AddProperty(\"{path}\", ...) instead.");
+						}
+						else
+						{
+							// Parent exists but type is null/unknown — fall back to properties to avoid corruption.
+							containerKey = "properties";
+						}
+						break;
 
-			current = container;
+					case FieldContainer.Property:
+						if (isObjectLike)
+						{
+							// Object/nested parent — correct for Property intent. Container = properties.
+							containerKey = "properties";
+						}
+						else
+						{
+							// Known leaf type — contradiction.
+							throw new InvalidOperationException(
+								$"Cannot add '{parts[parts.Length - 1]}' as a sub-property of '{string.Join(".", parts, 0, parts.Length - 1)}' " +
+								$"(type: {parentType}): leaf fields use multi-fields. " +
+								$"Use AddField(\"{path}\", ...) instead.");
+						}
+						break;
+
+					default: // Auto — preserve today's inference
+						containerKey = isObjectLike ? "properties" : "fields";
+						break;
+				}
+
+				var container = next[containerKey]?.AsObject();
+				if (container == null)
+				{
+					container = [];
+					next[containerKey] = container;
+				}
+				current = container;
+			}
+			else
+			{
+				// Intermediate segment: use Auto inference unconditionally.
+				var isLeafType = parentType != null && !ObjectTypes.Contains(parentType);
+				var containerKey = isLeafType ? "fields" : "properties";
+				var container = next[containerKey]?.AsObject();
+				if (container == null)
+				{
+					container = [];
+					next[containerKey] = container;
+				}
+				current = container;
+			}
 		}
 
-		var fieldName = parts[^1];
+		var fieldName = parts[parts.Length - 1];
 		var existing = current[fieldName]?.AsObject();
 		var newDef = definition.ToJson();
 

--- a/src/Elastic.Mapping/Mappings/MappingsBuilderBase.cs
+++ b/src/Elastic.Mapping/Mappings/MappingsBuilderBase.cs
@@ -15,21 +15,24 @@ namespace Elastic.Mapping.Mappings;
 /// <typeparam name="TSelf">The derived builder type.</typeparam>
 public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBase<TSelf>
 {
-	private readonly List<(string Path, IFieldDefinition Definition)> _fields = [];
+	private readonly List<(string Path, IFieldDefinition Definition, FieldContainer Container)> _fields = [];
 	private readonly List<(string Name, RuntimeFieldDefinition Definition)> _runtimeFields = [];
 	private readonly List<DynamicTemplateDefinition> _dynamicTemplates = [];
+
+	private TSelf AddFieldCore(string path, Func<FieldBuilder, FieldBuilder> configure, FieldContainer container)
+	{
+		var builder = new FieldBuilder();
+		_ = configure(builder);
+		_fields.Add((path, builder.GetDefinition(), container));
+		return (TSelf)this;
+	}
 
 	/// <summary>
 	/// Adds a field definition at the specified path.
 	/// Called by generated property methods.
 	/// </summary>
-	protected TSelf AddPropertyField(string path, Func<FieldBuilder, FieldBuilder> configure)
-	{
-		var builder = new FieldBuilder();
-		_ = configure(builder);
-		_fields.Add((path, builder.GetDefinition()));
-		return (TSelf)this;
-	}
+	protected TSelf AddPropertyField(string path, Func<FieldBuilder, FieldBuilder> configure) =>
+		AddFieldCore(path, configure, FieldContainer.Auto);
 
 	/// <summary>
 	/// Adds a field definition directly at the specified path.
@@ -37,7 +40,7 @@ public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBa
 	/// </summary>
 	protected TSelf AddFieldDirect(string path, IFieldDefinition definition)
 	{
-		_fields.Add((path, definition));
+		_fields.Add((path, definition, FieldContainer.Auto));
 		return (TSelf)this;
 	}
 
@@ -48,19 +51,29 @@ public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBa
 	protected void MergeNestedFields(IReadOnlyList<(string Path, IFieldDefinition Definition)> fields)
 	{
 		foreach (var (path, def) in fields)
-			_fields.Add((path, def));
+			_fields.Add((path, def, FieldContainer.Auto));
 	}
 
 	/// <summary>
-	/// Adds a field that is not a property on the model (e.g., copy_to target field).
+	/// Adds a multi-field under the parent field's <c>"fields"</c> container.
+	/// For dotted paths (e.g. <c>"title.semantic_text"</c>) the leaf is always placed in the
+	/// immediate parent's <c>fields</c> — the parent must be a leaf type (text, keyword, date, etc.).
+	/// Throws at build if the parent is an object or nested type; use <see cref="AddProperty"/> instead.
+	/// For single-segment paths the field is placed directly in the root <c>properties</c>.
 	/// </summary>
-	public TSelf AddField(string name, Func<FieldBuilder, FieldBuilder> configure)
-	{
-		var builder = new FieldBuilder();
-		_ = configure(builder);
-		_fields.Add((name, builder.GetDefinition()));
-		return (TSelf)this;
-	}
+	public TSelf AddField(string name, Func<FieldBuilder, FieldBuilder> configure) =>
+		AddFieldCore(name, configure, FieldContainer.Field);
+
+	/// <summary>
+	/// Adds a sub-property under the parent field's <c>"properties"</c> container.
+	/// For dotted paths (e.g. <c>"applies_to.type"</c>) the leaf is always placed in the
+	/// immediate parent's <c>properties</c> — the parent must be an object or nested type.
+	/// Throws at build if the parent is a leaf type; use <see cref="AddField"/> instead.
+	/// Creates a new <c>type: object</c> parent when no parent is defined yet.
+	/// For single-segment paths the field is placed directly in the root <c>properties</c>.
+	/// </summary>
+	public TSelf AddProperty(string name, Func<FieldBuilder, FieldBuilder> configure) =>
+		AddFieldCore(name, configure, FieldContainer.Property);
 
 	/// <summary>
 	/// Adds a runtime field definition.
@@ -99,13 +112,17 @@ public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBa
 	public MappingOverrides Build()
 	{
 		var fields = new Dictionary<string, IFieldDefinition>();
-		foreach (var (path, def) in _fields)
+		var containers = new Dictionary<string, FieldContainer>();
+		foreach (var (path, def, container) in _fields)
+		{
 			fields[path] = def;
+			containers[path] = container;
+		}
 
 		var runtimeFields = new Dictionary<string, RuntimeFieldDefinition>();
 		foreach (var (name, def) in _runtimeFields)
 			runtimeFields[name] = def;
 
-		return new(fields, runtimeFields, [.. _dynamicTemplates]);
+		return new(fields, runtimeFields, [.. _dynamicTemplates], containers);
 	}
 }

--- a/tests/Elastic.Mapping.Tests/MappingGeneratorTests.cs
+++ b/tests/Elastic.Mapping.Tests/MappingGeneratorTests.cs
@@ -368,4 +368,43 @@ public class MappingGeneratorTests
 		subProps.GetProperty("repository").GetProperty("type").GetString().Should().Be("keyword");
 		subProps.GetProperty("displayName").GetProperty("type").GetString().Should().Be("text");
 	}
+
+	// ----- ExplicitContainer tests: AddField / AddProperty through the generated pipeline -----
+
+	[Test]
+	public void ExplicitContainer_AddFieldOnText_UsesFields()
+	{
+		// title is [Text], ConfigureMappings uses AddField("title.semantic", ...).
+		// The leaf must land under title.fields, not title.properties.
+		var json = ExplicitContainerMappingContext.ExplicitContainerDocument.GetMappingJson();
+		using var doc = System.Text.Json.JsonDocument.Parse(json);
+		var props = doc.RootElement.GetProperty("properties");
+
+		var title = props.GetProperty("title");
+		title.GetProperty("type").GetString().Should().Be("text",
+			"base [Text] type must be preserved");
+		title.TryGetProperty("properties", out _).Should().BeFalse(
+			"leaf parent must not get a properties key");
+		var semantic = title.GetProperty("fields").GetProperty("semantic");
+		semantic.GetProperty("type").GetString().Should().Be("semantic_text");
+		semantic.GetProperty("inference_id").GetString().Should().Be("my-elser");
+	}
+
+	[Test]
+	public void ExplicitContainer_AddPropertyOnObject_UsesProperties()
+	{
+		// meta is [Object], ConfigureMappings uses AddProperty("meta.extra", ...).
+		// The leaf must land under meta.properties.
+		var json = ExplicitContainerMappingContext.ExplicitContainerDocument.GetMappingJson();
+		using var doc = System.Text.Json.JsonDocument.Parse(json);
+		var props = doc.RootElement.GetProperty("properties");
+
+		var meta = props.GetProperty("meta");
+		meta.GetProperty("type").GetString().Should().Be("object",
+			"base [Object] type must be preserved");
+		meta.TryGetProperty("fields", out _).Should().BeFalse(
+			"object parent must not get a fields key");
+		var extra = meta.GetProperty("properties").GetProperty("extra");
+		extra.GetProperty("type").GetString().Should().Be("keyword");
+	}
 }

--- a/tests/Elastic.Mapping.Tests/MappingsBuilderTests.cs
+++ b/tests/Elastic.Mapping.Tests/MappingsBuilderTests.cs
@@ -125,9 +125,10 @@ public class MappingsBuilderTests
 	[Test]
 	public void MappingsBuilder_DottedPath_ObjectParent_UsesProperties()
 	{
+		// AddField on a parent, then AddProperty for the child (object parent → properties).
 		var builder = new MappingsBuilder<LogEntry>()
 			.AddField("metadata", f => f.Object())
-			.AddField("metadata.inner", f => f.Keyword());
+			.AddProperty("metadata.inner", f => f.Keyword());
 
 		var overrides = builder.Build();
 		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
@@ -397,5 +398,221 @@ public class MappingsBuilderTests
 		var completion = doc.RootElement.GetProperty("properties").GetProperty("message")
 			.GetProperty("fields").GetProperty("completion");
 		completion.GetProperty("index_options").GetString().Should().Be("offsets");
+	}
+
+	// ----- Explicit AddField / AddProperty intent tests -----
+
+	[Test]
+	public void AddField_TextParent_LeafUnderFields()
+	{
+		// AddField on a text parent → leaf goes under "fields" (multi-field)
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("summary", f => f.Text().Analyzer("standard"))
+			.AddField("summary.semantic", f => f.SemanticText().InferenceId("my-elser"));
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var summary = doc.RootElement.GetProperty("properties").GetProperty("summary");
+		summary.GetProperty("type").GetString().Should().Be("text");
+		summary.TryGetProperty("properties", out _).Should().BeFalse("leaf parent must not get a properties key");
+		var semantic = summary.GetProperty("fields").GetProperty("semantic");
+		semantic.GetProperty("type").GetString().Should().Be("semantic_text");
+		semantic.GetProperty("inference_id").GetString().Should().Be("my-elser");
+	}
+
+	[Test]
+	public void AddField_KeywordParent_LeafUnderFields()
+	{
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("tag", f => f.Keyword())
+			.AddField("tag.text", f => f.Text().Analyzer("standard"));
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var tag = doc.RootElement.GetProperty("properties").GetProperty("tag");
+		tag.GetProperty("type").GetString().Should().Be("keyword");
+		tag.TryGetProperty("properties", out _).Should().BeFalse();
+		var text = tag.GetProperty("fields").GetProperty("text");
+		text.GetProperty("type").GetString().Should().Be("text");
+	}
+
+	[Test]
+	public void AddProperty_ObjectParent_LeafUnderProperties()
+	{
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("metadata", f => f.Object())
+			.AddProperty("metadata.extra", f => f.Keyword());
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var metadata = doc.RootElement.GetProperty("properties").GetProperty("metadata");
+		metadata.GetProperty("type").GetString().Should().Be("object");
+		metadata.TryGetProperty("fields", out _).Should().BeFalse("object parent must not get a fields key");
+		var extra = metadata.GetProperty("properties").GetProperty("extra");
+		extra.GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void AddField_ObjectParent_Throws()
+	{
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("metadata", f => f.Object())
+			.AddField("metadata.inner", f => f.Keyword());
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+
+		var act = () => overrides.MergeIntoMappings(baseMappings);
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*AddProperty*");
+	}
+
+	[Test]
+	public void AddProperty_LeafParent_Throws()
+	{
+		// message is a text field in the base mapping
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddProperty("message.sub", f => f.Keyword());
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+
+		var act = () => overrides.MergeIntoMappings(baseMappings);
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*AddField*");
+	}
+
+	[Test]
+	public void AddField_MissingParent_Throws()
+	{
+		// "ghost" is not defined anywhere — AddField requires the parent to exist
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("ghost.child", f => f.Keyword());
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+
+		var act = () => overrides.MergeIntoMappings(baseMappings);
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*parent field is not defined*");
+	}
+
+	[Test]
+	public void AddProperty_MissingParent_CreatesObjectParent()
+	{
+		// "ghost" is not defined — AddProperty creates it as object
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddProperty("ghost.child", f => f.Keyword());
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var ghost = doc.RootElement.GetProperty("properties").GetProperty("ghost");
+		ghost.GetProperty("type").GetString().Should().Be("object");
+		var child = ghost.GetProperty("properties").GetProperty("child");
+		child.GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void AddField_ChildBeforeParent_LeafUnderFieldsRegardlessOfOrder()
+	{
+		// The ordering trap: child declared first, parent second.
+		// The depth-first sort in MergeIntoMappings must make this order-independent.
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("title.semantic_text", f => f.SemanticText().InferenceId("my-elser"))
+			.AddField("title", f => f.Text());
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var title = doc.RootElement.GetProperty("properties").GetProperty("title");
+		title.GetProperty("type").GetString().Should().Be("text",
+			"parent type must be preserved regardless of declaration order");
+		title.TryGetProperty("properties", out _).Should().BeFalse(
+			"leaf parent must never get a properties key");
+		var semantic = title.GetProperty("fields").GetProperty("semantic_text");
+		semantic.GetProperty("type").GetString().Should().Be("semantic_text");
+	}
+
+	[Test]
+	public void AddProperty_ChildBeforeParent_LeafUnderPropertiesRegardlessOfOrder()
+	{
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddProperty("meta.inner", f => f.Keyword())
+			.AddField("meta", f => f.Object());
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var meta = doc.RootElement.GetProperty("properties").GetProperty("meta");
+		meta.GetProperty("type").GetString().Should().Be("object",
+			"parent type must be preserved regardless of declaration order");
+		meta.TryGetProperty("fields", out _).Should().BeFalse();
+		var inner = meta.GetProperty("properties").GetProperty("inner");
+		inner.GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void AddField_TopLevelSingleSegment_RootProperty()
+	{
+		// Single-segment path: intent is ignored; leaf goes to root properties
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("standalone", f => f.Keyword());
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var standalone = doc.RootElement.GetProperty("properties").GetProperty("standalone");
+		standalone.GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void AddProperty_TopLevelSingleSegment_RootProperty()
+	{
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddProperty("standalone2", f => f.Keyword());
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var standalone2 = doc.RootElement.GetProperty("properties").GetProperty("standalone2");
+		standalone2.GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void AddField_SamePathAddedTwice_LastWins()
+	{
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("summary", f => f.Text())
+			.AddField("summary.a", f => f.Keyword().IgnoreAbove(128))
+			.AddField("summary.a", f => f.Keyword().IgnoreAbove(512));
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var a = doc.RootElement.GetProperty("properties").GetProperty("summary")
+			.GetProperty("fields").GetProperty("a");
+		a.GetProperty("ignore_above").GetInt32().Should().Be(512, "last definition wins");
 	}
 }

--- a/tests/Elastic.Mapping.Tests/TestModels.cs
+++ b/tests/Elastic.Mapping.Tests/TestModels.cs
@@ -593,3 +593,42 @@ public class GapFixDocument : IConfigureElasticsearch<GapFixDocument>
 [ElasticsearchMappingContext]
 [Index<GapFixDocument>(Name = "gap-fix-test")]
 public static partial class GapFixMappingContext;
+
+// ============================================================================
+// EXPLICIT CONTAINER TEST MODEL
+// Exercises the new AddField (multi-field) / AddProperty (sub-property) API.
+// ============================================================================
+
+/// <summary>
+/// Document with an explicit [Text] field for AddField and an [Object] field for AddProperty,
+/// demonstrating that the explicit container intent is honoured through the generated pipeline.
+/// </summary>
+public class ExplicitContainerDocument : IConfigureElasticsearch<ExplicitContainerDocument>
+{
+	[Id]
+	[Keyword]
+	public string Id { get; set; } = string.Empty;
+
+	[Text]
+	[JsonPropertyName("title")]
+	public string Title { get; set; } = string.Empty;
+
+	[Object]
+	[JsonPropertyName("meta")]
+	public IndexedProduct? Meta { get; set; }
+
+	public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) => analysis;
+
+	public MappingsBuilder<ExplicitContainerDocument> ConfigureMappings(MappingsBuilder<ExplicitContainerDocument> mappings) =>
+		mappings
+			// title is [Text] (leaf) → AddField puts the child under fields
+			.AddField("title.semantic", f => f.SemanticText().InferenceId("my-elser"))
+			// meta is [Object] → AddProperty puts the child under properties
+			.AddProperty("meta.extra", f => f.Keyword());
+
+	public IReadOnlyDictionary<string, string>? IndexSettings => null;
+}
+
+[ElasticsearchMappingContext]
+[Index<ExplicitContainerDocument>(Name = "explicit-container-test")]
+public static partial class ExplicitContainerMappingContext;


### PR DESCRIPTION
## Summary

- Replaces implicit `fields`/`properties` inference in `AddField` with two explicit methods: `AddField` (always multi-field, leaf parent required) and `AddProperty` (always sub-property, creates object parent if missing)
- `MergeIntoMappings` now sorts by path depth before merging — parents always applied before children, making the order of `AddField`/`AddProperty` declarations irrelevant
- Adds compile-time diagnostics **EMAP001** and **EMAP002** that flag misuse (e.g. `AddField` on an `[Object]` parent) when the parent type is statically known from model attributes
- Generated callers (`AddPropertyField`, `AddFieldDirect`, `MergeNestedFields`) keep `Auto` inference — no change to source-generated API behaviour

## The trap being fixed

```csharp
// Before: silently picks "fields" vs "properties" based on parent type in base JSON.
// If the parent was defined only via AddField (no attribute), and the child happened
// to merge first, the child would auto-create an object parent and land under "properties"
// instead of "fields" — silent, order-dependent wrong result.
.AddField("title.semantic_text", f => f.SemanticText().InferenceId(JinaInferenceId))

// After: intent is explicit and validated.
.AddField("title.semantic_text", ...)    // title is [Text] → ok, lands under fields
.AddProperty("applies_to.type", ...)     // applies_to is [Nested] → ok, lands under properties
// Wrong usage → throws at merge time (runtime) and errors at build time (EMAP001/EMAP002)
```

## Test plan

- [ ] `dotnet run --project tests/Elastic.Mapping.Tests/` → 204 tests pass
- [ ] `dotnet build src/Elastic.Mapping.Generator/` → 0 errors (EMAP001/EMAP002 in `AnalyzerReleases.Unshipped.md`)
- [ ] Pattern A tests in `MappingsBuilderTests.cs` cover: Field/Property on leaf and object parents, throw cases, the ordering-trap regression, missing parent, single-segment, and last-write-wins dedup
- [ ] Pattern B tests in `MappingGeneratorTests.cs` cover `ExplicitContainerDocument` with `[Text]`+`AddField` and `[Object]`+`AddProperty` through the full generated pipeline
- [ ] `website-ai-search` migration: `SharedMappingConfig.cs` `AddPropertyField` → `AddField`; `DocumentationMappingConfig.cs` `applies_to.*`/`parents.*` → `AddProperty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)