### PR TITLE
feat(generator): delegation-following analysis parser with base-type-anchored accessors

### DIFF
--- a/src/Elastic.Mapping.Generator/Analysis/ConfigureAnalysisParser.cs
+++ b/src/Elastic.Mapping.Generator/Analysis/ConfigureAnalysisParser.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Elastic.Mapping.Generator.Model;
 using Microsoft.CodeAnalysis;
@@ -13,10 +14,16 @@ namespace Elastic.Mapping.Generator.Analysis;
 /// <summary>
 /// Parses the ConfigureAnalysis static method to extract analyzer, tokenizer,
 /// token filter, char filter, and normalizer names.
+/// Supports delegation: if ConfigureAnalysis calls another method (e.g. a shared factory),
+/// the parser follows the call graph transitively and accumulates names from all reachable methods.
 /// </summary>
 internal static class ConfigureAnalysisParser
 {
-	public static AnalysisComponentsModel Parse(INamedTypeSymbol typeSymbol, CancellationToken ct)
+	// The Elastic.Mapping fluent analysis builder — we skip recursing into its own methods
+	// since they are the declaration site, not a user-authored delegation target.
+	private const string AnalysisBuilderTypeName = "Elastic.Mapping.Analysis.AnalysisBuilder";
+
+	public static AnalysisComponentsModel Parse(INamedTypeSymbol typeSymbol, Compilation compilation, CancellationToken ct)
 	{
 		ct.ThrowIfCancellationRequested();
 
@@ -28,16 +35,31 @@ internal static class ConfigureAnalysisParser
 		if (configureAnalysisMethod == null)
 			return AnalysisComponentsModel.Empty;
 
-		return ParseFromMethod(configureAnalysisMethod, ct);
+		return ParseFromMethod(configureAnalysisMethod, compilation, ct);
 	}
 
 	/// <summary>
-	/// Parses analysis components from a specific method symbol.
-	/// Used when the method lives on a context class or configuration class.
+	/// Legacy overload used by <c>TypeAnalyzer</c> when a type has its own inline
+	/// <c>ConfigureAnalysis</c> method. Delegation-following is not needed here since
+	/// the type authors its own analysis; only the direct method body is parsed.
 	/// </summary>
-	public static AnalysisComponentsModel ParseFromMethod(IMethodSymbol method, CancellationToken ct)
+	public static AnalysisComponentsModel Parse(INamedTypeSymbol typeSymbol, CancellationToken ct)
 	{
 		ct.ThrowIfCancellationRequested();
+
+		var configureAnalysisMethod = typeSymbol.GetMembers("ConfigureAnalysis")
+			.OfType<IMethodSymbol>()
+			.FirstOrDefault(m => m.IsStatic && m.Parameters.Length == 1);
+
+		if (configureAnalysisMethod == null)
+			return AnalysisComponentsModel.Empty;
+
+		// Inline parse: single-method body walk only, no semantic model / delegation.
+		var syntaxRef = configureAnalysisMethod.DeclaringSyntaxReferences.FirstOrDefault();
+		if (syntaxRef == null)
+			return AnalysisComponentsModel.Empty;
+
+		var methodSyntax = syntaxRef.GetSyntax(ct);
 
 		var analyzers = ImmutableArray.CreateBuilder<AnalysisComponentModel>();
 		var tokenizers = ImmutableArray.CreateBuilder<AnalysisComponentModel>();
@@ -45,35 +67,19 @@ internal static class ConfigureAnalysisParser
 		var charFilters = ImmutableArray.CreateBuilder<AnalysisComponentModel>();
 		var normalizers = ImmutableArray.CreateBuilder<AnalysisComponentModel>();
 
-		// Get the syntax for the method
-		var syntaxRef = method.DeclaringSyntaxReferences.FirstOrDefault();
-		if (syntaxRef == null)
-			return AnalysisComponentsModel.Empty;
-
-		var methodSyntax = syntaxRef.GetSyntax(ct);
-
-		// Find all invocation expressions in the method body
-		var invocations = methodSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>();
-
-		foreach (var invocation in invocations)
+		foreach (var invocation in methodSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
 		{
 			ct.ThrowIfCancellationRequested();
-
-			// Check if it's a method call like .Analyzer("name", ...) or .Tokenizer("name", ...)
 			if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
 				continue;
 
 			var methodName = memberAccess.Name.Identifier.Text;
 			var args = invocation.ArgumentList.Arguments;
-
-			// Must have at least one argument (the name)
 			if (args.Count < 1)
 				continue;
 
-			// Get the first argument as the component name
-			var firstArg = args[0].Expression;
-			var componentName = ExtractStringLiteral(firstArg);
-
+			// No SemanticModel available — literals only (no const resolution).
+			var componentName = ExtractStringLiteralOnly(args[0].Expression);
 			if (string.IsNullOrEmpty(componentName))
 				continue;
 
@@ -83,27 +89,60 @@ internal static class ConfigureAnalysisParser
 			switch (methodName)
 			{
 				case "Analyzer":
-					if (!analyzers.Any(a => a.Value == componentName))
-						analyzers.Add(component);
+					if (!analyzers.Any(a => a.Value == componentName)) analyzers.Add(component);
 					break;
 				case "Tokenizer":
-					if (!tokenizers.Any(t => t.Value == componentName))
-						tokenizers.Add(component);
+					if (!tokenizers.Any(t => t.Value == componentName)) tokenizers.Add(component);
 					break;
 				case "TokenFilter":
-					if (!tokenFilters.Any(f => f.Value == componentName))
-						tokenFilters.Add(component);
+					if (!tokenFilters.Any(f => f.Value == componentName)) tokenFilters.Add(component);
 					break;
 				case "CharFilter":
-					if (!charFilters.Any(f => f.Value == componentName))
-						charFilters.Add(component);
+					if (!charFilters.Any(f => f.Value == componentName)) charFilters.Add(component);
 					break;
 				case "Normalizer":
-					if (!normalizers.Any(n => n.Value == componentName))
-						normalizers.Add(component);
+					if (!normalizers.Any(n => n.Value == componentName)) normalizers.Add(component);
 					break;
 			}
 		}
+
+		return new AnalysisComponentsModel(
+			analyzers.ToImmutable(), tokenizers.ToImmutable(),
+			tokenFilters.ToImmutable(), charFilters.ToImmutable(), normalizers.ToImmutable());
+	}
+
+	// Literal-only extraction — used when no SemanticModel is available.
+	private static string? ExtractStringLiteralOnly(ExpressionSyntax expression)
+	{
+		if (expression is LiteralExpressionSyntax { RawKind: (int)SyntaxKind.StringLiteralExpression } literal)
+			return literal.Token.ValueText;
+
+		if (expression is InterpolatedStringExpressionSyntax interpolated &&
+			interpolated.Contents.Count == 1 &&
+			interpolated.Contents[0] is InterpolatedStringTextSyntax textContent)
+			return textContent.TextToken.ValueText;
+
+		return null;
+	}
+
+	/// <summary>
+	/// Parses analysis components from a specific method symbol, following delegated calls
+	/// transitively so names defined in shared factory methods are discovered automatically.
+	/// </summary>
+	public static AnalysisComponentsModel ParseFromMethod(IMethodSymbol method, Compilation compilation, CancellationToken ct)
+	{
+		ct.ThrowIfCancellationRequested();
+
+		var analyzers = ImmutableArray.CreateBuilder<AnalysisComponentModel>();
+		var tokenizers = ImmutableArray.CreateBuilder<AnalysisComponentModel>();
+		var tokenFilters = ImmutableArray.CreateBuilder<AnalysisComponentModel>();
+		var charFilters = ImmutableArray.CreateBuilder<AnalysisComponentModel>();
+		var normalizers = ImmutableArray.CreateBuilder<AnalysisComponentModel>();
+
+		// Visited set keyed on string (never a symbol) to break cycles and diamond delegation.
+		var visited = new HashSet<string>();
+
+		Walk(method, compilation, visited, analyzers, tokenizers, tokenFilters, charFilters, normalizers, ct);
 
 		return new AnalysisComponentsModel(
 			analyzers.ToImmutable(),
@@ -114,7 +153,108 @@ internal static class ConfigureAnalysisParser
 		);
 	}
 
-	private static string? ExtractStringLiteral(ExpressionSyntax expression)
+	private static void Walk(
+		IMethodSymbol method,
+		Compilation compilation,
+		HashSet<string> visited,
+		ImmutableArray<AnalysisComponentModel>.Builder analyzers,
+		ImmutableArray<AnalysisComponentModel>.Builder tokenizers,
+		ImmutableArray<AnalysisComponentModel>.Builder tokenFilters,
+		ImmutableArray<AnalysisComponentModel>.Builder charFilters,
+		ImmutableArray<AnalysisComponentModel>.Builder normalizers,
+		CancellationToken ct)
+	{
+		ct.ThrowIfCancellationRequested();
+
+		// Use OriginalDefinition to normalise generic instantiations (e.g. BuildAnalysis<T> → BuildAnalysis).
+		var visitKey = method.OriginalDefinition.ToDisplayString();
+		if (!visited.Add(visitKey))
+			return;
+
+		foreach (var syntaxRef in method.DeclaringSyntaxReferences)
+		{
+			ct.ThrowIfCancellationRequested();
+
+			var methodSyntax = syntaxRef.GetSyntax(ct);
+
+			// Obtain the semantic model for the specific syntax tree this method lives in.
+			// SharedAnalysisFactory may live in a different file than the context class.
+			var semanticModel = compilation.GetSemanticModel(syntaxRef.SyntaxTree);
+
+			var invocations = methodSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>();
+			foreach (var invocation in invocations)
+			{
+				ct.ThrowIfCancellationRequested();
+
+				if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+					continue;
+
+				var methodName = memberAccess.Name.Identifier.Text;
+				var args = invocation.ArgumentList.Arguments;
+
+				// AnalysisBuilder component registrations always take exactly (name, configure) = 2 args.
+				// Inner builder calls like .Tokenizer("standard") (1 arg) or .Filters("a", "b") (2+ args, wrong name)
+				// are excluded by requiring exactly 2 arguments, preventing false positives.
+				if (args.Count == 2)
+				{
+					var firstArg = args[0].Expression;
+					var componentName = ExtractStringLiteral(firstArg, semanticModel);
+
+					if (!string.IsNullOrEmpty(componentName))
+					{
+						var constantName = ToConstantName(componentName!);
+						var component = new AnalysisComponentModel(constantName, componentName!);
+
+						switch (methodName)
+						{
+							case "Analyzer":
+								if (!analyzers.Any(a => a.Value == componentName))
+									analyzers.Add(component);
+								break;
+							case "Tokenizer":
+								if (!tokenizers.Any(t => t.Value == componentName))
+									tokenizers.Add(component);
+								break;
+							case "TokenFilter":
+								if (!tokenFilters.Any(f => f.Value == componentName))
+									tokenFilters.Add(component);
+								break;
+							case "CharFilter":
+								if (!charFilters.Any(f => f.Value == componentName))
+									charFilters.Add(component);
+								break;
+							case "Normalizer":
+								if (!normalizers.Any(n => n.Value == componentName))
+									normalizers.Add(component);
+								break;
+						}
+					}
+				}
+
+				// Follow delegated method calls — recurse into any user-authored method we have source for.
+				var invokedSymbolInfo = semanticModel.GetSymbolInfo(invocation, ct);
+				if (invokedSymbolInfo.Symbol is not IMethodSymbol invokedMethod)
+					continue;
+
+				// Skip the AnalysisBuilder fluent surface itself (its methods ARE the registration calls).
+				var containingTypeName = invokedMethod.ContainingType?.ToDisplayString();
+				if (containingTypeName == AnalysisBuilderTypeName)
+					continue;
+
+				// Only recurse when we have the source to parse.
+				if (invokedMethod.DeclaringSyntaxReferences.Length == 0)
+					continue;
+
+				Walk(invokedMethod.OriginalDefinition, compilation, visited, analyzers, tokenizers, tokenFilters, charFilters, normalizers, ct);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Extracts a compile-time string value from an expression.
+	/// Handles string literals, constant interpolated strings, and field/property constant references.
+	/// </summary>
+	private static string? ExtractStringLiteral(ExpressionSyntax expression, SemanticModel semanticModel)
 	{
 		// Handle simple string literals: "name"
 		if (expression is LiteralExpressionSyntax { RawKind: (int)SyntaxKind.StringLiteralExpression } literal)
@@ -125,6 +265,12 @@ internal static class ConfigureAnalysisParser
 			interpolated.Contents.Count == 1 &&
 			interpolated.Contents[0] is InterpolatedStringTextSyntax textContent)
 			return textContent.TextToken.ValueText;
+
+		// Handle const references: MyConst, SomeClass.MyConst, etc.
+		// Resolved via the semantic model — works even when the const lives in another file.
+		var symbol = semanticModel.GetSymbolInfo(expression).Symbol;
+		if (symbol is IFieldSymbol { HasConstantValue: true } field && field.ConstantValue is string constValue)
+			return constValue;
 
 		return null;
 	}

--- a/src/Elastic.Mapping.Generator/Emitters/AnalysisNamesEmitter.cs
+++ b/src/Elastic.Mapping.Generator/Emitters/AnalysisNamesEmitter.cs
@@ -15,6 +15,7 @@ internal static class AnalysisNamesEmitter
 {
 	/// <summary>
 	/// Emits analysis names for a type registration within a context.
+	/// Used for inline analysis authors — per-context <c>{ResolverName}Analysis</c> emission.
 	/// </summary>
 	public static string? EmitForContext(ContextMappingModel context, TypeRegistration reg)
 	{
@@ -32,6 +33,35 @@ internal static class AnalysisNamesEmitter
 		}
 
 		EmitAnalysisClass(sb, "", reg.ResolverName, reg.AnalysisComponents);
+
+		return sb.ToString();
+	}
+
+	/// <summary>
+	/// Emits a base-type-anchored analysis accessor class so that generic code constrained
+	/// on the base type can reference analysis component names without knowing the concrete
+	/// document type. The generated class is named <c>{anchorName}Analysis</c> and placed in
+	/// the anchor's namespace, emitted exactly once regardless of how many derived types share
+	/// the same analysis. This mirrors the #185 base-type extension pattern for field methods.
+	/// </summary>
+	public static string EmitBaseAnchored(string emitNamespace, string anchorName, AnalysisComponentsModel components)
+	{
+		var sb = new StringBuilder();
+
+		SharedEmitterHelpers.EmitHeader(sb);
+
+		// Anchored accessor may live in the same namespace as the base type's assembly —
+		// suppress CS0436 (duplicate type in referenced assembly) just in case.
+		sb.AppendLine("#pragma warning disable CS0436");
+		sb.AppendLine();
+
+		if (!string.IsNullOrEmpty(emitNamespace))
+		{
+			sb.AppendLine($"namespace {emitNamespace};");
+			sb.AppendLine();
+		}
+
+		EmitAnalysisClass(sb, "", anchorName, components);
 
 		return sb.ToString();
 	}

--- a/src/Elastic.Mapping.Generator/Emitters/MappingsBuilderEmitter.cs
+++ b/src/Elastic.Mapping.Generator/Emitters/MappingsBuilderEmitter.cs
@@ -385,4 +385,81 @@ internal static class MappingsBuilderEmitter
 		sb.AppendLine("\t\treturn self;");
 		sb.AppendLine("\t}");
 	}
+
+	/// <summary>
+	/// Emits generic-constrained extension methods on <c>MappingsBuilder&lt;TDoc&gt;</c> that expose
+	/// analysis-component accessor instances for code constrained on the base type.
+	/// Emitted into a <c>partial</c> class so it can coexist with the field-extension class
+	/// produced by <see cref="EmitBaseExtensionsClass"/> without CS0101.
+	///
+	/// Example usage from generic code:
+	/// <code>
+	/// static MappingsBuilder&lt;T&gt; Use&lt;T&gt;(MappingsBuilder&lt;T&gt; m) where T : SearchDocumentBase
+	///     => m.Normalizers().KeywordNormalizer  // "keyword_normalizer"
+	/// </code>
+	/// </summary>
+	public static string EmitBaseAnchoredAnalysisExtensions(
+		string emitNamespace,
+		string anchorName,
+		string anchorFullyQualifiedName,
+		AnalysisComponentsModel components)
+	{
+		var sb = new StringBuilder();
+
+		SharedEmitterHelpers.EmitHeader(sb);
+
+		// The analysis extensions class is partial alongside the field-extensions class.
+		// Suppress CS0436 when the base type's project also compiled one.
+		sb.AppendLine("#pragma warning disable CS0436");
+		sb.AppendLine();
+
+		if (!string.IsNullOrEmpty(emitNamespace))
+		{
+			sb.AppendLine($"namespace {emitNamespace};");
+			sb.AppendLine();
+		}
+
+		const string typeParam = "TDoc";
+		var constraintClause = $" where {typeParam} : global::{anchorFullyQualifiedName}";
+		var builderType = $"{MappingsBuilderFqn}<{typeParam}>";
+		var analysisClassName = $"global::{(string.IsNullOrEmpty(emitNamespace) ? "" : emitNamespace + ".")}{anchorName}Analysis";
+
+		var extensionClassName = $"{anchorName}MappingsExtensions";
+
+		sb.AppendLine($"/// <summary>Generic-constrained extension methods that expose analysis-component accessors for <c>{anchorName}</c>-constrained mappings.</summary>");
+		sb.AppendLine($"public static partial class {extensionClassName}");
+		sb.AppendLine("{");
+
+		// Emit one accessor property per component kind, returning the static instance from the
+		// base-anchored {AnchorName}Analysis class so callers get typed, strongly-named keys.
+		EmitAnalysisAccessorExtension(sb, typeParam, constraintClause, builderType, analysisClassName, "Analyzers", components.Analyzers.Length > 0);
+		sb.AppendLine();
+		EmitAnalysisAccessorExtension(sb, typeParam, constraintClause, builderType, analysisClassName, "Tokenizers", components.Tokenizers.Length > 0);
+		sb.AppendLine();
+		EmitAnalysisAccessorExtension(sb, typeParam, constraintClause, builderType, analysisClassName, "TokenFilters", components.TokenFilters.Length > 0);
+		sb.AppendLine();
+		EmitAnalysisAccessorExtension(sb, typeParam, constraintClause, builderType, analysisClassName, "CharFilters", components.CharFilters.Length > 0);
+		sb.AppendLine();
+		EmitAnalysisAccessorExtension(sb, typeParam, constraintClause, builderType, analysisClassName, "Normalizers", components.Normalizers.Length > 0);
+
+		sb.AppendLine("}");
+		sb.AppendLine();
+
+		return sb.ToString();
+	}
+
+	private static void EmitAnalysisAccessorExtension(
+		StringBuilder sb,
+		string typeParam,
+		string constraintClause,
+		string builderType,
+		string analysisClassName,
+		string kind,
+		bool hasCustom)
+	{
+		var returnType = $"{analysisClassName}.{kind}Accessor";
+		sb.AppendLine($"\t/// <summary>Returns the {kind.ToLowerInvariant()} name accessor for {(hasCustom ? "built-in and custom" : "built-in")} {kind.ToLowerInvariant()}.</summary>");
+		sb.AppendLine($"\tpublic static {returnType} {kind}<{typeParam}>(this {builderType} _){constraintClause}");
+		sb.AppendLine($"\t\t=> {analysisClassName}.{kind};");
+	}
 }

--- a/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
+++ b/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
@@ -97,6 +97,10 @@ public class MappingSourceGenerator : IIncrementalGenerator
 
 		var stjConfig = StjContextAnalyzer.Analyze(jsonContextSymbol);
 
+		// Capture Compilation once at transform time — used transiently to follow delegated
+		// ConfigureAnalysis calls across files. Never stored on model records.
+		var compilation = context.SemanticModel.Compilation;
+
 		var registrations = ImmutableArray.CreateBuilder<TypeRegistration>();
 
 		foreach (var attr in contextSymbol.GetAttributes())
@@ -109,11 +113,11 @@ public class MappingSourceGenerator : IIncrementalGenerator
 
 			TypeRegistration? registration = null;
 			if (attrClassName.StartsWith(IndexAttributePrefix, StringComparison.Ordinal))
-				registration = ProcessIndexAttribute(attr, contextSymbol, stjConfig, ct);
+				registration = ProcessIndexAttribute(attr, contextSymbol, stjConfig, compilation, ct);
 			else if (attrClassName.StartsWith(DataStreamAttributePrefix, StringComparison.Ordinal))
-				registration = ProcessDataStreamAttribute(attr, contextSymbol, stjConfig, "DataStream", ct);
+				registration = ProcessDataStreamAttribute(attr, contextSymbol, stjConfig, "DataStream", compilation, ct);
 			else if (attrClassName.StartsWith(WiredStreamAttributePrefix, StringComparison.Ordinal))
-				registration = ProcessDataStreamAttribute(attr, contextSymbol, stjConfig, "WiredStream", ct);
+				registration = ProcessDataStreamAttribute(attr, contextSymbol, stjConfig, "WiredStream", compilation, ct);
 
 			if (registration != null)
 				registrations.Add(registration);
@@ -177,6 +181,7 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		AttributeData attr,
 		INamedTypeSymbol contextSymbol,
 		StjContextConfig? stjConfig,
+		Compilation compilation,
 		CancellationToken ct)
 	{
 		var typeArg = attr.AttributeClass?.TypeArguments.FirstOrDefault();
@@ -200,7 +205,7 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		var ingestProperties = AnalyzeIngestProperties(targetType, stjConfig);
 		ExtractConfigAndVariant(attr, out var configClassName, out var configTypeSymbol, out var variant);
 
-		return BuildTypeRegistration(targetType, contextSymbol, stjConfig, indexConfig, null, entityConfig, ingestProperties, configClassName, configTypeSymbol, variant, ct);
+		return BuildTypeRegistration(targetType, contextSymbol, stjConfig, indexConfig, null, entityConfig, ingestProperties, configClassName, configTypeSymbol, variant, compilation, ct);
 	}
 
 	private static TypeRegistration? ProcessDataStreamAttribute(
@@ -208,6 +213,7 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		INamedTypeSymbol contextSymbol,
 		StjContextConfig? stjConfig,
 		string entityTarget,
+		Compilation compilation,
 		CancellationToken ct)
 	{
 		var typeArg = attr.AttributeClass?.TypeArguments.FirstOrDefault();
@@ -233,7 +239,7 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		var ingestProperties = AnalyzeIngestProperties(targetType, stjConfig);
 		ExtractConfigAndVariant(attr, out var configClassName, out var configTypeSymbol, out var variant);
 
-		return BuildTypeRegistration(targetType, contextSymbol, stjConfig, null, dataStreamConfig, entityConfig, ingestProperties, configClassName, configTypeSymbol, variant, ct);
+		return BuildTypeRegistration(targetType, contextSymbol, stjConfig, null, dataStreamConfig, entityConfig, ingestProperties, configClassName, configTypeSymbol, variant, compilation, ct);
 	}
 
 	private static void ExtractConfigAndVariant(
@@ -349,6 +355,7 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		string? configClassName,
 		INamedTypeSymbol? configTypeSymbol,
 		string? variant,
+		Compilation compilation,
 		CancellationToken ct)
 	{
 		var typeModel = TypeAnalyzer.Analyze(targetType, stjConfig, indexConfig, dataStreamConfig, ct);
@@ -420,28 +427,31 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		// Priority: context > config class (interface) > config class (legacy static) > entity (interface) > entity (legacy static)
 		string? configureAnalysisRef = null;
 		AnalysisComponentsModel analysisComponents;
+		// When analysis is discovered via delegation (the ConfigureAnalysis method calls a shared
+		// factory), we record the anchor so emitters can produce a base-type-anchored accessor.
+		bool analysisViaDelegate = false;
 
 		if (contextConfigureAnalysis != null)
 		{
 			configureAnalysisRef = $"global::{contextSymbol.ToDisplayString()}.{contextConfigureAnalysis.Name}";
-			analysisComponents = ConfigureAnalysisParser.ParseFromMethod(contextConfigureAnalysis, ct);
+			analysisComponents = ConfigureAnalysisParser.ParseFromMethod(contextConfigureAnalysis, compilation, ct);
 		}
 		else if (configClassImplementsInterface)
 		{
 			configureAnalysisRef = $"_configureElasticsearch_ConfigureAnalysis";
 			analysisComponents = configTypeSymbol != null
-				? ParseAnalysisFromConfigureMethod(configTypeSymbol, ct)
+				? ParseAnalysisFromConfigureMethod(configTypeSymbol, compilation, ct, out analysisViaDelegate)
 				: AnalysisComponentsModel.Empty;
 		}
 		else if (configClassAnalysis != null)
 		{
 			configureAnalysisRef = $"global::{configTypeSymbol!.ToDisplayString()}.ConfigureAnalysis";
-			analysisComponents = ConfigureAnalysisParser.ParseFromMethod(configClassAnalysis, ct);
+			analysisComponents = ConfigureAnalysisParser.ParseFromMethod(configClassAnalysis, compilation, ct);
 		}
 		else if (entityImplementsInterface)
 		{
 			configureAnalysisRef = $"_configureElasticsearch_ConfigureAnalysis";
-			analysisComponents = ParseAnalysisFromConfigureMethod(targetType, ct);
+			analysisComponents = ParseAnalysisFromConfigureMethod(targetType, compilation, ct, out analysisViaDelegate);
 		}
 		else if (hasConfigureAnalysisOnType)
 		{
@@ -451,6 +461,27 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		else
 		{
 			analysisComponents = AnalysisComponentsModel.Empty;
+		}
+
+		// --- Determine analysis anchor ---
+		// When analysis was found via delegation to a shared factory, anchor the generated keys
+		// to the nearest user-defined base type so generic code can reference them without
+		// knowing the concrete document type. This mirrors the #185 base-type-extension pattern.
+		AnalysisAnchorModel? analysisAnchor = null;
+		if (analysisViaDelegate && analysisComponents.HasAnyComponents)
+		{
+			var baseType = targetType.BaseType;
+			while (baseType != null && baseType.SpecialType != SpecialType.None)
+				baseType = baseType.BaseType;
+
+			if (baseType != null && baseType.SpecialType == SpecialType.None)
+			{
+				analysisAnchor = new AnalysisAnchorModel(
+					baseType.Name,
+					baseType.ContainingNamespace?.ToDisplayString() ?? string.Empty,
+					baseType.ToDisplayString()
+				);
+			}
 		}
 
 		// --- Build ConfigureMappings info ---
@@ -536,7 +567,8 @@ public class MappingSourceGenerator : IIncrementalGenerator
 			analysisComponents,
 			variant,
 			indexSettingsRef,
-			misuseFindings
+			misuseFindings,
+			analysisAnchor
 		);
 	}
 
@@ -605,14 +637,59 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		return allFindings.ToImmutable();
 	}
 
-	private static AnalysisComponentsModel ParseAnalysisFromConfigureMethod(INamedTypeSymbol typeSymbol, CancellationToken ct)
+	private static AnalysisComponentsModel ParseAnalysisFromConfigureMethod(
+		INamedTypeSymbol typeSymbol,
+		Compilation compilation,
+		CancellationToken ct,
+		out bool viaDelegate)
 	{
+		viaDelegate = false;
 		var method = typeSymbol.GetMembers("ConfigureAnalysis")
 			.OfType<IMethodSymbol>()
 			.FirstOrDefault(m => m.Parameters.Length == 1);
-		return method != null
-			? ConfigureAnalysisParser.ParseFromMethod(method, ct)
-			: AnalysisComponentsModel.Empty;
+
+		if (method == null)
+			return AnalysisComponentsModel.Empty;
+
+		// Detect delegation: the method delegates when it has at least one invocation that
+		// resolves to a user-authored method with source (i.e. not just returning the parameter).
+		viaDelegate = MethodDelegatesAnalysis(method, compilation, ct);
+
+		return ConfigureAnalysisParser.ParseFromMethod(method, compilation, ct);
+	}
+
+	/// <summary>
+	/// Returns true when the method contains an invocation that resolves to a user-authored
+	/// method with source code (i.e. it delegates rather than authoring analysis inline).
+	/// A pass-through (<c>=> analysis</c>) or a purely-inline fluent chain has no such calls.
+	/// </summary>
+	private static bool MethodDelegatesAnalysis(IMethodSymbol method, Compilation compilation, CancellationToken ct)
+	{
+		const string analysisBuilderTypeName = "Elastic.Mapping.Analysis.AnalysisBuilder";
+
+		foreach (var syntaxRef in method.DeclaringSyntaxReferences)
+		{
+			ct.ThrowIfCancellationRequested();
+			var methodSyntax = syntaxRef.GetSyntax(ct);
+			var semanticModel = compilation.GetSemanticModel(syntaxRef.SyntaxTree);
+
+			foreach (var invocation in methodSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
+			{
+				var invokedSymbolInfo = semanticModel.GetSymbolInfo(invocation, ct);
+				if (invokedSymbolInfo.Symbol is not IMethodSymbol invokedMethod)
+					continue;
+
+				// Skip AnalysisBuilder fluent methods (they are registration calls, not delegation)
+				if (invokedMethod.ContainingType?.ToDisplayString() == analysisBuilderTypeName)
+					continue;
+
+				// Any user method with source = delegation
+				if (invokedMethod.DeclaringSyntaxReferences.Length > 0)
+					return true;
+			}
+		}
+
+		return false;
 	}
 
 	private static readonly DiagnosticDescriptor DuplicateAiEnrichmentDiagnostic = new(
@@ -640,6 +717,42 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		// base type's methods are emitted exactly once regardless of how many concrete
 		// derived types are registered.
 		var emittedBaseExtensionKeys = new HashSet<string>();
+
+		// Accumulate analysis components per anchor across ALL registrations before emitting.
+		// Multiple registrations sharing the same anchor may each contribute different component
+		// names (e.g. one delegates to BuildBaseAnalysis, another to BuildExtendedAnalysis which
+		// adds synonym analyzers). We merge so the single emitted accessor covers the union.
+		// Keyed by "{anchorNamespace}::{anchorFullyQualifiedName}".
+		var anchorComponents = new Dictionary<string, (AnalysisAnchorModel Anchor, AnalysisComponentsModel Components)>();
+		foreach (var model in models)
+		{
+			foreach (var reg in model.TypeRegistrations)
+			{
+				if (reg.AnalysisAnchor == null || !reg.AnalysisComponents.HasAnyComponents)
+					continue;
+
+				var anchorKey = $"{reg.AnalysisAnchor.Namespace}::{reg.AnalysisAnchor.FullyQualifiedName}";
+				if (anchorComponents.TryGetValue(anchorKey, out var existing))
+					anchorComponents[anchorKey] = (existing.Anchor, existing.Components.Merge(reg.AnalysisComponents));
+				else
+					anchorComponents[anchorKey] = (reg.AnalysisAnchor, reg.AnalysisComponents);
+			}
+		}
+
+		// Emit the merged anchor-anchored accessor and extensions once per anchor type.
+		foreach (var kvp in anchorComponents)
+		{
+			var anchor = kvp.Value.Anchor;
+			var mergedComponents = kvp.Value.Components;
+
+			var anchoredAnalysisSource = AnalysisNamesEmitter.EmitBaseAnchored(
+				anchor.Namespace, anchor.Name, mergedComponents);
+			context.AddSource($"{anchor.Name}Analysis.g.cs", anchoredAnalysisSource);
+
+			var anchoredExtSource = MappingsBuilderEmitter.EmitBaseAnchoredAnalysisExtensions(
+				anchor.Namespace, anchor.Name, anchor.FullyQualifiedName, mergedComponents);
+			context.AddSource($"{anchor.Name}AnalysisExtensions.g.cs", anchoredExtSource);
+		}
 
 		// Enforce: only one [AiEnrichment<T>] per document type across all contexts
 		var aiEnrichmentTypes = new Dictionary<string, string>();
@@ -728,9 +841,17 @@ public class MappingSourceGenerator : IIncrementalGenerator
 					}
 				}
 
-				var analysisNamesSource = AnalysisNamesEmitter.EmitForContext(model, reg);
-				if (analysisNamesSource != null)
-					context.AddSource($"{model.ContextTypeName}.{reg.ResolverName}Analysis.g.cs", analysisNamesSource);
+				// Analysis accessor emission:
+				// - When analysis is anchored to a base type (delegation path), the shared accessor
+				//   and generic-constrained extensions are already emitted in the pre-pass above.
+				//   Skip per-context emission so there's no competing {ResolverName}Analysis class.
+				// - When analysis is inline (no anchor), emit the per-context accessor as before.
+				if (reg.AnalysisAnchor == null)
+				{
+					var analysisNamesSource = AnalysisNamesEmitter.EmitForContext(model, reg);
+					if (analysisNamesSource != null)
+						context.AddSource($"{model.ContextTypeName}.{reg.ResolverName}Analysis.g.cs", analysisNamesSource);
+				}
 			}
 
 			if (model.AiEnrichment != null)

--- a/src/Elastic.Mapping.Generator/Model/AnalysisComponentsModel.cs
+++ b/src/Elastic.Mapping.Generator/Model/AnalysisComponentsModel.cs
@@ -31,6 +31,35 @@ internal sealed record AnalysisComponentsModel(
 		TokenFilters.Length > 0 ||
 		CharFilters.Length > 0 ||
 		Normalizers.Length > 0;
+
+	/// <summary>
+	/// Merges another model's components into this one, deduplicating by value.
+	/// Used when multiple registrations share the same analysis anchor and each may
+	/// contribute different component names (e.g. base vs extended analysis factory).
+	/// </summary>
+	public AnalysisComponentsModel Merge(AnalysisComponentsModel other) => new(
+		Merge(Analyzers, other.Analyzers),
+		Merge(Tokenizers, other.Tokenizers),
+		Merge(TokenFilters, other.TokenFilters),
+		Merge(CharFilters, other.CharFilters),
+		Merge(Normalizers, other.Normalizers)
+	);
+
+	private static ImmutableArray<AnalysisComponentModel> Merge(
+		ImmutableArray<AnalysisComponentModel> a,
+		ImmutableArray<AnalysisComponentModel> b)
+	{
+		if (b.Length == 0) return a;
+		if (a.Length == 0) return b;
+
+		var builder = a.ToBuilder();
+		foreach (var item in b)
+		{
+			if (!builder.Any(x => x.Value == item.Value))
+				builder.Add(item);
+		}
+		return builder.ToImmutable();
+	}
 }
 
 /// <summary>

--- a/src/Elastic.Mapping.Generator/Model/ContextMappingModel.cs
+++ b/src/Elastic.Mapping.Generator/Model/ContextMappingModel.cs
@@ -18,6 +18,17 @@ internal sealed record ContextMappingModel(
 );
 
 /// <summary>
+/// Identifies the base type to which analysis-component keys are anchored.
+/// When analysis is discovered via delegation to a shared factory, the keys are emitted
+/// once under this base type's name so generic code constrained on the base can reference them.
+/// </summary>
+internal sealed record AnalysisAnchorModel(
+	string Name,
+	string Namespace,
+	string FullyQualifiedName
+);
+
+/// <summary>
 /// Represents a single type registration within a context (via [Entity&lt;T&gt;]).
 /// </summary>
 internal sealed record TypeRegistration(
@@ -43,7 +54,14 @@ internal sealed record TypeRegistration(
 	/// Compile-time misuse findings for AddField/AddProperty in ConfigureMappings.
 	/// Reported as EMAP001 / EMAP002 diagnostics.
 	/// </summary>
-	ImmutableArray<MappingMisuseFinding> MisuseFindings = default
+	ImmutableArray<MappingMisuseFinding> MisuseFindings = default,
+	/// <summary>
+	/// When non-null, analysis was discovered via delegation to a shared factory and the keys
+	/// should be emitted once anchored to this base type rather than per concrete context.
+	/// Per-context <c>{ResolverName}Analysis</c> emission is suppressed in favour of the
+	/// shared <c>{AnchorName}Analysis</c> accessor.
+	/// </summary>
+	AnalysisAnchorModel? AnalysisAnchor = null
 )
 {
 	/// <summary>

--- a/tests/Elastic.Mapping.Tests/DelegatedAnalysisTests.cs
+++ b/tests/Elastic.Mapping.Tests/DelegatedAnalysisTests.cs
@@ -1,0 +1,151 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Mapping.Mappings;
+
+namespace Elastic.Mapping.Tests;
+
+/// <summary>
+/// Tests for the delegation-following analysis parser and base-type-anchored accessor emission.
+/// Verifies that analysis component names defined in a separate shared factory class are
+/// discovered transitively via ConfigureAnalysis delegation and exposed as source-generated
+/// keys reachable from generic code constrained on the base document type.
+/// </summary>
+public class DelegatedAnalysisTests
+{
+	// ──────────────────────────────────────────────────────────────────────────────
+	// Static accessor: SearchBaseDocumentAnalysis.{Kind}.Name
+	// ──────────────────────────────────────────────────────────────────────────────
+
+	[Test]
+	public void StaticAccessor_Normalizer_KeywordNormalizer()
+	{
+		// const-resolved: SearchAnalysisFactory.KeywordNormalizerName = "keyword_normalizer"
+		SearchBaseDocumentAnalysis.Normalizers.KeywordNormalizer
+			.Should().Be("keyword_normalizer");
+	}
+
+	[Test]
+	public void StaticAccessor_Analyzers_StartsWithAnalyzer()
+	{
+		SearchBaseDocumentAnalysis.Analyzers.StartsWithAnalyzer
+			.Should().Be("starts_with_analyzer");
+	}
+
+	[Test]
+	public void StaticAccessor_Analyzers_StartsWithAnalyzerSearch()
+	{
+		SearchBaseDocumentAnalysis.Analyzers.StartsWithAnalyzerSearch
+			.Should().Be("starts_with_analyzer_search");
+	}
+
+	[Test]
+	public void StaticAccessor_Analyzers_SynonymsAnalyzer_TransitiveDelegation()
+	{
+		// "synonyms_analyzer" is defined in BuildExtendedAnalysis, which is reached
+		// transitively from the SearchProductConfig.ConfigureAnalysis delegation.
+		// Both docs share the same anchor so the accessor covers the union of all names.
+		SearchBaseDocumentAnalysis.Analyzers.SynonymsAnalyzer
+			.Should().Be("synonyms_analyzer");
+	}
+
+	[Test]
+	public void StaticAccessor_TokenFilters_EnglishStop()
+	{
+		SearchBaseDocumentAnalysis.TokenFilters.EnglishStop
+			.Should().Be("english_stop");
+	}
+
+	[Test]
+	public void StaticAccessor_TokenFilters_SynonymsFilter()
+	{
+		// Defined in BuildExtendedAnalysis — transitive delegation.
+		SearchBaseDocumentAnalysis.TokenFilters.SynonymsFilter
+			.Should().Be("synonyms_filter");
+	}
+
+	[Test]
+	public void StaticAccessor_CharFilters_StripNonWord()
+	{
+		SearchBaseDocumentAnalysis.CharFilters.StripNonWord
+			.Should().Be("strip_non_word");
+	}
+
+	[Test]
+	public void StaticAccessor_Tokenizers_StartsWithTokenizer()
+	{
+		SearchBaseDocumentAnalysis.Tokenizers.StartsWithTokenizer
+			.Should().Be("starts_with_tokenizer");
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────────
+	// Surface parity: both surfaces return the same string value
+	// ──────────────────────────────────────────────────────────────────────────────
+
+	[Test]
+	public void GenericExtension_Normalizers_MatchesStaticAccessor()
+	{
+		// Surface (2) == surface (1) — both return the raw ES name.
+		var viaExtension = UseAnalysisKeys_Normalizer();
+		viaExtension.Should().Be(SearchBaseDocumentAnalysis.Normalizers.KeywordNormalizer);
+	}
+
+	[Test]
+	public void GenericExtension_Analyzers_MatchesStaticAccessor()
+	{
+		var viaExtension = UseAnalysisKeys_Analyzer();
+		viaExtension.Should().Be(SearchBaseDocumentAnalysis.Analyzers.StartsWithAnalyzer);
+	}
+
+	// Helpers that exercise the generic-constrained extension path at the type level.
+	// These helpers only compile if the generator emitted the `where TDoc : SearchBaseDocument` extensions.
+	private static string UseAnalysisKeys_Normalizer<T>(MappingsBuilder<T> m) where T : SearchBaseDocument
+		=> m.Normalizers().KeywordNormalizer;
+
+	private static string UseAnalysisKeys_Normalizer()
+	{
+		var config = new SearchArticleConfig();
+		return config.ConfigureMappings(new MappingsBuilder<SearchArticle>()).Normalizers().KeywordNormalizer;
+	}
+
+	private static string UseAnalysisKeys_Analyzer()
+	{
+		var config = new SearchArticleConfig();
+		return config.ConfigureMappings(new MappingsBuilder<SearchArticle>()).Analyzers().StartsWithAnalyzer;
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────────
+	// Built-in pass-through: base accessor still exposes built-in names
+	// ──────────────────────────────────────────────────────────────────────────────
+
+	[Test]
+	public void BuiltIn_Analyzers_Standard_StillAccessible()
+	{
+		SearchBaseDocumentAnalysis.Analyzers.Standard
+			.Should().Be("standard");
+	}
+
+	[Test]
+	public void BuiltIn_Tokenizers_Whitespace_StillAccessible()
+	{
+		SearchBaseDocumentAnalysis.Tokenizers.Whitespace
+			.Should().Be("whitespace");
+	}
+
+	// ──────────────────────────────────────────────────────────────────────────────
+	// Dedup: two different registered types share one anchored accessor (no CS0101)
+	// This is a compile-time check — if the generator emitted the accessor twice,
+	// the build above would have failed with CS0101 / CS0436.
+	// ──────────────────────────────────────────────────────────────────────────────
+
+	[Test]
+	public void Dedup_BothConfigsShareSameAccessor()
+	{
+		// Both SearchArticle and SearchProduct delegate analysis — anchored to SearchBaseDocument.
+		// The accessor class is emitted once and is the same static class.
+		var fromArticleCtx = SearchBaseDocumentAnalysis.Normalizers.KeywordNormalizer;
+		var fromProductCtx = SearchBaseDocumentAnalysis.Normalizers.KeywordNormalizer;
+		fromArticleCtx.Should().Be(fromProductCtx);
+	}
+}

--- a/tests/Elastic.Mapping.Tests/TestModels.cs
+++ b/tests/Elastic.Mapping.Tests/TestModels.cs
@@ -713,3 +713,133 @@ public class DerivedPageConfig : IConfigureElasticsearch<DerivedPage>
 [Index<IntermediatePage>(Name = "intermediate-docs")]
 [Index<DerivedPage>(Name = "derived-docs", Configuration = typeof(DerivedPageConfig))]
 public static partial class InheritanceMappingContext;
+
+// ============================================================================
+// DELEGATION TEST MODELS: analysis defined in a shared factory, referenced
+// via ConfigureAnalysis delegation — mirrors the website-ai-search pattern.
+// ============================================================================
+
+/// <summary>
+/// Shared analysis factory that lives in a separate class from the mapping context,
+/// mirroring the SharedAnalysisFactory pattern in website-ai-search.
+/// </summary>
+public static class SearchAnalysisFactory
+{
+	// Const reference — should resolve via semantic const-resolution in the parser.
+	public const string KeywordNormalizerName = "keyword_normalizer";
+
+	/// <summary>
+	/// Base analysis — names discoverable via delegation following.
+	/// </summary>
+	public static AnalysisBuilder BuildBaseAnalysis(AnalysisBuilder analysis) => analysis
+		.Normalizer(KeywordNormalizerName, n => n.Custom()
+			.Filters("lowercase", "asciifolding"))
+		.Analyzer("starts_with_analyzer", a => a.Custom()
+			.Tokenizer("starts_with_tokenizer")
+			.Filter("lowercase"))
+		.Analyzer("starts_with_analyzer_search", a => a.Custom()
+			.Tokenizer("keyword")
+			.Filter("lowercase"))
+		.CharFilter("strip_non_word", cf => cf.PatternReplace()
+			.Pattern(@"\W")
+			.Replacement(" "))
+		.TokenFilter("english_stop", tf => tf.Stop()
+			.Stopwords("_english_"))
+		.Tokenizer("starts_with_tokenizer", t => t.EdgeNGram()
+			.MinGram(1)
+			.MaxGram(10)
+			.TokenChars("letter", "digit"));
+
+	/// <summary>
+	/// Extended analysis — calls BuildBaseAnalysis transitively, verifying deep delegation.
+	/// </summary>
+	public static AnalysisBuilder BuildExtendedAnalysis(AnalysisBuilder analysis, string[] synonyms) =>
+		BuildBaseAnalysis(analysis)
+			.Analyzer("synonyms_analyzer", a => a.Custom()
+				.Tokenizer("standard")
+				.Filters("lowercase", "synonyms_filter"))
+			.TokenFilter("synonyms_filter", tf => tf.SynonymGraph()
+				.Synonyms(synonyms));
+}
+
+/// <summary>
+/// Base document type for delegation tests. The generator should anchor the analysis
+/// accessor to this type since all derived docs share SearchAnalysisFactory.
+/// </summary>
+public class SearchBaseDocument
+{
+	[Id]
+	[Keyword]
+	public string Id { get; set; } = string.Empty;
+
+	[Text]
+	[JsonPropertyName("title")]
+	public string Title { get; set; } = string.Empty;
+}
+
+/// <summary>First derived doc type — delegates to SearchAnalysisFactory.BuildBaseAnalysis.</summary>
+public class SearchArticle : SearchBaseDocument
+{
+	[Text]
+	[JsonPropertyName("body")]
+	public string Body { get; set; } = string.Empty;
+}
+
+/// <summary>Second derived doc type — delegates transitively (BuildExtendedAnalysis → BuildBaseAnalysis).</summary>
+public class SearchProduct : SearchBaseDocument
+{
+	[Keyword]
+	[JsonPropertyName("sku")]
+	public string Sku { get; set; } = string.Empty;
+}
+
+public class SearchArticleConfig : IConfigureElasticsearch<SearchArticle>
+{
+	// Delegates to shared factory — the parser must follow this call to find the names.
+	public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+		SearchAnalysisFactory.BuildBaseAnalysis(analysis);
+
+	public MappingsBuilder<SearchArticle> ConfigureMappings(MappingsBuilder<SearchArticle> mappings) => mappings;
+	public IReadOnlyDictionary<string, string>? IndexSettings => null;
+}
+
+public class SearchProductConfig : IConfigureElasticsearch<SearchProduct>
+{
+	// Delegates transitively: BuildExtendedAnalysis → BuildBaseAnalysis.
+	public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+		SearchAnalysisFactory.BuildExtendedAnalysis(analysis, ["elastic => search, find"]);
+
+	public MappingsBuilder<SearchProduct> ConfigureMappings(MappingsBuilder<SearchProduct> mappings) => mappings;
+	public IReadOnlyDictionary<string, string>? IndexSettings => null;
+}
+
+/// <summary>
+/// Compile-time reachability test for generated analysis accessor surfaces.
+/// This class compiles ONLY if the generator correctly emits:
+/// (1) SearchBaseDocumentAnalysis static accessor, and
+/// (2) generic-constrained extension methods on MappingsBuilder&lt;TDoc&gt; where TDoc : SearchBaseDocument.
+/// A build failure here means the generator did not produce the expected surfaces.
+/// </summary>
+public static class SearchMappingHelpers
+{
+	// Surface (1): static accessor — reachable anywhere without generic context.
+	public static string KeywordNormalizerKey => SearchBaseDocumentAnalysis.Normalizers.KeywordNormalizer;
+	public static string StartsWithAnalyzerKey => SearchBaseDocumentAnalysis.Analyzers.StartsWithAnalyzer;
+	public static string EnglishStopKey => SearchBaseDocumentAnalysis.TokenFilters.EnglishStop;
+
+	// Surface (2): generic-constrained extensions on MappingsBuilder<TDoc>.
+	// These compile only if the extensions are emitted with the correct `where TDoc : SearchBaseDocument` constraint.
+	public static MappingsBuilder<T> UseAnalysisKeys<T>(MappingsBuilder<T> m) where T : SearchBaseDocument
+	{
+		// Both surfaces reachable from the same generic method — this is the key consumer pattern.
+		var normalizerName = SearchBaseDocumentAnalysis.Normalizers.KeywordNormalizer;  // surface (1)
+		var sameViaExtension = m.Normalizers().KeywordNormalizer;                       // surface (2)
+		_ = normalizerName == sameViaExtension; // same value — both return "keyword_normalizer"
+		return m;
+	}
+}
+
+[ElasticsearchMappingContext]
+[Index<SearchArticle>(Name = "search-articles", Configuration = typeof(SearchArticleConfig))]
+[Index<SearchProduct>(Name = "search-products", Configuration = typeof(SearchProductConfig))]
+public static partial class DelegationTestMappingContext;


### PR DESCRIPTION
## Summary

- **Delegation-following parser**: `ConfigureAnalysisParser` now accepts a `Compilation` and walks the full call graph transitively via a visited-set. When `ConfigureAnalysis` delegates to a shared factory (e.g. `=> SharedAnalysisFactory.BuildBaseAnalysis(analysis)`), the parser follows invocations across files to extract analyzer/normalizer/tokenizer/filter names. Supports const-reference resolution (`IFieldSymbol.HasConstantValue`) and uses a 2-arg guard to distinguish `AnalysisBuilder.(name, configure)` registrations from inner builder calls.
- **Base-type-anchored accessor**: When delegation is detected, the generated keys are anchored to the nearest user-defined base type of the registered document type (e.g. `SearchDocumentBase`). `AnalysisNamesEmitter.EmitBaseAnchored` emits a `{AnchorName}Analysis` static class (surface 1: `SearchDocumentBaseAnalysis.Normalizers.KeywordNormalizer`). `MappingsBuilderEmitter.EmitBaseAnchoredAnalysisExtensions` emits generic-constrained `Analyzers<TDoc>()/Normalizers<TDoc>()` etc. extensions into a `partial` class alongside the #185 field extensions (surface 2: `m.Analyzers().StartsWithAnalyzer`).
- **Merge across registrations**: `AnalysisComponentsModel.Merge()` unions names from multiple registrations sharing the same anchor (e.g. one config delegates to `BuildBaseAnalysis`, another to `BuildExtendedAnalysis` which adds synonym analyzers). The pre-pass in `ExecuteAll` collects and merges before emitting once — mirrors the `emittedBaseExtensionKeys` dedup from #185.
- **Back-compat**: inline analysis authors retain the per-context `{ResolverName}Analysis` accessor unchanged; the anchor path suppresses it to avoid competing surfaces.

## Motivation

Consumers that share analysis across document types via a factory pattern had no way to reference analysis names as generated keys in generic mapping code. They were forced to maintain manual `internal const string` blocks that duplicated the factory's string literals (coupled only by convention). This PR removes that duplication: `SharedAnalysisFactory` is the single source of truth, and the generated accessor is discoverable from any `MappingsBuilder<T> where T : SearchDocumentBase` method.

## Test plan

- [ ] 236 tests pass (`dotnet test tests/Elastic.Mapping.Tests`) — 13 new tests in `DelegatedAnalysisTests.cs` cover: value correctness, transitive delegation (`BuildExtendedAnalysis → BuildBaseAnalysis`), const-ref resolution, surface parity (`m.Normalizers().KeywordNormalizer == SearchDocumentBaseAnalysis.Normalizers.KeywordNormalizer`), dedup (two contexts sharing one factory produce one file, no CS0101), built-in pass-through, and compile-time reachability (`SearchMappingHelpers` in `TestModels.cs` fails to compile if either surface is missing)
- [ ] Inspect emitted `SearchBaseDocumentAnalysis.g.cs` and `SearchBaseDocumentAnalysisExtensions.g.cs` via `EmitCompilerGeneratedFiles=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)