### PR TITLE
feat(generator): emit inheritance-aware generic-constrained extension methods

### DIFF
--- a/src/Elastic.Mapping.Generator/Analysis/TypeAnalyzer.cs
+++ b/src/Elastic.Mapping.Generator/Analysis/TypeAnalyzer.cs
@@ -72,13 +72,83 @@ internal static class TypeAnalyzer
 		);
 	}
 
+	/// <summary>
+	/// Entry-point overload: walks the full base-type chain (most-derived first, up to <c>object</c>).
+	/// Properties declared on the registered type itself get <c>null</c> declaring-type fields;
+	/// properties from base types are stamped with the declaring type's identity.
+	/// </summary>
 	private static ImmutableArray<PropertyMappingModel> GetProperties(
 		INamedTypeSymbol typeSymbol,
 		StjContextConfig? stjConfig,
 		CancellationToken ct
-	) =>
-		GetProperties(typeSymbol, stjConfig, [], ct);
+	)
+	{
+		var builder = ImmutableArray.CreateBuilder<PropertyMappingModel>();
 
+		// Track names already added so most-derived-wins for overridden/shadowed properties.
+		var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
+
+		var currentType = typeSymbol;
+		while (currentType != null && currentType.SpecialType == SpecialType.None)
+		{
+			ct.ThrowIfCancellationRequested();
+
+			// Determine whether properties at this level are "own" (same as registered type) or inherited.
+			var isRegisteredType = SymbolEqualityComparer.Default.Equals(currentType, typeSymbol);
+
+			foreach (var member in currentType.GetMembers())
+			{
+				ct.ThrowIfCancellationRequested();
+
+				if (member is not IPropertySymbol property)
+					continue;
+
+				if (property.DeclaredAccessibility != Accessibility.Public)
+					continue;
+
+				if (property.IsStatic || property.IsIndexer)
+					continue;
+
+				if (IsConfigureElasticsearchProperty(property))
+					continue;
+
+				// IgnoreReadOnlyProperties: skip properties with no setter
+				if (stjConfig?.IgnoreReadOnlyProperties == true && property.SetMethod == null && !property.IsReadOnly)
+					continue;
+				if (stjConfig?.IgnoreReadOnlyProperties == true && property.IsReadOnly)
+					continue;
+
+				// Most-derived-wins: skip if a more-derived type already added this property name.
+				if (!seenPropertyNames.Add(property.Name))
+					continue;
+
+				var propModel = AnalyzeProperty(property, stjConfig, [], ct);
+				if (propModel == null)
+					continue;
+
+				// Stamp declaring-type identity for inherited properties.
+				if (!isRegisteredType)
+				{
+					propModel = propModel with
+					{
+						DeclaringTypeName = currentType.Name,
+						DeclaringTypeNamespace = currentType.ContainingNamespace?.ToDisplayString() ?? string.Empty,
+						DeclaringTypeFullyQualifiedName = currentType.ToDisplayString()
+					};
+				}
+
+				builder.Add(propModel);
+			}
+
+			currentType = currentType.BaseType;
+		}
+
+		return builder.ToImmutable();
+	}
+
+	/// <summary>
+	/// Internal overload used by nested/object-type analysis: single type only, no base traversal.
+	/// </summary>
 	private static ImmutableArray<PropertyMappingModel> GetProperties(
 		INamedTypeSymbol typeSymbol,
 		StjContextConfig? stjConfig,

--- a/src/Elastic.Mapping.Generator/Emitters/MappingsBuilderEmitter.cs
+++ b/src/Elastic.Mapping.Generator/Emitters/MappingsBuilderEmitter.cs
@@ -120,14 +120,16 @@ internal static class MappingsBuilderEmitter
 		var nestedBuilders = new List<(string PropertyName, string FieldName, NestedTypeModel NestedType)>();
 
 		sb.AppendLine($"/// <summary>Extension methods for configuring {resolverName} mappings on <see cref=\"{MappingsBuilderFqn}{{TDocument}}\"/>.</summary>");
-		sb.AppendLine($"public static class {extensionClassName}");
+		sb.AppendLine($"public static partial class {extensionClassName}");
 		sb.AppendLine("{");
 
-		var props = model.Properties.Where(p => !p.IsIgnored).ToList();
+		// Only emit closed extension methods for own properties (DeclaringTypeName == null).
+		// Base-type properties are emitted once globally as generic-constrained methods via EmitBaseExtensionsClass.
+		var props = model.Properties.Where(p => !p.IsIgnored && p.DeclaringTypeName == null).ToList();
 		for (var i = 0; i < props.Count; i++)
 		{
 			var prop = props[i];
-			EmitPropertyExtensionMethod(sb, builderType, prop);
+			EmitPropertyExtensionMethod(sb, builderType, prop, null, null);
 
 			if (prop.NestedType != null)
 				nestedBuilders.Add((prop.PropertyName, prop.FieldName, prop.NestedType));
@@ -155,15 +157,36 @@ internal static class MappingsBuilderEmitter
 		}
 	}
 
-	private static void EmitPropertyExtensionMethod(StringBuilder sb, string builderType, PropertyMappingModel prop)
+	/// <summary>
+	/// Emits a single property extension method.
+	/// When <paramref name="typeParam"/> is <c>null</c>, emits a closed method for the concrete type
+	/// (<c>builderType</c> is already the fully-typed e.g. <c>MappingsBuilder&lt;global::Foo&gt;</c>).
+	/// When <paramref name="typeParam"/> is set (e.g. <c>"TDoc"</c>), emits a generic-constrained method
+	/// with a <c>where TDoc : global::{constraintFqn}</c> constraint and uses
+	/// <c>MappingsBuilder&lt;TDoc&gt;</c> as both receiver and return type.
+	/// </summary>
+	private static void EmitPropertyExtensionMethod(
+		StringBuilder sb,
+		string builderType,
+		PropertyMappingModel prop,
+		string? typeParam,
+		string? constraintFqn
+	)
 	{
 		var inputBuilder = GetBuilderTypeForFieldType(prop.FieldType);
 		var factoryMethod = GetFactoryMethodForFieldType(prop.FieldType);
 
+		// For generic form: receiver/return is MappingsBuilder<TDoc> with constraint
+		var effectiveBuilderType = typeParam != null
+			? $"{MappingsBuilderFqn}<{typeParam}>"
+			: builderType;
+		var genericSuffix = typeParam != null ? $"<{typeParam}>" : string.Empty;
+		var constraintClause = typeParam != null ? $" where {typeParam} : global::{constraintFqn}" : string.Empty;
+
 		if (factoryMethod != null)
 		{
 			sb.AppendLine($"\t/// <summary>Configure the {prop.PropertyName} field (maps to \"{prop.FieldName}\").</summary>");
-			sb.AppendLine($"\tpublic static {builderType} {prop.PropertyName}(this {builderType} self, global::System.Func<{inputBuilder}, {FieldBuilderFqn}> configure)");
+			sb.AppendLine($"\tpublic static {effectiveBuilderType} {prop.PropertyName}{genericSuffix}(this {effectiveBuilderType} self, global::System.Func<{inputBuilder}, {FieldBuilderFqn}> configure){constraintClause}");
 			sb.AppendLine("\t{");
 			sb.AppendLine($"\t\tvar fb = new {FieldBuilderFqn}();");
 			sb.AppendLine($"\t\t_ = configure(fb.{factoryMethod}());");
@@ -174,7 +197,7 @@ internal static class MappingsBuilderEmitter
 		else
 		{
 			sb.AppendLine($"\t/// <summary>Configure the {prop.PropertyName} field (maps to \"{prop.FieldName}\").</summary>");
-			sb.AppendLine($"\tpublic static {builderType} {prop.PropertyName}(this {builderType} self, global::System.Func<{FieldBuilderFqn}, {FieldBuilderFqn}> configure)");
+			sb.AppendLine($"\tpublic static {effectiveBuilderType} {prop.PropertyName}{genericSuffix}(this {effectiveBuilderType} self, global::System.Func<{FieldBuilderFqn}, {FieldBuilderFqn}> configure){constraintClause}");
 			sb.AppendLine("\t{");
 			sb.AppendLine($"\t\tself.AddPropertyField(\"{prop.FieldName}\", configure);");
 			sb.AppendLine("\t\treturn self;");
@@ -268,5 +291,100 @@ internal static class MappingsBuilderEmitter
 			sb.AppendLine("\t\treturn this;");
 			sb.AppendLine("\t}");
 		}
+	}
+
+	/// <summary>
+	/// Emits a standalone file containing generic-constrained extension methods for all properties
+	/// declared on a single base type. This ensures that a shared generic helper
+	/// <c>MappingsBuilder&lt;T&gt; where T : BaseType</c> can call these methods on any derived type
+	/// without ambiguity (no CS0121), because the methods are emitted exactly once per declaring type.
+	/// </summary>
+	public static string EmitBaseExtensionsClass(
+		string emitNamespace,
+		string declaringTypeName,
+		string declaringTypeFullyQualifiedName,
+		IReadOnlyList<PropertyMappingModel> props,
+		HashSet<string> emittedNestedBuilders
+	)
+	{
+		var sb = new StringBuilder();
+
+		SharedEmitterHelpers.EmitHeader(sb);
+
+		// Nested builder classes from base types may already be compiled into a referenced assembly
+		// (e.g. the base type's project compiled them first). CS0436 is a harmless warning in that
+		// scenario — suppress it for the duration of this generated file.
+		sb.AppendLine("#pragma warning disable CS0436");
+		sb.AppendLine();
+
+		if (!string.IsNullOrEmpty(emitNamespace))
+		{
+			sb.AppendLine($"namespace {emitNamespace};");
+			sb.AppendLine();
+		}
+
+		const string typeParam = "TDoc";
+		var extensionClassName = $"{declaringTypeName}MappingsExtensions";
+
+		var nestedBuilders = new List<(string PropertyName, string FieldName, NestedTypeModel NestedType)>();
+
+		sb.AppendLine($"/// <summary>Generic-constrained extension methods for configuring {declaringTypeName} base-type mappings.</summary>");
+		sb.AppendLine($"public static partial class {extensionClassName}");
+		sb.AppendLine("{");
+
+		var nonIgnored = props.Where(p => !p.IsIgnored).ToList();
+		for (var i = 0; i < nonIgnored.Count; i++)
+		{
+			var prop = nonIgnored[i];
+			EmitPropertyExtensionMethod(sb, builderType: string.Empty /* unused in generic form */, prop, typeParam, declaringTypeFullyQualifiedName);
+
+			if (prop.NestedType != null)
+				nestedBuilders.Add((prop.PropertyName, prop.FieldName, prop.NestedType));
+
+			if (i < nonIgnored.Count - 1)
+				sb.AppendLine();
+		}
+
+		// Emit generic-constrained nested property overloads
+		foreach (var (propertyName, fieldName, nestedType) in nestedBuilders)
+		{
+			sb.AppendLine();
+			EmitGenericNestedPropertyOverload(sb, typeParam, declaringTypeFullyQualifiedName, propertyName, fieldName, nestedType);
+		}
+
+		sb.AppendLine("}");
+		sb.AppendLine();
+
+		// Emit nested builder classes for base-type nested properties — deduplicate via shared set
+		foreach (var (propertyName, fieldName, nestedType) in nestedBuilders)
+		{
+			if (emittedNestedBuilders.Add(nestedType.TypeName))
+				EmitNestedBuilderClass(sb, declaringTypeName, propertyName, fieldName, nestedType);
+		}
+
+		return sb.ToString();
+	}
+
+	private static void EmitGenericNestedPropertyOverload(
+		StringBuilder sb,
+		string typeParam,
+		string constraintFqn,
+		string propertyName,
+		string fieldName,
+		NestedTypeModel nestedType
+	)
+	{
+		var nestedBuilderClassName = $"{nestedType.TypeName}NestedBuilder";
+		var effectiveBuilderType = $"{MappingsBuilderFqn}<{typeParam}>";
+		var constraintClause = $" where {typeParam} : global::{constraintFqn}";
+
+		sb.AppendLine($"\t/// <summary>Configure nested properties of the {propertyName} field (maps to \"{fieldName}\").</summary>");
+		sb.AppendLine($"\tpublic static {effectiveBuilderType} {propertyName}<{typeParam}>(this {effectiveBuilderType} self, global::System.Func<{nestedBuilderClassName}, {nestedBuilderClassName}> configure){constraintClause}");
+		sb.AppendLine("\t{");
+		sb.AppendLine($"\t\tvar nested = new {nestedBuilderClassName}(\"{fieldName}\");");
+		sb.AppendLine("\t\t_ = configure(nested);");
+		sb.AppendLine("\t\tself.MergeNestedFields(nested.GetFields());");
+		sb.AppendLine("\t\treturn self;");
+		sb.AppendLine("\t}");
 	}
 }

--- a/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
+++ b/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
@@ -635,6 +635,12 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		// reference the same nested type (e.g. IndexedProduct).
 		var emittedNestedBuilders = new HashSet<string>();
 
+		// Track emitted generic-constrained base-type extension classes globally.
+		// Keyed by "{declaringNamespace}::{declaringTypeFullyQualifiedName}" so each
+		// base type's methods are emitted exactly once regardless of how many concrete
+		// derived types are registered.
+		var emittedBaseExtensionKeys = new HashSet<string>();
+
 		// Enforce: only one [AiEnrichment<T>] per document type across all contexts
 		var aiEnrichmentTypes = new Dictionary<string, string>();
 		foreach (var model in models)
@@ -701,6 +707,25 @@ public class MappingSourceGenerator : IIncrementalGenerator
 				{
 					var mappingsExtensionsSource = MappingsBuilderEmitter.EmitForContext(model, reg, emittedNestedBuilders);
 					context.AddSource($"{model.ContextTypeName}.{reg.TypeName}MappingsExtensions.g.cs", mappingsExtensionsSource);
+				}
+
+				// Emit generic-constrained extension methods for base-type properties.
+				// Group by declaring type FQN so each base type's class is emitted exactly once globally.
+				var baseGroups = reg.TypeModel.Properties
+					.Where(p => p.DeclaringTypeName != null && !p.IsIgnored)
+					.GroupBy(p => p.DeclaringTypeFullyQualifiedName!);
+				foreach (var group in baseGroups)
+				{
+					var declaringFqn = group.Key;
+					var declaringName = group.First().DeclaringTypeName!;
+					var declaringNs = group.First().DeclaringTypeNamespace ?? string.Empty;
+					var baseKey = $"{declaringNs}::{declaringFqn}";
+					if (emittedBaseExtensionKeys.Add(baseKey))
+					{
+						var baseExtSource = MappingsBuilderEmitter.EmitBaseExtensionsClass(
+							declaringNs, declaringName, declaringFqn, group.ToList(), emittedNestedBuilders);
+						context.AddSource($"{declaringName}MappingsExtensions.g.cs", baseExtSource);
+					}
 				}
 
 				var analysisNamesSource = AnalysisNamesEmitter.EmitForContext(model, reg);

--- a/src/Elastic.Mapping.Generator/Model/PropertyMappingModel.cs
+++ b/src/Elastic.Mapping.Generator/Model/PropertyMappingModel.cs
@@ -25,7 +25,16 @@ internal sealed record PropertyMappingModel(
 	string FieldType,
 	bool IsIgnored,
 	ImmutableDictionary<string, string?> Options,
-	NestedTypeModel? NestedType = null
+	NestedTypeModel? NestedType = null,
+	/// <summary>
+	/// Simple name of the type that declares this property (e.g. <c>SearchDocumentBase</c>).
+	/// <c>null</c> means the property is declared on the registered concrete type itself ("own property").
+	/// </summary>
+	string? DeclaringTypeName = null,
+	/// <summary>Namespace of the declaring type (e.g. <c>Elastic.Internal.Search</c>). <c>null</c> for own properties.</summary>
+	string? DeclaringTypeNamespace = null,
+	/// <summary>Full display string of the declaring type (e.g. <c>Elastic.Internal.Search.SearchDocumentBase</c>). <c>null</c> for own properties.</summary>
+	string? DeclaringTypeFullyQualifiedName = null
 )
 {
 	public static PropertyMappingModel Create(
@@ -34,9 +43,13 @@ internal sealed record PropertyMappingModel(
 		string fieldType,
 		bool isIgnored = false,
 		ImmutableDictionary<string, string?>? options = null,
-		NestedTypeModel? nestedType = null
+		NestedTypeModel? nestedType = null,
+		string? declaringTypeName = null,
+		string? declaringTypeNamespace = null,
+		string? declaringTypeFullyQualifiedName = null
 	) =>
-		new(propertyName, fieldName, fieldType, isIgnored, options ?? ImmutableDictionary<string, string?>.Empty, nestedType);
+		new(propertyName, fieldName, fieldType, isIgnored, options ?? ImmutableDictionary<string, string?>.Empty, nestedType,
+			declaringTypeName, declaringTypeNamespace, declaringTypeFullyQualifiedName);
 }
 
 /// <summary>

--- a/tests/Elastic.Mapping.Tests/InheritanceMappingTests.cs
+++ b/tests/Elastic.Mapping.Tests/InheritanceMappingTests.cs
@@ -161,4 +161,41 @@ public class InheritanceMappingTests
 	private static Elastic.Mapping.Mappings.MappingsBuilder<T> ConfigureViaSectionHelper<T>(
 		Elastic.Mapping.Mappings.MappingsBuilder<T> m) where T : IntermediatePage =>
 		m.Section(f => f.IgnoreAbove(512));
+
+	// ── [Id] on a base class: accessor delegate + keyword type ───────────────
+
+	[Test]
+	public void IntermediatePage_GetId_ReturnsInheritedIdValue()
+	{
+		// [Id] is declared on InheritanceBase; IntermediatePage inherits it.
+		// The generated GetId delegate must cast to IntermediatePage and access Id.
+		var ctx = InheritanceMappingContext.IntermediatePage.Context;
+		var doc = new IntermediatePage { Id = "abc-123" };
+		ctx.GetId!(doc).Should().Be("abc-123");
+	}
+
+	[Test]
+	public void DerivedPage_GetId_ReturnsIdFromThreeLevelChain()
+	{
+		// [Id] flows through InheritanceBase → IntermediatePage → DerivedPage.
+		var ctx = InheritanceMappingContext.DerivedPage.Context;
+		var doc = new DerivedPage { Id = "xyz-789" };
+		ctx.GetId!(doc).Should().Be("xyz-789");
+	}
+
+	[Test]
+	public void InheritedId_IsMappedAsKeyword()
+	{
+		// [Id][Keyword] on InheritanceBase must produce a keyword-typed field
+		// in the mapping JSON for every derived type.
+		//
+		// IntermediatePage has no ConfigureMappings, so GetMappingJson() returns
+		// the raw pretty-printed generator output.  DerivedPage has DerivedPageConfig,
+		// so its JSON is produced by MergeIntoMappings (compact, no spaces).
+		var intermediateJson = InheritanceMappingContext.IntermediatePage.GetMappingJson();
+		var derivedJson      = InheritanceMappingContext.DerivedPage.GetMappingJson();
+
+		intermediateJson.Should().Contain("\"id\": { \"type\": \"keyword\"");  // pretty
+		derivedJson.Should().Contain("\"id\":{\"type\":\"keyword\"");           // compact
+	}
 }

--- a/tests/Elastic.Mapping.Tests/InheritanceMappingTests.cs
+++ b/tests/Elastic.Mapping.Tests/InheritanceMappingTests.cs
@@ -1,0 +1,164 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Mapping.Tests;
+
+/// <summary>
+/// Verifies that the source generator correctly handles type inheritance:
+/// - Base-type properties appear in mapping JSON, Fields accessors, and hashes.
+/// - Generic-constrained extension methods compile and are callable from helpers
+///   constrained to a base type.
+/// - Intermediate types that are both directly registered and a base of another
+///   registered type do not produce CS0101 duplicate-class errors (partial classes).
+/// - 3-level chains (DerivedPage : IntermediatePage : InheritanceBase) produce
+///   the full flattened mapping.
+/// </summary>
+public class InheritanceMappingTests
+{
+	// ── JSON: base fields present in derived-type mappings ───────────────────
+
+	[Test]
+	public void IntermediatePage_MappingJson_ContainsInheritedBaseFields()
+	{
+		var json = InheritanceMappingContext.IntermediatePage.GetMappingJson();
+		// Own field
+		json.Should().Contain("\"section\"");
+		// InheritanceBase fields
+		json.Should().Contain("\"title\"");
+		json.Should().Contain("\"status\"");
+		json.Should().Contain("\"id\"");
+	}
+
+	[Test]
+	public void DerivedPage_MappingJson_ContainsAllThreeLevels()
+	{
+		var json = InheritanceMappingContext.DerivedPage.GetMappingJson();
+		// Own field
+		json.Should().Contain("\"content\"");
+		// IntermediatePage field
+		json.Should().Contain("\"section\"");
+		// InheritanceBase fields
+		json.Should().Contain("\"title\"");
+		json.Should().Contain("\"status\"");
+		json.Should().Contain("\"id\"");
+	}
+
+	[Test]
+	public void DerivedPage_MappingJson_TitleHasStandardAnalyzer()
+	{
+		// DerivedPageConfig.AddBaseOverrides calls .Title(f => f.Analyzer("standard"))
+		// via the generic-constrained extension; verify the override was applied.
+		var json = InheritanceMappingContext.DerivedPage.GetMappingJson();
+		json.Should().Contain("\"analyzer\":\"standard\"");
+	}
+
+	[Test]
+	public void DerivedPage_MappingJson_SectionHasIgnoreAbove()
+	{
+		// DerivedPageConfig.AddIntermediateOverrides calls .Section(f => f.IgnoreAbove(256))
+		var json = InheritanceMappingContext.DerivedPage.GetMappingJson();
+		json.Should().Contain("\"ignore_above\":256");
+	}
+
+	// ── Fields accessors: base properties reachable by name ──────────────────
+
+	[Test]
+	public void IntermediatePage_Fields_ExposesInheritedAndOwnFieldNames()
+	{
+		InheritanceMappingContext.IntermediatePage.Fields.Title.Should().Be("title");
+		InheritanceMappingContext.IntermediatePage.Fields.Status.Should().Be("status");
+		InheritanceMappingContext.IntermediatePage.Fields.Id.Should().Be("id");
+		InheritanceMappingContext.IntermediatePage.Fields.Section.Should().Be("section");
+	}
+
+	[Test]
+	public void DerivedPage_Fields_ExposesAllThreeLevels()
+	{
+		InheritanceMappingContext.DerivedPage.Fields.Content.Should().Be("content");
+		InheritanceMappingContext.DerivedPage.Fields.Section.Should().Be("section");
+		InheritanceMappingContext.DerivedPage.Fields.Title.Should().Be("title");
+		InheritanceMappingContext.DerivedPage.Fields.Status.Should().Be("status");
+		InheritanceMappingContext.DerivedPage.Fields.Id.Should().Be("id");
+	}
+
+	// ── FieldMapping dictionaries ─────────────────────────────────────────────
+
+	[Test]
+	public void IntermediatePage_FieldMapping_ContainsInheritedProps()
+	{
+		var map = InheritanceMappingContext.IntermediatePage.FieldMapping.PropertyToField;
+		map.Should().ContainKey("Title").WhoseValue.Should().Be("title");
+		map.Should().ContainKey("Status").WhoseValue.Should().Be("status");
+		map.Should().ContainKey("Section").WhoseValue.Should().Be("section");
+	}
+
+	[Test]
+	public void DerivedPage_FieldMapping_ContainsAllThreeLevels()
+	{
+		var map = InheritanceMappingContext.DerivedPage.FieldMapping.PropertyToField;
+		map.Should().ContainKey("Content").WhoseValue.Should().Be("content");
+		map.Should().ContainKey("Section").WhoseValue.Should().Be("section");
+		map.Should().ContainKey("Title").WhoseValue.Should().Be("title");
+		map.Should().ContainKey("Status").WhoseValue.Should().Be("status");
+	}
+
+	// ── Hash stability: base fields must be included in the hash ─────────────
+
+	[Test]
+	public void IntermediatePage_Hash_IsStableAndNonEmpty()
+	{
+		var h1 = InheritanceMappingContext.IntermediatePage.Hash;
+		var h2 = InheritanceMappingContext.IntermediatePage.Hash;
+		h1.Should().NotBeNullOrEmpty();
+		h1.Should().Be(h2);
+	}
+
+	[Test]
+	public void DerivedPage_Hash_DiffersFromIntermediatePage()
+	{
+		// DerivedPage has extra own fields + different analysis — must produce a different hash.
+		var intermediate = InheritanceMappingContext.IntermediatePage.Hash;
+		var derived = InheritanceMappingContext.DerivedPage.Hash;
+		derived.Should().NotBe(intermediate);
+	}
+
+	// ── Generic-constrained extension methods compile and run ─────────────────
+
+	[Test]
+	public void BaseConstrainedHelper_CanCallGeneratedMethods_WithConcreteBuilder()
+	{
+		// Simulates the SharedMappingConfig pattern: a generic helper constrained to
+		// InheritanceBase that calls .Title(...) — proves the generic extension method
+		// is emitted and callable from a concrete MappingsBuilder<IntermediatePage>.
+		var builder = new Elastic.Mapping.Mappings.MappingsBuilder<IntermediatePage>();
+
+		var overrides = ConfigureViaBaseHelper(builder).Build();
+		var json = overrides.MergeIntoMappings("{}");
+
+		json.Should().Contain("\"analyzer\":\"keyword\"");
+	}
+
+	[Test]
+	public void IntermediateConstrainedHelper_CanCallGeneratedMethods_WithDerivedBuilder()
+	{
+		// Proves Section<TDoc> where TDoc:IntermediatePage is callable from
+		// a MappingsBuilder<DerivedPage>.
+		var builder = new Elastic.Mapping.Mappings.MappingsBuilder<DerivedPage>();
+
+		var overrides = ConfigureViaSectionHelper(builder).Build();
+		var json = overrides.MergeIntoMappings("{}");
+
+		json.Should().Contain("\"ignore_above\":512");
+	}
+
+	// These private helpers are the compile-time proof: they won't compile unless
+	// the generator emitted Title<TDoc>/Section<TDoc> with the correct constraints.
+	private static Elastic.Mapping.Mappings.MappingsBuilder<T> ConfigureViaBaseHelper<T>(
+		Elastic.Mapping.Mappings.MappingsBuilder<T> m) where T : InheritanceBase =>
+		m.Title(f => f.Analyzer("keyword"));
+
+	private static Elastic.Mapping.Mappings.MappingsBuilder<T> ConfigureViaSectionHelper<T>(
+		Elastic.Mapping.Mappings.MappingsBuilder<T> m) where T : IntermediatePage =>
+		m.Section(f => f.IgnoreAbove(512));
+}

--- a/tests/Elastic.Mapping.Tests/TestModels.cs
+++ b/tests/Elastic.Mapping.Tests/TestModels.cs
@@ -632,3 +632,84 @@ public class ExplicitContainerDocument : IConfigureElasticsearch<ExplicitContain
 [ElasticsearchMappingContext]
 [Index<ExplicitContainerDocument>(Name = "explicit-container-test")]
 public static partial class ExplicitContainerMappingContext;
+
+// ============================================================================
+// INHERITANCE TEST MODELS
+// Covers base-type property inclusion and generic-constrained extension methods.
+// ============================================================================
+
+/// <summary>
+/// Root base — never directly registered; only appears as an ancestor.
+/// Its properties must appear in every derived document's mapping JSON,
+/// Fields accessor, and hash.
+/// </summary>
+public class InheritanceBase
+{
+	[Id]
+	[Keyword]
+	[JsonPropertyName("id")]
+	public string Id { get; set; } = string.Empty;
+
+	[Text]
+	[JsonPropertyName("title")]
+	public string Title { get; set; } = string.Empty;
+
+	[Keyword]
+	[JsonPropertyName("status")]
+	public string Status { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Mid-level type: directly registered in <see cref="InheritanceMappingContext"/>
+/// AND the base of <see cref="DerivedPage"/>.
+/// Exercises the partial-class dedup: both a closed extension class
+/// (<c>IntermediatePageMappingsExtensions</c>) and a generic-constrained base
+/// extension class (<c>IntermediatePageMappingsExtensions</c>, partial) must
+/// be emitted without CS0101.
+/// </summary>
+public class IntermediatePage : InheritanceBase
+{
+	[Keyword]
+	[JsonPropertyName("section")]
+	public string Section { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Leaf type: inherits from <see cref="IntermediatePage"/> which inherits from
+/// <see cref="InheritanceBase"/>. Exercises 3-level inheritance — DerivedPage's
+/// mapping must include title/status (from InheritanceBase), section (from
+/// IntermediatePage), and content (own).
+/// </summary>
+public class DerivedPage : IntermediatePage
+{
+	[Text]
+	[JsonPropertyName("content")]
+	public string Content { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Configuration for <see cref="DerivedPage"/> that uses generic-constrained
+/// helper methods. These helpers compile ONLY if the generator emitted correct
+/// generic-constrained extension methods for InheritanceBase and IntermediatePage.
+/// </summary>
+public class DerivedPageConfig : IConfigureElasticsearch<DerivedPage>
+{
+	// Generic helper constrained to InheritanceBase — exercises Title<TDoc>, Status<TDoc>
+	private static MappingsBuilder<T> AddBaseOverrides<T>(MappingsBuilder<T> m) where T : InheritanceBase =>
+		m.Title(f => f.Analyzer("standard"));
+
+	// Generic helper constrained to IntermediatePage — exercises Section<TDoc>
+	private static MappingsBuilder<T> AddIntermediateOverrides<T>(MappingsBuilder<T> m) where T : IntermediatePage =>
+		m.Section(f => f.IgnoreAbove(256));
+
+	public MappingsBuilder<DerivedPage> ConfigureMappings(MappingsBuilder<DerivedPage> mappings) =>
+		AddBaseOverrides(AddIntermediateOverrides(mappings));
+
+	public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) => analysis;
+	public IReadOnlyDictionary<string, string>? IndexSettings => null;
+}
+
+[ElasticsearchMappingContext]
+[Index<IntermediatePage>(Name = "intermediate-docs")]
+[Index<DerivedPage>(Name = "derived-docs", Configuration = typeof(DerivedPageConfig))]
+public static partial class InheritanceMappingContext;


### PR DESCRIPTION
## Summary

- Extends the Roslyn source generator to walk the full `BaseType` chain when analysing registered document types, so base-class properties are included everywhere own properties are (auto-mapping JSON, `Fields`/`FieldMappings` accessors, `GetPropertyMap`, `TextFields`, `ComputeHash`, and fluent builder methods).
- Emits per-base-type `public static partial class {BaseName}MappingsExtensions` with generic-constrained fluent methods — e.g. `Title<TDoc>(this MappingsBuilder<TDoc> self, …) where TDoc : SearchDocumentBase` — so a shared generic helper can call them directly.
- Deduplicates base-extension classes globally (one per declaring-type FQN) to avoid CS0121 ambiguity. Both closed and base-extension classes are `partial` to handle types that are simultaneously registered directly and used as a base of another registered type (e.g. `SiteDocument`).

## Motivation

The generator previously only modelled each concrete type's own declared properties. Any property on a shared base class (e.g. `SearchDocumentBase.Title`) had to be wired via raw `AddField("title", …)` strings inside generic helpers — no compile-time safety, no refactor support.

## Changes

| File | What changed |
|---|---|
| `Model/PropertyMappingModel.cs` | Added `DeclaringTypeName`, `DeclaringTypeNamespace`, `DeclaringTypeFullyQualifiedName` (`string?`) — `null` = own property |
| `Analysis/TypeAnalyzer.cs` | `GetProperties` now walks the `BaseType` chain with most-derived-wins de-dup |
| `Emitters/MappingsBuilderEmitter.cs` | Closed class filters to own props only; new `EmitBaseExtensionsClass` emits generic-constrained methods; `partial` on both class kinds; `#pragma warning disable CS0436` for cross-assembly nested-builder dedup |
| `MappingSourceGenerator.cs` | `emittedBaseExtensionKeys` global set; base extension class emitted once per declaring type |

## Tests

`InheritanceMappingTests.cs` (15 tests) covering all four aspects:
- Mapping JSON includes base fields at all inheritance levels (3-level chain)
- `Fields`/`FieldMappings` accessors expose inherited properties
- `GetId` accessor resolves through the base chain at runtime
- `[Id][Keyword]` base property mapped as `keyword` type
- Generic-constrained helpers (`where T:InheritanceBase`, `where T:IntermediatePage`) compile and produce correct output — compile-time proof embedded in `DerivedPageConfig`

## Behavioral change

Registered types now include base-class fields in their generated mapping JSON and hashes. This is a one-time hash shift for any consumer that has base-class properties — expected and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)