### PR TITLE
feat(mapping): additive field builder with Clear() for explicit reset

### DIFF
--- a/src/Elastic.Mapping.Generator/Emitters/MappingsBuilderEmitter.cs
+++ b/src/Elastic.Mapping.Generator/Emitters/MappingsBuilderEmitter.cs
@@ -188,9 +188,7 @@ internal static class MappingsBuilderEmitter
 			sb.AppendLine($"\t/// <summary>Configure the {prop.PropertyName} field (maps to \"{prop.FieldName}\").</summary>");
 			sb.AppendLine($"\tpublic static {effectiveBuilderType} {prop.PropertyName}{genericSuffix}(this {effectiveBuilderType} self, global::System.Func<{inputBuilder}, {FieldBuilderFqn}> configure){constraintClause}");
 			sb.AppendLine("\t{");
-			sb.AppendLine($"\t\tvar fb = new {FieldBuilderFqn}();");
-			sb.AppendLine($"\t\t_ = configure(fb.{factoryMethod}());");
-			sb.AppendLine($"\t\tself.AddFieldDirect(\"{prop.FieldName}\", fb.GetDefinition());");
+			sb.AppendLine($"\t\tself.AddFieldDirect(\"{prop.FieldName}\", fb => configure(fb.{factoryMethod}()));");
 			sb.AppendLine("\t\treturn self;");
 			sb.AppendLine("\t}");
 		}

--- a/src/Elastic.Mapping/Mappings/Builders/FieldBuilder.cs
+++ b/src/Elastic.Mapping/Mappings/Builders/FieldBuilder.cs
@@ -13,69 +13,196 @@ namespace Elastic.Mapping.Mappings.Builders;
 public sealed class FieldBuilder
 {
 	private IFieldDefinition? _definition;
+	private object? _typeBuilder;
 
 	/// <summary>Creates a text field.</summary>
-	public TextFieldBuilder Text() => new(this);
+	public TextFieldBuilder Text()
+	{
+		if (_typeBuilder is TextFieldBuilder tb) return tb;
+		var result = new TextFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a keyword field.</summary>
-	public KeywordFieldBuilder Keyword() => new(this);
+	public KeywordFieldBuilder Keyword()
+	{
+		if (_typeBuilder is KeywordFieldBuilder kb) return kb;
+		var result = new KeywordFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a date field.</summary>
-	public DateFieldBuilder Date() => new(this);
+	public DateFieldBuilder Date()
+	{
+		if (_typeBuilder is DateFieldBuilder db) return db;
+		var result = new DateFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a long field.</summary>
-	public LongFieldBuilder Long() => new(this);
+	public LongFieldBuilder Long()
+	{
+		if (_typeBuilder is LongFieldBuilder lb) return lb;
+		var result = new LongFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates an integer field.</summary>
-	public IntegerFieldBuilder Integer() => new(this);
+	public IntegerFieldBuilder Integer()
+	{
+		if (_typeBuilder is IntegerFieldBuilder ib) return ib;
+		var result = new IntegerFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a short field.</summary>
-	public ShortFieldBuilder Short() => new(this);
+	public ShortFieldBuilder Short()
+	{
+		if (_typeBuilder is ShortFieldBuilder sb) return sb;
+		var result = new ShortFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a byte field.</summary>
-	public ByteFieldBuilder Byte() => new(this);
+	public ByteFieldBuilder Byte()
+	{
+		if (_typeBuilder is ByteFieldBuilder bb) return bb;
+		var result = new ByteFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a double field.</summary>
-	public DoubleFieldBuilder Double() => new(this);
+	public DoubleFieldBuilder Double()
+	{
+		if (_typeBuilder is DoubleFieldBuilder dob) return dob;
+		var result = new DoubleFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a float field.</summary>
-	public FloatFieldBuilder Float() => new(this);
+	public FloatFieldBuilder Float()
+	{
+		if (_typeBuilder is FloatFieldBuilder fb) return fb;
+		var result = new FloatFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a boolean field.</summary>
-	public BooleanFieldBuilder Boolean() => new(this);
+	public BooleanFieldBuilder Boolean()
+	{
+		if (_typeBuilder is BooleanFieldBuilder boolb) return boolb;
+		var result = new BooleanFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates an IP field.</summary>
-	public IpFieldBuilder Ip() => new(this);
+	public IpFieldBuilder Ip()
+	{
+		if (_typeBuilder is IpFieldBuilder ipb) return ipb;
+		var result = new IpFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a geo_point field.</summary>
-	public GeoPointFieldBuilder GeoPoint() => new(this);
+	public GeoPointFieldBuilder GeoPoint()
+	{
+		if (_typeBuilder is GeoPointFieldBuilder gpb) return gpb;
+		var result = new GeoPointFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a geo_shape field.</summary>
-	public GeoShapeFieldBuilder GeoShape() => new(this);
+	public GeoShapeFieldBuilder GeoShape()
+	{
+		if (_typeBuilder is GeoShapeFieldBuilder gsb) return gsb;
+		var result = new GeoShapeFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a nested field.</summary>
-	public NestedFieldBuilder Nested() => new(this);
+	public NestedFieldBuilder Nested()
+	{
+		if (_typeBuilder is NestedFieldBuilder nb) return nb;
+		var result = new NestedFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates an object field.</summary>
-	public ObjectFieldBuilder Object() => new(this);
+	public ObjectFieldBuilder Object()
+	{
+		if (_typeBuilder is ObjectFieldBuilder ob) return ob;
+		var result = new ObjectFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a completion field.</summary>
-	public CompletionFieldBuilder Completion() => new(this);
+	public CompletionFieldBuilder Completion()
+	{
+		if (_typeBuilder is CompletionFieldBuilder cb) return cb;
+		var result = new CompletionFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a dense_vector field.</summary>
-	public DenseVectorFieldBuilder DenseVector() => new(this);
+	public DenseVectorFieldBuilder DenseVector()
+	{
+		if (_typeBuilder is DenseVectorFieldBuilder dvb) return dvb;
+		var result = new DenseVectorFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a semantic_text field.</summary>
-	public SemanticTextFieldBuilder SemanticText() => new(this);
+	public SemanticTextFieldBuilder SemanticText()
+	{
+		if (_typeBuilder is SemanticTextFieldBuilder stb) return stb;
+		var result = new SemanticTextFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a search_as_you_type field.</summary>
-	public SearchAsYouTypeFieldBuilder SearchAsYouType() => new(this);
+	public SearchAsYouTypeFieldBuilder SearchAsYouType()
+	{
+		if (_typeBuilder is SearchAsYouTypeFieldBuilder saytb) return saytb;
+		var result = new SearchAsYouTypeFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a flattened field.</summary>
-	public FlattenedFieldBuilder Flattened() => new(this);
+	public FlattenedFieldBuilder Flattened()
+	{
+		if (_typeBuilder is FlattenedFieldBuilder flatb) return flatb;
+		var result = new FlattenedFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a binary field.</summary>
-	public BinaryFieldBuilder Binary() => new(this);
+	public BinaryFieldBuilder Binary()
+	{
+		if (_typeBuilder is BinaryFieldBuilder binb) return binb;
+		var result = new BinaryFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a range field.</summary>
 	public RangeFieldBuilder Range(string rangeType) => new(this, rangeType);
@@ -83,6 +210,7 @@ public sealed class FieldBuilder
 	/// <summary>Creates an alias field.</summary>
 	public FieldBuilder Alias(string path)
 	{
+		_typeBuilder = null;
 		_definition = new AliasFieldDefinition(path);
 		return this;
 	}
@@ -90,16 +218,24 @@ public sealed class FieldBuilder
 	/// <summary>Creates a percolator field.</summary>
 	public FieldBuilder Percolator()
 	{
+		_typeBuilder = null;
 		_definition = new PercolatorFieldDefinition();
 		return this;
 	}
 
 	/// <summary>Creates a rank_feature field.</summary>
-	public RankFeatureFieldBuilder RankFeature() => new(this);
+	public RankFeatureFieldBuilder RankFeature()
+	{
+		if (_typeBuilder is RankFeatureFieldBuilder rfb) return rfb;
+		var result = new RankFeatureFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a rank_features field.</summary>
 	public FieldBuilder RankFeatures()
 	{
+		_typeBuilder = null;
 		_definition = new RankFeaturesFieldDefinition();
 		return this;
 	}
@@ -107,22 +243,42 @@ public sealed class FieldBuilder
 	/// <summary>Creates a histogram field.</summary>
 	public FieldBuilder Histogram()
 	{
+		_typeBuilder = null;
 		_definition = new HistogramFieldDefinition();
 		return this;
 	}
 
 	/// <summary>Creates a constant_keyword field.</summary>
-	public ConstantKeywordFieldBuilder ConstantKeyword() => new(this);
+	public ConstantKeywordFieldBuilder ConstantKeyword()
+	{
+		if (_typeBuilder is ConstantKeywordFieldBuilder ckb) return ckb;
+		var result = new ConstantKeywordFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a wildcard field.</summary>
-	public WildcardFieldBuilder Wildcard() => new(this);
+	public WildcardFieldBuilder Wildcard()
+	{
+		if (_typeBuilder is WildcardFieldBuilder wb) return wb;
+		var result = new WildcardFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a token_count field.</summary>
-	public TokenCountFieldBuilder TokenCount() => new(this);
+	public TokenCountFieldBuilder TokenCount()
+	{
+		if (_typeBuilder is TokenCountFieldBuilder tcb) return tcb;
+		var result = new TokenCountFieldBuilder(this);
+		_typeBuilder = result;
+		return result;
+	}
 
 	/// <summary>Creates a version field.</summary>
 	public FieldBuilder Version()
 	{
+		_typeBuilder = null;
 		_definition = new VersionFieldDefinition();
 		return this;
 	}

--- a/src/Elastic.Mapping/Mappings/Builders/FieldTypeBuilders.cs
+++ b/src/Elastic.Mapping/Mappings/Builders/FieldTypeBuilders.cs
@@ -17,7 +17,7 @@ public sealed class TextFieldBuilder
 	private bool? _index;
 	private string? _copyTo;
 	private string? _termVector;
-	private readonly List<(string Name, IFieldDefinition Definition)> _multiFields = [];
+	private readonly Dictionary<string, IFieldDefinition> _multiFields = [];
 
 	internal TextFieldBuilder(FieldBuilder parent) => _parent = parent;
 
@@ -63,12 +63,25 @@ public sealed class TextFieldBuilder
 		return this;
 	}
 
-	/// <summary>Adds a multi-field.</summary>
+	/// <summary>Adds a multi-field. If a multi-field with the same name already exists, it is overwritten.</summary>
 	public TextFieldBuilder MultiField(string name, Func<MultiFieldBuilder, MultiFieldBuilder> configure)
 	{
 		var builder = new MultiFieldBuilder();
 		_ = configure(builder);
-		_multiFields.Add((name, builder.GetDefinition()));
+		_multiFields[name] = builder.GetDefinition();
+		return this;
+	}
+
+	/// <summary>Clears all accumulated state, resetting this builder to its initial empty state.</summary>
+	public TextFieldBuilder Clear()
+	{
+		_analyzer = null;
+		_searchAnalyzer = null;
+		_norms = null;
+		_index = null;
+		_copyTo = null;
+		_termVector = null;
+		_multiFields.Clear();
 		return this;
 	}
 
@@ -83,7 +96,7 @@ public sealed class TextFieldBuilder
 			builder._copyTo,
 			builder._termVector,
 			builder._multiFields.Count > 0
-				? builder._multiFields.ToDictionary(x => x.Name, x => x.Definition)
+				? new Dictionary<string, IFieldDefinition>(builder._multiFields)
 				: null
 		));
 		return builder._parent;
@@ -98,7 +111,7 @@ public sealed class KeywordFieldBuilder
 	private int? _ignoreAbove;
 	private bool? _docValues;
 	private bool? _index;
-	private readonly List<(string Name, IFieldDefinition Definition)> _multiFields = [];
+	private readonly Dictionary<string, IFieldDefinition> _multiFields = [];
 
 	internal KeywordFieldBuilder(FieldBuilder parent) => _parent = parent;
 
@@ -130,12 +143,23 @@ public sealed class KeywordFieldBuilder
 		return this;
 	}
 
-	/// <summary>Adds a multi-field.</summary>
+	/// <summary>Adds a multi-field. If a multi-field with the same name already exists, it is overwritten.</summary>
 	public KeywordFieldBuilder MultiField(string name, Func<MultiFieldBuilder, MultiFieldBuilder> configure)
 	{
 		var builder = new MultiFieldBuilder();
 		_ = configure(builder);
-		_multiFields.Add((name, builder.GetDefinition()));
+		_multiFields[name] = builder.GetDefinition();
+		return this;
+	}
+
+	/// <summary>Clears all accumulated state, resetting this builder to its initial empty state.</summary>
+	public KeywordFieldBuilder Clear()
+	{
+		_normalizer = null;
+		_ignoreAbove = null;
+		_docValues = null;
+		_index = null;
+		_multiFields.Clear();
 		return this;
 	}
 
@@ -148,7 +172,7 @@ public sealed class KeywordFieldBuilder
 			builder._docValues,
 			builder._index,
 			builder._multiFields.Count > 0
-				? builder._multiFields.ToDictionary(x => x.Name, x => x.Definition)
+				? new Dictionary<string, IFieldDefinition>(builder._multiFields)
 				: null
 		));
 		return builder._parent;

--- a/src/Elastic.Mapping/Mappings/MappingsBuilder.cs
+++ b/src/Elastic.Mapping/Mappings/MappingsBuilder.cs
@@ -20,8 +20,8 @@ public sealed class MappingsBuilder<TDocument> : MappingsBuilderBase<MappingsBui
 		base.AddPropertyField(path, configure);
 
 	/// <inheritdoc cref="MappingsBuilderBase{TSelf}.AddFieldDirect"/>
-	public new MappingsBuilder<TDocument> AddFieldDirect(string path, IFieldDefinition definition) =>
-		base.AddFieldDirect(path, definition);
+	public MappingsBuilder<TDocument> AddFieldDirect(string path, Action<FieldBuilder> action) =>
+		base.AddFieldDirect(path, action);
 
 	/// <inheritdoc cref="MappingsBuilderBase{TSelf}.MergeNestedFields"/>
 	public new void MergeNestedFields(IReadOnlyList<(string Path, IFieldDefinition Definition)> fields) =>

--- a/src/Elastic.Mapping/Mappings/MappingsBuilderBase.cs
+++ b/src/Elastic.Mapping/Mappings/MappingsBuilderBase.cs
@@ -15,15 +15,13 @@ namespace Elastic.Mapping.Mappings;
 /// <typeparam name="TSelf">The derived builder type.</typeparam>
 public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBase<TSelf>
 {
-	private readonly List<(string Path, IFieldDefinition Definition, FieldContainer Container)> _fields = [];
+	private readonly List<(string Path, Action<FieldBuilder> Action, FieldContainer Container)> _fieldActions = [];
 	private readonly List<(string Name, RuntimeFieldDefinition Definition)> _runtimeFields = [];
 	private readonly List<DynamicTemplateDefinition> _dynamicTemplates = [];
 
 	private TSelf AddFieldCore(string path, Func<FieldBuilder, FieldBuilder> configure, FieldContainer container)
 	{
-		var builder = new FieldBuilder();
-		_ = configure(builder);
-		_fields.Add((path, builder.GetDefinition(), container));
+		_fieldActions.Add((path, fb => { _ = configure(fb); }, container));
 		return (TSelf)this;
 	}
 
@@ -35,12 +33,12 @@ public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBa
 		AddFieldCore(path, configure, FieldContainer.Auto);
 
 	/// <summary>
-	/// Adds a field definition directly at the specified path.
+	/// Adds a field action directly at the specified path.
 	/// Called by generated type-constrained property methods.
 	/// </summary>
-	protected TSelf AddFieldDirect(string path, IFieldDefinition definition)
+	protected TSelf AddFieldDirect(string path, Action<FieldBuilder> action, FieldContainer container = FieldContainer.Auto)
 	{
-		_fields.Add((path, definition, FieldContainer.Auto));
+		_fieldActions.Add((path, action, container));
 		return (TSelf)this;
 	}
 
@@ -51,7 +49,7 @@ public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBa
 	protected void MergeNestedFields(IReadOnlyList<(string Path, IFieldDefinition Definition)> fields)
 	{
 		foreach (var (path, def) in fields)
-			_fields.Add((path, def, FieldContainer.Auto));
+			_fieldActions.Add((path, fb => fb.SetDefinition(def), FieldContainer.Auto));
 	}
 
 	/// <summary>
@@ -101,23 +99,29 @@ public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBa
 	/// Returns true if any mapping configurations have been added.
 	/// </summary>
 	public bool HasConfiguration =>
-		_fields.Count > 0 ||
+		_fieldActions.Count > 0 ||
 		_runtimeFields.Count > 0 ||
 		_dynamicTemplates.Count > 0;
 
 	/// <summary>
 	/// Builds the mapping overrides from all configured fields, runtime fields, and dynamic templates.
-	/// Later entries override earlier ones when paths collide.
+	/// Multiple actions for the same path are accumulated additively on a single shared builder.
 	/// </summary>
 	public MappingOverrides Build()
 	{
-		var fields = new Dictionary<string, IFieldDefinition>();
+		var builders = new Dictionary<string, FieldBuilder>();
 		var containers = new Dictionary<string, FieldContainer>();
-		foreach (var (path, def, container) in _fields)
+		foreach (var (path, action, container) in _fieldActions)
 		{
-			fields[path] = def;
+			if (!builders.TryGetValue(path, out var fb))
+			{
+				fb = new FieldBuilder();
+				builders[path] = fb;
+			}
+			action(fb);
 			containers[path] = container;
 		}
+		var fields = builders.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.GetDefinition());
 
 		var runtimeFields = new Dictionary<string, RuntimeFieldDefinition>();
 		foreach (var (name, def) in _runtimeFields)

--- a/tests/Elastic.Mapping.Tests/MappingsBuilderTests.cs
+++ b/tests/Elastic.Mapping.Tests/MappingsBuilderTests.cs
@@ -615,4 +615,79 @@ public class MappingsBuilderTests
 			.GetProperty("fields").GetProperty("a");
 		a.GetProperty("ignore_above").GetInt32().Should().Be(512, "last definition wins");
 	}
+
+	[Test]
+	public void MappingsBuilder_Additive_SecondCallMergesMultiFields()
+	{
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("title", f => f.Text().MultiField("keyword", mf => mf.Keyword()))
+			.AddField("title", f => f.Text().MultiField("semantic_text", mf => mf.SemanticText()));
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var title = doc.RootElement.GetProperty("properties").GetProperty("title");
+		title.GetProperty("fields").GetProperty("keyword").GetProperty("type").GetString().Should().Be("keyword");
+		title.GetProperty("fields").GetProperty("semantic_text").GetProperty("type").GetString().Should().Be("semantic_text");
+	}
+
+	[Test]
+	public void MappingsBuilder_Additive_SecondCallCanAddSearchAnalyzerWithoutLosingMultiFields()
+	{
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("title", f => f.Text()
+				.MultiField("keyword", mf => mf.Keyword())
+				.MultiField("completion", mf => mf.SearchAsYouType()))
+			.AddField("title", f => f.Text().SearchAnalyzer("synonyms"));
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var title = doc.RootElement.GetProperty("properties").GetProperty("title");
+		title.GetProperty("search_analyzer").GetString().Should().Be("synonyms");
+		title.GetProperty("fields").GetProperty("keyword").GetProperty("type").GetString().Should().Be("keyword");
+		title.GetProperty("fields").GetProperty("completion").GetProperty("type").GetString().Should().Be("search_as_you_type");
+	}
+
+	[Test]
+	public void MappingsBuilder_Clear_ResetsAccumulatedState()
+	{
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("title", f => f.Text()
+				.MultiField("keyword", mf => mf.Keyword())
+				.MultiField("completion", mf => mf.SearchAsYouType()))
+			.AddField("title", f => f.Text().Clear()
+				.MultiField("semantic_text", mf => mf.SemanticText()));
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var title = doc.RootElement.GetProperty("properties").GetProperty("title");
+		var fields = title.GetProperty("fields");
+		fields.TryGetProperty("keyword", out _).Should().BeFalse("keyword should have been cleared");
+		fields.TryGetProperty("completion", out _).Should().BeFalse("completion should have been cleared");
+		fields.GetProperty("semantic_text").GetProperty("type").GetString().Should().Be("semantic_text");
+	}
+
+	[Test]
+	public void MappingsBuilder_Additive_SameMultiFieldNameOverwrites()
+	{
+		var builder = new MappingsBuilder<LogEntry>()
+			.AddField("title", f => f.Text().MultiField("keyword", mf => mf.Keyword().Normalizer("first")))
+			.AddField("title", f => f.Text().MultiField("keyword", mf => mf.Keyword().Normalizer("second")));
+
+		var overrides = builder.Build();
+		var baseMappings = TestMappingContext.LogEntry.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var keyword = doc.RootElement.GetProperty("properties").GetProperty("title").GetProperty("fields").GetProperty("keyword");
+		keyword.GetProperty("normalizer").GetString().Should().Be("second");
+	}
 }


### PR DESCRIPTION
## Problem

Calling a typed mapping extension method (e.g. `.Title()`) a second time silently **overwrote** the entire first definition — multifields, analyzer settings, everything. This made it impossible for a shared base helper (e.g. `AddSearchDocumentMappings`) and a concrete override to both configure the same field without one discarding the other's work.

## Solution

Change `MappingsBuilderBase` to store `Action<FieldBuilder>` per path and **replay all actions on a single shared `FieldBuilder`** in `Build()`. Because `FieldBuilder` now caches a persistent type-specific builder in `_typeBuilder`, all actions for the same path accumulate into the same builder instance.

**Multi-field merging** — `TextFieldBuilder` and `KeywordFieldBuilder` switch their `_multiFields` storage from `List` to `Dictionary`, so same-name multifields overwrite (last-write-wins) and different names accumulate. Two calls each adding a multifield now produce a union of both.

**Scalar merging** — scalar properties (`_analyzer`, `_searchAnalyzer`, etc.) are just fields on the persistent builder; a second call's assignments overwrite the first's for that property, which is the correct and expected behaviour.

**Explicit reset** — `TextFieldBuilder.Clear()` and `KeywordFieldBuilder.Clear()` reset all accumulated state so the next chain starts fresh:

```csharp
// Additive (default): second call adds semantic_text alongside existing multifields
m.Title(f => f.MultiField("keyword", mf => mf.Keyword()))
 .Title(f => f.MultiField("semantic_text", mf => mf.SemanticText()));

// Explicit reset: discard all previous config, start clean
m.Title(f => f.Clear().MultiField("semantic_text", mf => mf.SemanticText()));
```

## Changes

| File | What changed |
|---|---|
| `MappingsBuilderBase.cs` | `_fields` → `_fieldActions` (`Action<FieldBuilder>`); `Build()` replays per-path; `MergeNestedFields` converts `IFieldDefinition` to action via `fb.SetDefinition` |
| `MappingsBuilder.cs` | `AddFieldDirect` overload updated to `Action<FieldBuilder>` |
| `FieldBuilder.cs` | `_typeBuilder` cache; all factory methods return persistent builder or create one |
| `FieldTypeBuilders.cs` | `TextFieldBuilder`/`KeywordFieldBuilder`: `_multiFields` → `Dictionary`, `Clear()` added |
| `MappingsBuilderEmitter.cs` | Generated code: `self.AddFieldDirect("x", fb => configure(fb.Type()))` (1 line, was 3) |
| `MappingsBuilderTests.cs` | 4 new tests: additive multifield merge, search_analyzer without losing multifields, `Clear()` reset, same multifield name overwrites |

## Backwards compatibility

All 223 existing tests pass unchanged. The previous `AddField("x", …)` × 2 test still asserts `analyzer == "second"` — because scalar assignment is still last-write-wins on the persistent builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)