### PR TITLE
feat: remote reindex support, reindex management APIs, and semantic_text workarounds

### DIFF
--- a/docs/helpers/server-reindex.md
+++ b/docs/helpers/server-reindex.md
@@ -89,9 +89,156 @@ var options = new ServerReindexOptions
 };
 ```
 
+## Remote reindex
+
+Reindex documents from a remote Elasticsearch cluster using `RemoteSource`. This is GA in Elastic Cloud Serverless — any ECH deployment or Serverless project endpoint is accepted without an allowlist.
+
+### Basic authentication
+
+```csharp
+var reindex = new ServerReindex(transport, new ServerReindexOptions
+{
+    Source = "remote-index",
+    Destination = "local-index",
+    Remote = new RemoteSource
+    {
+        Host = "https://my-deployment.es.us-east-1.aws.elastic.cloud:443",
+        Username = "reindex_user",
+        Password = "secret",
+    },
+});
+
+await foreach (var progress in reindex.MonitorAsync())
+{
+    Console.WriteLine($"Remote reindex {progress.FractionComplete:P0}");
+}
+```
+
+### API key authentication (Elastic Stack)
+
+Use the native `api_key` field, supported by Elasticsearch 8.x+:
+
+```csharp
+var reindex = new ServerReindex(transport, new ServerReindexOptions
+{
+    Source = "remote-index",
+    Destination = "local-index",
+    Remote = new RemoteSource
+    {
+        Host = "https://my-deployment.es.us-east-1.aws.elastic.cloud:443",
+        ApiKey = "dGVzdEtleQ==",
+        SocketTimeout = "2m",
+        ConnectTimeout = "30s",
+    },
+});
+```
+
+### Header-based authentication (Serverless)
+
+For Serverless-to-Serverless reindex where the remote expects a raw `Authorization` header, use the `Headers` dictionary:
+
+```csharp
+var reindex = new ServerReindex(transport, new ServerReindexOptions
+{
+    Source = "remote-index",
+    Destination = "local-index",
+    Remote = new RemoteSource
+    {
+        Host = "https://my-project.es.us-east-1.aws.elastic.cloud:443",
+        Headers = new Dictionary<string, string>
+        {
+            ["Authorization"] = "ApiKey base64EncodedApiKey=="
+        },
+    },
+});
+```
+
+### Semantic text indices
+
+Indices with `semantic_text` fields need two workarounds for remote reindex:
+
+1. **Batch size** -- `semantic_text` documents with dense vector embeddings can be very large (~200+ KB each). The default batch size of 1000 often exceeds the 100 MB on-heap coordinating buffer, causing `es_rejected_execution_exception`. Lower `SourceSize` to stay within limits. See [elastic/elasticsearch#150635](https://github.com/elastic/elasticsearch/issues/150635).
+
+2. **Inference fields** -- the stored `_source` of `semantic_text` documents includes an `_inference_fields` metadata block. On ingest, the destination cluster also tries to add this field, causing a "Duplicate field '_inference_fields'" parse error. Set `ExcludeInferenceFields = true` to strip it from the source. See [elastic/elasticsearch#150634](https://github.com/elastic/elasticsearch/issues/150634).
+
+   **Caveat:** removing `_inference_fields` causes the destination to re-run inference on every document, even when chunk embeddings already exist in `_source`. This is an Elasticsearch-side limitation.
+
+```csharp
+var reindex = new ServerReindex(transport, new ServerReindexOptions
+{
+    Source = "semantic-index",
+    Destination = "semantic-index",
+    SourceSize = 100,
+    ExcludeInferenceFields = true,
+    Conflicts = "proceed",
+    Remote = new RemoteSource
+    {
+        Host = "https://source-project.es.us-east-1.aws.elastic.cloud:443",
+        Headers = new Dictionary<string, string>
+        {
+            ["Authorization"] = "ApiKey base64EncodedApiKey=="
+        },
+        SocketTimeout = "5m",
+        ConnectTimeout = "30s",
+    },
+});
+
+await foreach (var progress in reindex.MonitorAsync())
+{
+    Console.WriteLine($"Remote reindex {progress.FractionComplete:P0} -- " +
+                      $"{progress.Created} created");
+}
+```
+
+### Tuning batch size
+
+Remote reindex uses an on-heap buffer that defaults to 100 MB. For large documents (especially `semantic_text` with embeddings), lower the batch size:
+
+```csharp
+var reindex = new ServerReindex(transport, new ServerReindexOptions
+{
+    Source = "remote-large-docs",
+    Destination = "local-index",
+    SourceSize = 10,
+    Remote = new RemoteSource
+    {
+        Host = "https://remote.es.cloud:443",
+        Username = "user",
+        Password = "pass",
+    },
+});
+```
+
+### RemoteSource reference
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Host` | `string` | Remote Elasticsearch endpoint (scheme + host + port). Required. |
+| `Username` | `string?` | Username for basic auth. |
+| `Password` | `string?` | Password for basic auth. |
+| `ApiKey` | `string?` | API key for the remote cluster. Emitted as the native `api_key` field. |
+| `Headers` | `Dictionary<string, string>?` | Custom HTTP headers (e.g. `Authorization` for Serverless). |
+| `SocketTimeout` | `string?` | Socket read timeout (e.g. `"1m"`). Default: 30s. |
+| `ConnectTimeout` | `string?` | Connection timeout (e.g. `"30s"`). Default: 30s. |
+
+## Scripts
+
+Apply a Painless script to modify documents during reindex. Provide the full JSON script object:
+
+```csharp
+var options = new ServerReindexOptions
+{
+    Source = "old-index",
+    Destination = "new-index",
+    Script = """{"source":"ctx._source.tag = 'migrated'"}""",
+};
+```
+
+Scripts compose cleanly with `ExcludeInferenceFields` -- the `_source` exclusion runs at fetch time, and the script runs at index time.
+
 ## Full body override
 
-For advanced use cases not covered by the structured options (scripts, remote reindex, custom conflict handling), pass the complete request body directly. When `Body` is set, `Source`, `Destination`, `Query`, and `Pipeline` are ignored:
+For advanced use cases not covered by the structured options, pass the complete request body directly. When `Body` is set, all other structured options are ignored:
 
 ```csharp
 var options = new ServerReindexOptions
@@ -117,8 +264,14 @@ var options = new ServerReindexOptions
 | `Query` | `string?` | `null` | JSON query body to filter source documents. |
 | `Pipeline` | `string?` | `null` | Ingest pipeline name. |
 | `RequestsPerSecond` | `float?` | `null` | Throttle. Use `-1` for unlimited. |
-| `Slices` | `string?` | `null` | `"auto"` or a number string. |
+| `Slices` | `string?` | `null` | `"auto"` or a number string. Not supported for remote reindex. |
+| `SourceSize` | `int?` | `null` | Docs per batch from source (default 1000). Lower for remote with large docs. |
+| `MaxDocs` | `long?` | `null` | Maximum total documents to reindex. |
+| `Conflicts` | `string?` | `null` | `"abort"` (default) or `"proceed"` to continue on version conflicts. |
+| `Script` | `string?` | `null` | Painless script JSON object to modify documents during reindex. |
+| `ExcludeInferenceFields` | `bool` | `false` | Strip `_inference_fields` from `_source` (workaround for [#150634](https://github.com/elastic/elasticsearch/issues/150634)). |
 | `PollInterval` | `TimeSpan` | `5s` | How often to poll the task status. |
+| `Remote` | `RemoteSource?` | `null` | Remote cluster configuration for cross-cluster reindex. |
 | `Body` | `string?` | `null` | Full override body JSON. |
 
 ## ReindexProgress
@@ -127,8 +280,9 @@ Each yielded progress snapshot exposes:
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `TaskId` | `string` | The Elasticsearch task ID. |
+| `TaskId` | `string` | The Elasticsearch task ID. Stable across relocations when using the reindex management API. |
 | `IsCompleted` | `bool` | Whether the task has finished. |
+| `Cancelled` | `bool` | Whether the task has been cancelled. |
 | `Total` | `long` | Total documents to process. |
 | `Created` | `long` | Documents created. |
 | `Updated` | `long` | Documents updated. |
@@ -137,7 +291,47 @@ Each yielded progress snapshot exposes:
 | `VersionConflicts` | `long` | Version conflicts encountered. |
 | `Elapsed` | `TimeSpan` | Time elapsed since the task started. |
 | `FractionComplete` | `double?` | 0.0 to 1.0, or `null` if total is unknown. |
+| `Description` | `string?` | Sanitized operation description (source/dest, remote host). Only from reindex management API. |
+| `StartTime` | `DateTimeOffset?` | When the task started. Only from reindex management API. |
 | `Error` | `string?` | Error description if the task failed. |
+
+## Management APIs
+
+`ReindexOperations` exposes the reindex-specific management endpoints introduced in Elasticsearch 9.5.0. These are relocation-aware and work in Serverless (where `/_tasks` is unavailable).
+
+```csharp
+var ops = new ReindexOperations(transport);
+```
+
+### List running reindex operations
+
+```csharp
+var response = await ops.ListAsync(detailed: true);
+```
+
+### Get status of a specific reindex
+
+Falls back to `/_tasks/{taskId}` on older clusters.
+
+```csharp
+var progress = await ops.GetStatusAsync("r1A2WoRbTwKZ516z6NEs5A:36619");
+Console.WriteLine($"{progress.FractionComplete:P0} complete");
+```
+
+### Cancel a reindex
+
+Falls back to `/_tasks/{taskId}/_cancel` on older clusters.
+
+```csharp
+var finalState = await ops.CancelAsync("r1A2WoRbTwKZ516z6NEs5A:36619");
+Console.WriteLine($"Cancelled: {finalState?.Cancelled}");
+```
+
+### Rethrottle
+
+```csharp
+await ops.RethrottleAsync("r1A2WoRbTwKZ516z6NEs5A:36619", requestsPerSecond: 500);
+```
 
 ## Related
 

--- a/src/Elastic.Ingest.Elasticsearch/Helpers/ReindexOperations.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/ReindexOperations.cs
@@ -1,0 +1,174 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Transport;
+
+namespace Elastic.Ingest.Elasticsearch.Helpers;
+
+/// <summary>
+/// Provides access to the reindex-specific management APIs introduced in Elasticsearch 9.5.0.
+/// <para>
+/// <c>GET /_reindex</c> — list all running reindex operations.<br/>
+/// <c>GET /_reindex/{taskId}</c> — get status for one operation (relocation-aware).<br/>
+/// <c>POST /_reindex/{taskId}/_cancel</c> — cancel an operation (relocation-aware).<br/>
+/// <c>POST /_reindex/{taskId}/_rethrottle</c> — change throttle on an in-flight operation.
+/// </para>
+/// <para>
+/// <see cref="GetStatusAsync"/> and <see cref="CancelAsync"/> fall back to the legacy
+/// <c>/_tasks</c> API when the reindex management endpoints are not available (older clusters).
+/// <see cref="ListAsync"/> is new-only — there is no legacy equivalent.
+/// </para>
+/// </summary>
+public sealed class ReindexOperations
+{
+	private readonly ITransport _transport;
+
+	/// <summary>
+	/// Creates a new <see cref="ReindexOperations"/> instance.
+	/// </summary>
+	public ReindexOperations(ITransport transport) => _transport = transport;
+
+	/// <summary>
+	/// Lists all currently running reindex operations.
+	/// <para>Calls <c>GET /_reindex</c>. Requires Elasticsearch 9.5.0+ or Serverless.</para>
+	/// </summary>
+	/// <param name="detailed">When <c>true</c>, includes detailed task status in each entry.</param>
+	/// <param name="ctx">Cancellation token.</param>
+	/// <returns>The raw JSON response containing a <c>reindex</c> array.</returns>
+	public async Task<JsonResponse> ListAsync(bool detailed = false, CancellationToken ctx = default)
+	{
+		var url = detailed ? "/_reindex?detailed=true" : "/_reindex";
+		var response = await _transport.RequestAsync<JsonResponse>(
+			HttpMethod.GET, url, cancellationToken: ctx
+		).ConfigureAwait(false);
+
+		if (response.ApiCallDetails.HttpStatusCode is not 200)
+			throw new Exception(
+				$"Failed to list reindex operations: {response}",
+				response.ApiCallDetails.OriginalException
+			);
+
+		return response;
+	}
+
+	/// <summary>
+	/// Gets the status and progress of a specific reindex task.
+	/// Tries <c>GET /_reindex/{taskId}</c> first, falls back to <c>GET /_tasks/{taskId}</c>.
+	/// </summary>
+	public async Task<ReindexProgress> GetStatusAsync(string taskId, CancellationToken ctx = default)
+	{
+		var result = await ReindexTaskMonitor.GetStatusAsync(_transport, taskId, ctx).ConfigureAwait(false);
+		return ServerReindex.ParseProgress(taskId, result.Response, result.Shape);
+	}
+
+	/// <summary>
+	/// Cancels a running reindex operation.
+	/// Tries <c>POST /_reindex/{taskId}/_cancel</c> first (relocation-aware), falls back to
+	/// <c>POST /_tasks/{taskId}/_cancel</c>.
+	/// </summary>
+	/// <param name="taskId">The reindex task identifier.</param>
+	/// <param name="waitForCompletion">
+	/// When <c>true</c> (default), blocks until cancellation is complete and returns the final task state.
+	/// When <c>false</c>, returns immediately after acknowledgement.
+	/// </param>
+	/// <param name="ctx">Cancellation token.</param>
+	/// <returns>
+	/// The final <see cref="ReindexProgress"/> when <paramref name="waitForCompletion"/> is <c>true</c>;
+	/// <c>null</c> when <c>false</c> (only acknowledgement is returned).
+	/// </returns>
+	public async Task<ReindexProgress?> CancelAsync(
+		string taskId, bool waitForCompletion = true, CancellationToken ctx = default)
+	{
+		var result = await TryCancelReindexApiAsync(taskId, waitForCompletion, ctx).ConfigureAwait(false);
+		if (result.HasValue)
+		{
+			var (response, shape) = result.Value;
+			if (!waitForCompletion)
+				return null;
+			return ServerReindex.ParseProgress(taskId, response, shape);
+		}
+
+		// Fallback to legacy task cancel
+		var fallback = await CancelViaTaskApiAsync(taskId, ctx).ConfigureAwait(false);
+		return waitForCompletion
+			? ServerReindex.ParseProgress(taskId, fallback, ReindexTaskMonitor.ApiShape.TaskApi)
+			: null;
+	}
+
+	/// <summary>
+	/// Changes the throttle on an in-flight reindex operation.
+	/// <para>Calls <c>POST /_reindex/{taskId}/_rethrottle?requests_per_second={rps}</c>.</para>
+	/// </summary>
+	/// <param name="taskId">The reindex task identifier.</param>
+	/// <param name="requestsPerSecond">
+	/// The new throttle value. Use <c>-1</c> to disable throttling.
+	/// </param>
+	/// <param name="ctx">Cancellation token.</param>
+	public async Task<JsonResponse> RethrottleAsync(
+		string taskId, float requestsPerSecond, CancellationToken ctx = default)
+	{
+		var response = await _transport.RequestAsync<JsonResponse>(
+			HttpMethod.POST,
+			$"/_reindex/{taskId}/_rethrottle?requests_per_second={requestsPerSecond}",
+			cancellationToken: ctx
+		).ConfigureAwait(false);
+
+		if (response.ApiCallDetails.HttpStatusCode is not 200)
+			throw new Exception(
+				$"Failed to rethrottle reindex task '{taskId}': {response}",
+				response.ApiCallDetails.OriginalException
+			);
+
+		return response;
+	}
+
+	private async Task<(JsonResponse Response, ReindexTaskMonitor.ApiShape Shape)?> TryCancelReindexApiAsync(
+		string taskId, bool waitForCompletion, CancellationToken ctx)
+	{
+		var wfc = waitForCompletion ? "true" : "false";
+		var response = await _transport.RequestAsync<JsonResponse>(
+			HttpMethod.POST,
+			$"/_reindex/{taskId}/_cancel?wait_for_completion={wfc}",
+			cancellationToken: ctx
+		).ConfigureAwait(false);
+
+		if (response.ApiCallDetails.HttpStatusCode is 200)
+			return (response, ReindexTaskMonitor.ApiShape.ReindexApi);
+
+		// 503 during relocation handoff — retry once
+		if (response.ApiCallDetails.HttpStatusCode is 503)
+		{
+			await Task.Delay(TimeSpan.FromSeconds(2), ctx).ConfigureAwait(false);
+			var retry = await _transport.RequestAsync<JsonResponse>(
+				HttpMethod.POST,
+				$"/_reindex/{taskId}/_cancel?wait_for_completion={wfc}",
+				cancellationToken: ctx
+			).ConfigureAwait(false);
+
+			if (retry.ApiCallDetails.HttpStatusCode is 200)
+				return (retry, ReindexTaskMonitor.ApiShape.ReindexApi);
+		}
+
+		return null;
+	}
+
+	private async Task<JsonResponse> CancelViaTaskApiAsync(string taskId, CancellationToken ctx)
+	{
+		var response = await _transport.RequestAsync<JsonResponse>(
+			HttpMethod.POST,
+			$"/_tasks/{taskId}/_cancel",
+			cancellationToken: ctx
+		).ConfigureAwait(false);
+
+		if (response.ApiCallDetails.HttpStatusCode is not 200)
+			throw new Exception(
+				$"Failed to cancel task '{taskId}': {response}",
+				response.ApiCallDetails.OriginalException
+			);
+
+		return response;
+	}
+}

--- a/src/Elastic.Ingest.Elasticsearch/Helpers/ReindexProgress.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/ReindexProgress.cs
@@ -10,11 +10,14 @@ namespace Elastic.Ingest.Elasticsearch.Helpers;
 /// </summary>
 public class ReindexProgress
 {
-	/// <summary> The Elasticsearch task ID. </summary>
+	/// <summary> The Elasticsearch task ID. Stable across node-shutdown relocations when using the reindex management API. </summary>
 	public string TaskId { get; init; } = string.Empty;
 
 	/// <summary> Whether the reindex task has completed. </summary>
 	public bool IsCompleted { get; init; }
+
+	/// <summary> Whether the reindex task has been cancelled. </summary>
+	public bool Cancelled { get; init; }
 
 	/// <summary> Total documents to process. </summary>
 	public long Total { get; init; }
@@ -39,6 +42,12 @@ public class ReindexProgress
 
 	/// <summary> Fraction of work completed (0.0 to 1.0), or null if total is unknown. </summary>
 	public double? FractionComplete => Total > 0 ? (double)(Created + Updated + Deleted + Noops) / Total : null;
+
+	/// <summary> A sanitized description of the reindex operation (source/dest indices, remote host). Only populated by the reindex management API. </summary>
+	public string? Description { get; init; }
+
+	/// <summary> When the task started. Only populated by the reindex management API. </summary>
+	public DateTimeOffset? StartTime { get; init; }
 
 	/// <summary> Error description if the task failed. </summary>
 	public string? Error { get; init; }

--- a/src/Elastic.Ingest.Elasticsearch/Helpers/ReindexTaskMonitor.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/ReindexTaskMonitor.cs
@@ -1,0 +1,116 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Transport;
+
+namespace Elastic.Ingest.Elasticsearch.Helpers;
+
+/// <summary>
+/// Polls reindex task status using the dedicated <c>GET /_reindex/{taskId}</c> API (9.5.0+),
+/// falling back to <c>GET /_tasks/{taskId}</c> on older clusters.
+/// </summary>
+internal static class ReindexTaskMonitor
+{
+	/// <summary>
+	/// Indicates which API shape a <see cref="JsonResponse"/> was obtained from.
+	/// </summary>
+	internal enum ApiShape { ReindexApi, TaskApi }
+
+	internal readonly record struct PollResult(JsonResponse Response, ApiShape Shape);
+
+	/// <summary>
+	/// Polls the reindex task at the given interval, yielding <see cref="PollResult"/> on each poll.
+	/// Tries the reindex management API first; if the endpoint is unavailable, falls back to the
+	/// task API for the remainder of the operation.
+	/// </summary>
+	internal static async IAsyncEnumerable<PollResult> PollAsync(
+		ITransport transport,
+		string taskId,
+		TimeSpan pollInterval,
+		[EnumeratorCancellation] CancellationToken ctx = default)
+	{
+		var useReindexApi = true;
+
+		while (!ctx.IsCancellationRequested)
+		{
+			PollResult result;
+			if (useReindexApi)
+			{
+				result = await TryReindexApiAsync(transport, taskId, ctx).ConfigureAwait(false);
+				if (result.Shape == ApiShape.TaskApi)
+					useReindexApi = false;
+			}
+			else
+			{
+				var response = await FetchTaskApiAsync(transport, taskId, ctx).ConfigureAwait(false);
+				result = new PollResult(response, ApiShape.TaskApi);
+			}
+
+			yield return result;
+
+			var completed = result.Shape == ApiShape.ReindexApi
+				? result.Response.Get<bool>("completed")
+				: result.Response.Get<bool>("completed");
+			if (completed)
+				yield break;
+
+			await Task.Delay(pollInterval, ctx).ConfigureAwait(false);
+		}
+	}
+
+	/// <summary>
+	/// Single-shot status fetch via the reindex management API with fallback.
+	/// </summary>
+	internal static async Task<PollResult> GetStatusAsync(
+		ITransport transport, string taskId, CancellationToken ctx = default)
+	{
+		var result = await TryReindexApiAsync(transport, taskId, ctx).ConfigureAwait(false);
+		return result;
+	}
+
+	private static async Task<PollResult> TryReindexApiAsync(
+		ITransport transport, string taskId, CancellationToken ctx)
+	{
+		var response = await transport.RequestAsync<JsonResponse>(
+			HttpMethod.GET,
+			$"/_reindex/{taskId}",
+			cancellationToken: ctx
+		).ConfigureAwait(false);
+
+		var status = response.ApiCallDetails.HttpStatusCode;
+
+		// 200 = success on reindex management API
+		if (status is 200)
+			return new PollResult(response, ApiShape.ReindexApi);
+
+		// 404 with "resource_not_found_exception" could mean the task genuinely doesn't exist
+		// on the new API, OR it could mean the endpoint itself doesn't exist on an older cluster.
+		// 405 (Method Not Allowed) definitively means the endpoint doesn't exist.
+		// In either ambiguous case, try the task API as fallback.
+		var fallback = await FetchTaskApiAsync(transport, taskId, ctx).ConfigureAwait(false);
+		return new PollResult(fallback, ApiShape.TaskApi);
+	}
+
+	private static async Task<JsonResponse> FetchTaskApiAsync(
+		ITransport transport, string taskId, CancellationToken ctx)
+	{
+		var response = await transport.RequestAsync<JsonResponse>(
+			HttpMethod.GET,
+			$"/_tasks/{taskId}",
+			cancellationToken: ctx
+		).ConfigureAwait(false);
+
+		if (response.ApiCallDetails.HttpStatusCode is not 200)
+			throw new Exception(
+				$"Failed to get task status for '{taskId}': {response}",
+				response.ApiCallDetails.OriginalException
+			);
+
+		return response;
+	}
+}

--- a/src/Elastic.Ingest.Elasticsearch/Helpers/RemoteSource.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/RemoteSource.cs
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+using System.Collections.Generic;
+
+namespace Elastic.Ingest.Elasticsearch.Helpers;
+
+/// <summary>
+/// Configures a remote Elasticsearch cluster as the source for a <see cref="ServerReindex"/> operation.
+/// Maps to the <c>source.remote</c> block in the <c>_reindex</c> request body.
+/// <para>
+/// In Elastic Cloud Serverless, only Elastic Cloud endpoints (ECH deployments and other Serverless
+/// projects) are accepted — no allowlist configuration is needed.
+/// In self-managed or ECH deployments the remote host must be listed in
+/// <c>reindex.remote.whitelist</c> in <c>elasticsearch.yml</c>.
+/// </para>
+/// </summary>
+public class RemoteSource
+{
+	/// <summary>
+	/// The remote Elasticsearch endpoint including scheme, host, and port.
+	/// For example: <c>https://my-deployment.es.us-east-1.aws.elastic.cloud:443</c>.
+	/// </summary>
+	public string Host { get; init; } = null!;
+
+	/// <summary> Username for basic authentication on the remote cluster. </summary>
+	public string? Username { get; init; }
+
+	/// <summary> Password for basic authentication on the remote cluster. </summary>
+	public string? Password { get; init; }
+
+	/// <summary>
+	/// API key for the remote cluster. Emitted as the native <c>api_key</c> field in the
+	/// <c>source.remote</c> block. Supported by Elasticsearch 8.x+ / Elastic Stack.
+	/// <para>
+	/// For Serverless-to-Serverless reindex where the remote expects a raw <c>Authorization</c>
+	/// header, use <see cref="Headers"/> instead:
+	/// <c>Headers = new() { ["Authorization"] = "ApiKey base64value" }</c>.
+	/// </para>
+	/// </summary>
+	public string? ApiKey { get; init; }
+
+	/// <summary>
+	/// Custom HTTP headers sent with every request to the remote cluster.
+	/// Use this for Serverless auth where the remote expects a raw <c>Authorization</c> header,
+	/// e.g. <c>new Dictionary&lt;string, string&gt; { ["Authorization"] = "ApiKey base64value" }</c>.
+	/// </summary>
+	public Dictionary<string, string>? Headers { get; init; }
+
+	/// <summary> Socket read timeout for the remote connection (e.g. <c>"1m"</c>). Defaults to 30s. </summary>
+	public string? SocketTimeout { get; init; }
+
+	/// <summary> Connection timeout for the remote cluster (e.g. <c>"30s"</c>). Defaults to 30s. </summary>
+	public string? ConnectTimeout { get; init; }
+}

--- a/src/Elastic.Ingest.Elasticsearch/Helpers/ServerReindex.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/ServerReindex.cs
@@ -46,16 +46,17 @@ public sealed class ServerReindex
 	}
 
 	/// <summary>
-	/// Starts _reindex with wait_for_completion=false, then polls _tasks/{id}.
+	/// Starts _reindex with wait_for_completion=false, then polls <c>GET /_reindex/{id}</c>
+	/// (falling back to <c>GET /_tasks/{id}</c> on older clusters).
 	/// Yields progress on each poll. Completes when the task finishes.
 	/// </summary>
 	public async IAsyncEnumerable<ReindexProgress> MonitorAsync([EnumeratorCancellation] CancellationToken ctx = default)
 	{
 		var taskId = await StartReindexAsync(ctx).ConfigureAwait(false);
 
-		await foreach (var response in ElasticsearchTaskMonitor.PollTaskAsync(_transport, taskId, _options.PollInterval, ctx).ConfigureAwait(false))
+		await foreach (var result in ReindexTaskMonitor.PollAsync(_transport, taskId, _options.PollInterval, ctx).ConfigureAwait(false))
 		{
-			yield return ParseProgress(taskId, response);
+			yield return ParseProgress(taskId, result.Response, result.Shape);
 		}
 	}
 
@@ -96,18 +97,40 @@ public sealed class ServerReindex
 			sb.Append("&requests_per_second=").Append(_options.RequestsPerSecond.Value);
 		if (_options.Slices != null)
 			sb.Append("&slices=").Append(_options.Slices);
+		if (_options.MaxDocs.HasValue)
+			sb.Append("&max_docs=").Append(_options.MaxDocs.Value);
 		return sb.ToString();
 	}
 
-	private string BuildBody()
+	/// <summary>
+	/// Builds the JSON request body that will be sent to <c>POST /_reindex</c>.
+	/// Useful for inspecting or logging the body before execution.
+	/// </summary>
+	public string BuildBody()
 	{
 		if (_options.Body != null)
 			return _options.Body;
 
 		var sb = new StringBuilder(256);
-		sb.Append(@"{""source"":{""index"":""");
+		if (_options.Conflicts != null)
+		{
+			sb.Append(@"{""conflicts"":""");
+			sb.Append(_options.Conflicts);
+			sb.Append(@""",""source"":{""index"":""");
+		}
+		else
+			sb.Append(@"{""source"":{""index"":""");
 		sb.Append(_source);
 		sb.Append('"');
+		if (_options.Remote != null)
+			AppendRemote(sb, _options.Remote);
+		if (_options.SourceSize.HasValue)
+		{
+			sb.Append(@",""size"":");
+			sb.Append(_options.SourceSize.Value);
+		}
+		if (_options.ExcludeInferenceFields)
+			sb.Append(@",""_source"":{""excludes"":[""_inference_fields""]}");
 		if (_options.Query != null)
 		{
 			sb.Append(@",""query"":");
@@ -122,11 +145,120 @@ public sealed class ServerReindex
 			sb.Append(_options.Pipeline);
 			sb.Append('"');
 		}
-		sb.Append(@"}}");
+		sb.Append('}');
+		if (_options.Script != null)
+		{
+			sb.Append(@",""script"":");
+			sb.Append(_options.Script);
+		}
+		sb.Append('}');
 		return sb.ToString();
 	}
 
-	private static ReindexProgress ParseProgress(string taskId, JsonResponse response)
+	private static void AppendRemote(StringBuilder sb, RemoteSource remote)
+	{
+		sb.Append(@",""remote"":{""host"":""");
+		sb.Append(remote.Host);
+		sb.Append('"');
+		if (remote.Username != null)
+		{
+			sb.Append(@",""username"":""");
+			sb.Append(remote.Username);
+			sb.Append('"');
+		}
+		if (remote.Password != null)
+		{
+			sb.Append(@",""password"":""");
+			sb.Append(remote.Password);
+			sb.Append('"');
+		}
+		if (remote.ApiKey != null)
+		{
+			sb.Append(@",""api_key"":""");
+			sb.Append(remote.ApiKey);
+			sb.Append('"');
+		}
+		if (remote.Headers is { Count: > 0 })
+		{
+			sb.Append(@",""headers"":{");
+			var first = true;
+			foreach (var kvp in remote.Headers)
+			{
+				if (!first) sb.Append(',');
+				sb.Append('"').Append(kvp.Key).Append(@""":""").Append(kvp.Value).Append('"');
+				first = false;
+			}
+			sb.Append('}');
+		}
+		if (remote.SocketTimeout != null)
+		{
+			sb.Append(@",""socket_timeout"":""");
+			sb.Append(remote.SocketTimeout);
+			sb.Append('"');
+		}
+		if (remote.ConnectTimeout != null)
+		{
+			sb.Append(@",""connect_timeout"":""");
+			sb.Append(remote.ConnectTimeout);
+			sb.Append('"');
+		}
+		sb.Append('}');
+	}
+
+	internal static ReindexProgress ParseProgress(
+		string taskId, JsonResponse response, ReindexTaskMonitor.ApiShape shape)
+	{
+		if (shape == ReindexTaskMonitor.ApiShape.ReindexApi)
+			return ParseReindexApiProgress(taskId, response);
+
+		return ParseTaskApiProgress(taskId, response);
+	}
+
+	/// <summary>
+	/// Parses the <c>GET /_reindex/{id}</c> response shape (9.5.0+).
+	/// Status fields live at <c>status.*</c> and <c>running_time_in_nanos</c> is at the root.
+	/// </summary>
+	private static ReindexProgress ParseReindexApiProgress(string taskId, JsonResponse response)
+	{
+		var completed = response.Get<bool>("completed");
+		var error = response.Get<string>("error.reason");
+
+		if (completed)
+		{
+			var respError = response.Get<string>("response.failures");
+			if (!string.IsNullOrEmpty(respError))
+				error ??= respError;
+		}
+
+		var id = response.Get<string>("id") ?? taskId;
+		var startMillis = response.Get<long>("start_time_in_millis");
+		DateTimeOffset? startTime = startMillis > 0
+			? DateTimeOffset.FromUnixTimeMilliseconds(startMillis)
+			: null;
+
+		return new ReindexProgress
+		{
+			TaskId = id,
+			IsCompleted = completed,
+			Cancelled = response.Get<bool>("cancelled"),
+			Total = response.Get<long>("status.total"),
+			Created = response.Get<long>("status.created"),
+			Updated = response.Get<long>("status.updated"),
+			Deleted = response.Get<long>("status.deleted"),
+			Noops = response.Get<long>("status.noops"),
+			VersionConflicts = response.Get<long>("status.version_conflicts"),
+			Elapsed = TimeSpan.FromMilliseconds(response.Get<long>("running_time_in_nanos") / 1_000_000.0),
+			Description = response.Get<string>("description"),
+			StartTime = startTime,
+			Error = error
+		};
+	}
+
+	/// <summary>
+	/// Parses the legacy <c>GET /_tasks/{id}</c> response shape.
+	/// Status fields live at <c>task.status.*</c> and <c>running_time_in_nanos</c> is under <c>task</c>.
+	/// </summary>
+	private static ReindexProgress ParseTaskApiProgress(string taskId, JsonResponse response)
 	{
 		var completed = response.Get<bool>("completed");
 		var error = response.Get<string>("error.reason");

--- a/src/Elastic.Ingest.Elasticsearch/Helpers/ServerReindexOptions.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/ServerReindexOptions.cs
@@ -32,12 +32,62 @@ public class ServerReindexOptions
 	/// <summary> Throttle in requests per second. -1 for unlimited. </summary>
 	public float? RequestsPerSecond { get; init; }
 
-	/// <summary> Number of slices: "auto" or a number string. </summary>
+	/// <summary> Number of slices: "auto" or a number string. Slicing is not supported for remote reindex. </summary>
 	public string? Slices { get; init; }
+
+	/// <summary>
+	/// Number of documents to read per batch from the source. Defaults to 1000.
+	/// Lower this for remote reindex with very large documents.
+	/// Maps to <c>source.size</c> in the request body.
+	/// </summary>
+	public int? SourceSize { get; init; }
+
+	/// <summary>
+	/// Maximum number of documents to reindex. When set, the operation stops after this many
+	/// documents have been processed. Maps to the top-level <c>max_docs</c> field.
+	/// </summary>
+	public long? MaxDocs { get; init; }
+
+	/// <summary>
+	/// How to handle version conflicts: <c>"abort"</c> (default) or <c>"proceed"</c>.
+	/// Set to <c>"proceed"</c> to continue reindexing when conflicts occur (useful for retries).
+	/// </summary>
+	public string? Conflicts { get; init; }
+
+	/// <summary>
+	/// Optional Painless script to modify documents during reindex. Maps to the top-level
+	/// <c>script</c> object in the request body. Provide the full JSON object, e.g.
+	/// <c>{"lang":"painless","source":"ctx._source.tag = 'migrated'"}</c>.
+	/// </summary>
+	public string? Script { get; init; }
+
+	/// <summary>
+	/// When <c>true</c>, strips the <c>_inference_fields</c> metadata from each document's
+	/// <c>_source</c> before it reaches the destination. This works around a known Elasticsearch
+	/// issue where reindex-from-remote fails with "Duplicate field '_inference_fields'" on indices
+	/// containing <c>semantic_text</c> fields.
+	/// <para>
+	/// Implemented via <c>_source</c> exclusion, so it composes cleanly with <see cref="Script"/>.
+	/// </para>
+	/// <para>
+	/// <b>Caveat:</b> removing <c>_inference_fields</c> causes the destination cluster to re-run
+	/// inference even when chunk embeddings are already present in <c>_source</c>. This is an
+	/// Elasticsearch-side limitation — see
+	/// <see href="https://github.com/elastic/elasticsearch/issues/150634">#150634</see>.
+	/// </para>
+	/// </summary>
+	public bool ExcludeInferenceFields { get; init; }
 
 	/// <summary> How often to poll the task status. Defaults to 5 seconds. </summary>
 	public TimeSpan PollInterval { get; init; } = TimeSpan.FromSeconds(5);
 
-	/// <summary> Optional full override body JSON. When set, Source/Destination/Query/Pipeline are ignored. </summary>
+	/// <summary>
+	/// Remote Elasticsearch cluster to read source documents from.
+	/// When set, the <c>source.remote</c> block is included in the <c>_reindex</c> request body.
+	/// <see cref="Source"/> is still required — it specifies the index on the remote cluster.
+	/// </summary>
+	public RemoteSource? Remote { get; init; }
+
+	/// <summary> Optional full override body JSON. When set, Source/Destination/Query/Pipeline/Remote and other structured options are ignored. </summary>
 	public string? Body { get; init; }
 }

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/ServerReindexBodyTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/ServerReindexBodyTests.cs
@@ -1,0 +1,287 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Elastic.Ingest.Elasticsearch.Helpers;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace Elastic.Ingest.Elasticsearch.Tests;
+
+public class ServerReindexBodyTests
+{
+	[Test]
+	public void BuildBodyWithoutRemoteProducesLocalReindex()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "src-index",
+			Destination = "dst-index",
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+		var source = doc.RootElement.GetProperty("source");
+
+		source.GetProperty("index").GetString().Should().Be("src-index");
+		source.TryGetProperty("remote", out _).Should().BeFalse("local reindex should not have a remote block");
+
+		doc.RootElement.GetProperty("dest").GetProperty("index").GetString().Should().Be("dst-index");
+	}
+
+	[Test]
+	public void BuildBodyWithRemoteBasicAuthIncludesCredentials()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "remote-index",
+			Destination = "local-index",
+			Remote = new RemoteSource
+			{
+				Host = "https://remote.es.cloud:443",
+				Username = "reindex_user",
+				Password = "s3cret",
+			},
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+		var remote = doc.RootElement.GetProperty("source").GetProperty("remote");
+
+		remote.GetProperty("host").GetString().Should().Be("https://remote.es.cloud:443");
+		remote.GetProperty("username").GetString().Should().Be("reindex_user");
+		remote.GetProperty("password").GetString().Should().Be("s3cret");
+		remote.TryGetProperty("api_key", out _).Should().BeFalse();
+		remote.TryGetProperty("headers", out _).Should().BeFalse("basic auth should not set headers");
+	}
+
+	[Test]
+	public void BuildBodyWithRemoteApiKeyUsesNativeField()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "remote-index",
+			Destination = "local-index",
+			Remote = new RemoteSource
+			{
+				Host = "https://remote.es.cloud:443",
+				ApiKey = "dGVzdEtleQ==",
+			},
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+		var remote = doc.RootElement.GetProperty("source").GetProperty("remote");
+
+		remote.GetProperty("host").GetString().Should().Be("https://remote.es.cloud:443");
+		remote.GetProperty("api_key").GetString().Should().Be("dGVzdEtleQ==");
+		remote.TryGetProperty("username", out _).Should().BeFalse();
+		remote.TryGetProperty("headers", out _).Should().BeFalse("native api_key should not set headers");
+	}
+
+	[Test]
+	public void BuildBodyWithRemoteHeadersUsesHeadersBlock()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "remote-index",
+			Destination = "local-index",
+			Remote = new RemoteSource
+			{
+				Host = "https://serverless.es.cloud:443",
+				Headers = new Dictionary<string, string>
+				{
+					["Authorization"] = "ApiKey dGVzdEtleQ=="
+				},
+			},
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+		var remote = doc.RootElement.GetProperty("source").GetProperty("remote");
+
+		remote.GetProperty("headers").GetProperty("Authorization").GetString()
+			.Should().Be("ApiKey dGVzdEtleQ==");
+		remote.TryGetProperty("api_key", out _).Should().BeFalse("headers auth should not set native api_key");
+	}
+
+	[Test]
+	public void BuildBodyWithRemoteTimeoutsIncludesTimeoutFields()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "remote-index",
+			Destination = "local-index",
+			Remote = new RemoteSource
+			{
+				Host = "https://remote.es.cloud:443",
+				Username = "user",
+				Password = "pass",
+				SocketTimeout = "2m",
+				ConnectTimeout = "30s",
+			},
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+		var remote = doc.RootElement.GetProperty("source").GetProperty("remote");
+
+		remote.GetProperty("socket_timeout").GetString().Should().Be("2m");
+		remote.GetProperty("connect_timeout").GetString().Should().Be("30s");
+	}
+
+	[Test]
+	public void BuildBodyWithRemoteAndQueryIncludesBoth()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "remote-index",
+			Destination = "local-index",
+			Query = """{"match_all":{}}""",
+			Remote = new RemoteSource
+			{
+				Host = "https://remote.es.cloud:443",
+				Username = "user",
+				Password = "pass",
+			},
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+		var source = doc.RootElement.GetProperty("source");
+
+		source.TryGetProperty("remote", out _).Should().BeTrue();
+		source.TryGetProperty("query", out _).Should().BeTrue();
+	}
+
+	[Test]
+	public void BuildBodyWithSourceSizeIncludesSizeInSource()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "remote-index",
+			Destination = "local-index",
+			SourceSize = 10,
+			Remote = new RemoteSource
+			{
+				Host = "https://remote.es.cloud:443",
+				Username = "user",
+				Password = "pass",
+			},
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+		var source = doc.RootElement.GetProperty("source");
+
+		source.GetProperty("size").GetInt32().Should().Be(10);
+	}
+
+	[Test]
+	public void BuildBodyWithConflictsIncludesTopLevelField()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "src-index",
+			Destination = "dst-index",
+			Conflicts = "proceed",
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+
+		doc.RootElement.GetProperty("conflicts").GetString().Should().Be("proceed");
+		doc.RootElement.GetProperty("source").GetProperty("index").GetString().Should().Be("src-index");
+	}
+
+	[Test]
+	public void BuildBodyWithExcludeInferenceFieldsAddsSourceExclusion()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "semantic-index",
+			Destination = "local-index",
+			ExcludeInferenceFields = true,
+			Remote = new RemoteSource
+			{
+				Host = "https://remote.es.cloud:443",
+				Username = "user",
+				Password = "pass",
+			},
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+		var source = doc.RootElement.GetProperty("source");
+
+		var sourceFilter = source.GetProperty("_source");
+		var excludes = sourceFilter.GetProperty("excludes");
+		excludes.GetArrayLength().Should().Be(1);
+		excludes[0].GetString().Should().Be("_inference_fields");
+	}
+
+	[Test]
+	public void BuildBodyWithExcludeInferenceFieldsComposesWithScript()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "semantic-index",
+			Destination = "local-index",
+			ExcludeInferenceFields = true,
+			Script = """{"lang":"painless","source":"ctx._source.tag = 'migrated'"}""",
+			Remote = new RemoteSource
+			{
+				Host = "https://remote.es.cloud:443",
+				Username = "user",
+				Password = "pass",
+			},
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+
+		doc.RootElement.GetProperty("source").GetProperty("_source")
+			.GetProperty("excludes")[0].GetString().Should().Be("_inference_fields");
+		doc.RootElement.GetProperty("script").GetProperty("source").GetString()
+			.Should().Contain("migrated");
+	}
+
+	[Test]
+	public void BuildBodyWithScriptIncludesTopLevelScriptBlock()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Source = "src-index",
+			Destination = "dst-index",
+			Script = """{"source":"ctx._source.tag = 'migrated'"}""",
+		});
+
+		var body = reindex.BuildBody();
+		var doc = JsonDocument.Parse(body);
+
+		doc.RootElement.GetProperty("script").GetProperty("source").GetString()
+			.Should().Be("ctx._source.tag = 'migrated'");
+	}
+
+	[Test]
+	public void BuildBodyWithBodyOverrideIgnoresAllStructuredOptions()
+	{
+		var reindex = new ServerReindex(TestSetup.SharedTransport, new ServerReindexOptions
+		{
+			Body = """{"source":{"index":"custom"},"dest":{"index":"custom-dest"}}""",
+			Remote = new RemoteSource
+			{
+				Host = "https://remote.es.cloud:443",
+			},
+			Conflicts = "proceed",
+			SourceSize = 5,
+			ExcludeInferenceFields = true,
+		});
+
+		var body = reindex.BuildBody();
+		body.Should().Be("""{"source":{"index":"custom"},"dest":{"index":"custom-dest"}}""",
+			"Body override should be used verbatim");
+	}
+}


### PR DESCRIPTION
## Summary

- **Remote reindex**: structured `RemoteSource` configuration for `source.remote` (basic auth, native `api_key`, custom `Headers` for Serverless, socket/connect timeouts, batch size tuning)
- **Reindex management APIs**: `ReindexOperations` class exposing `GET /_reindex` (list), `GET /_reindex/{id}` (status), `POST /_reindex/{id}/_cancel`, and `POST /_reindex/{id}/_rethrottle` -- the new relocation-aware endpoints from Elasticsearch 9.5.0
- **Automatic fallback**: `ServerReindex.MonitorAsync()` and `ReindexOperations` try the new `/_reindex/{id}` API first and silently fall back to `/_tasks/{id}` on older clusters
- **`ExcludeInferenceFields`**: `_source` exclusion workaround for the "Duplicate field `_inference_fields`" parse error when reindexing `semantic_text` indices from remote ([elastic/elasticsearch#150634](https://github.com/elastic/elasticsearch/issues/150634)). Composes cleanly with `Script`.
- **New options**: `SourceSize`, `MaxDocs`, `Conflicts`, `Script`, `Remote`, `ExcludeInferenceFields` on `ServerReindexOptions`
- **Enriched progress**: `Cancelled`, `Description`, `StartTime` on `ReindexProgress`

## Test plan

- [x] 12 unit tests for `BuildBody()` covering local reindex, remote with basic auth, native `api_key`, custom headers, timeouts, source size, conflicts, scripts, `ExcludeInferenceFields`, `ExcludeInferenceFields` + `Script` composition, and `Body` override
- [x] Full unit test suite passes (125 tests)
- [ ] Integration test with live cluster for remote reindex (requires two clusters)
- [ ] Verify fallback behavior against a pre-9.5.0 cluster


Made with [Cursor](https://cursor.com)