### PR TITLE
test(mapping): CLR type inference tests without Elastic.Mapping attributes

### DIFF
--- a/tests/Elastic.Mapping.Tests/ClrTypeInferenceTests.cs
+++ b/tests/Elastic.Mapping.Tests/ClrTypeInferenceTests.cs
@@ -1,0 +1,142 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json;
+
+namespace Elastic.Mapping.Tests;
+
+/// <summary>
+/// Validates that CLR types are correctly inferred to Elasticsearch field types
+/// when no Elastic.Mapping field attributes ([Text], [Keyword], [Date], etc.) are present.
+/// </summary>
+public class ClrTypeInferenceTests
+{
+	private JsonElement _properties;
+
+	[Before(Test)]
+	public void Setup()
+	{
+		var json = ClrInferenceMappingContext.ClrInferenceDocument.GetMappingJson();
+		using var doc = JsonDocument.Parse(json);
+		_properties = doc.RootElement.GetProperty("properties").Clone();
+	}
+
+	[Test]
+	public void String_InfersAsText()
+	{
+		_properties.GetProperty("stringField").GetProperty("type").GetString().Should().Be("text");
+		_properties.GetProperty("nullableStringField").GetProperty("type").GetString().Should().Be("text");
+	}
+
+	[Test]
+	public void StringArray_InfersAsText()
+	{
+		_properties.GetProperty("stringArrayField").GetProperty("type").GetString().Should().Be("text");
+		_properties.GetProperty("stringListField").GetProperty("type").GetString().Should().Be("text");
+	}
+
+	[Test]
+	public void Int_InfersAsInteger()
+	{
+		_properties.GetProperty("intField").GetProperty("type").GetString().Should().Be("integer");
+		_properties.GetProperty("nullableIntField").GetProperty("type").GetString().Should().Be("integer");
+	}
+
+	[Test]
+	public void Long_InfersAsLong()
+	{
+		_properties.GetProperty("longField").GetProperty("type").GetString().Should().Be("long");
+		_properties.GetProperty("nullableLongField").GetProperty("type").GetString().Should().Be("long");
+	}
+
+	[Test]
+	public void Short_InfersAsShort()
+	{
+		_properties.GetProperty("shortField").GetProperty("type").GetString().Should().Be("short");
+		_properties.GetProperty("nullableShortField").GetProperty("type").GetString().Should().Be("short");
+	}
+
+	[Test]
+	public void Byte_InfersAsByte()
+	{
+		_properties.GetProperty("byteField").GetProperty("type").GetString().Should().Be("byte");
+		_properties.GetProperty("nullableByteField").GetProperty("type").GetString().Should().Be("byte");
+	}
+
+	[Test]
+	public void Double_InfersAsDouble()
+	{
+		_properties.GetProperty("doubleField").GetProperty("type").GetString().Should().Be("double");
+		_properties.GetProperty("nullableDoubleField").GetProperty("type").GetString().Should().Be("double");
+	}
+
+	[Test]
+	public void Float_InfersAsFloat()
+	{
+		_properties.GetProperty("floatField").GetProperty("type").GetString().Should().Be("float");
+		_properties.GetProperty("nullableFloatField").GetProperty("type").GetString().Should().Be("float");
+	}
+
+	[Test]
+	public void Decimal_InfersAsDouble()
+	{
+		_properties.GetProperty("decimalField").GetProperty("type").GetString().Should().Be("double");
+		_properties.GetProperty("nullableDecimalField").GetProperty("type").GetString().Should().Be("double");
+	}
+
+	[Test]
+	public void Bool_InfersAsBoolean()
+	{
+		_properties.GetProperty("boolField").GetProperty("type").GetString().Should().Be("boolean");
+		_properties.GetProperty("nullableBoolField").GetProperty("type").GetString().Should().Be("boolean");
+	}
+
+	[Test]
+	public void DateTime_InfersAsDate()
+	{
+		_properties.GetProperty("dateTimeField").GetProperty("type").GetString().Should().Be("date");
+		_properties.GetProperty("nullableDateTimeField").GetProperty("type").GetString().Should().Be("date");
+	}
+
+	[Test]
+	public void DateTimeOffset_InfersAsDate()
+	{
+		_properties.GetProperty("dateTimeOffsetField").GetProperty("type").GetString().Should().Be("date");
+		_properties.GetProperty("nullableDateTimeOffsetField").GetProperty("type").GetString().Should().Be("date");
+	}
+
+	[Test]
+	public void Guid_InfersAsKeyword()
+	{
+		_properties.GetProperty("guidField").GetProperty("type").GetString().Should().Be("keyword");
+		_properties.GetProperty("nullableGuidField").GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void Enum_InfersAsKeyword()
+	{
+		_properties.GetProperty("statusField").GetProperty("type").GetString().Should().Be("keyword");
+		_properties.GetProperty("nullableStatusField").GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void NestedObject_InfersAsObject()
+	{
+		_properties.GetProperty("addressField").GetProperty("type").GetString().Should().Be("object");
+	}
+
+	[Test]
+	public void NestedObjectList_InfersAsObject()
+	{
+		_properties.GetProperty("addressListField").GetProperty("type").GetString().Should().Be("object");
+	}
+
+	[Test]
+	public void NestedObject_IncludesSubProperties()
+	{
+		var address = _properties.GetProperty("addressField");
+		address.GetProperty("properties").GetProperty("street").GetProperty("type").GetString().Should().Be("text");
+		address.GetProperty("properties").GetProperty("city").GetProperty("type").GetString().Should().Be("text");
+	}
+}

--- a/tests/Elastic.Mapping.Tests/TestModels.cs
+++ b/tests/Elastic.Mapping.Tests/TestModels.cs
@@ -595,6 +595,73 @@ public class GapFixDocument : IConfigureElasticsearch<GapFixDocument>
 public static partial class GapFixMappingContext;
 
 // ============================================================================
+// CLR TYPE INFERENCE CONTEXT: no Elastic.Mapping field attributes, all types inferred
+// ============================================================================
+
+/// <summary>
+/// Covers every CLR → Elasticsearch type mapping from <c>TypeAnalyzer.InferFieldType</c>.
+/// No [Text], [Keyword], [Date], etc. attributes — only plain CLR types.
+/// </summary>
+public class ClrInferenceDocument
+{
+	// string → text
+	public string StringField { get; set; } = string.Empty;
+	public string? NullableStringField { get; set; }
+	public string[] StringArrayField { get; set; } = [];
+	public List<string> StringListField { get; set; } = [];
+
+	// numerics
+	public int IntField { get; set; }
+	public int? NullableIntField { get; set; }
+	public long LongField { get; set; }
+	public long? NullableLongField { get; set; }
+	public short ShortField { get; set; }
+	public short? NullableShortField { get; set; }
+	public byte ByteField { get; set; }
+	public byte? NullableByteField { get; set; }
+	public double DoubleField { get; set; }
+	public double? NullableDoubleField { get; set; }
+	public float FloatField { get; set; }
+	public float? NullableFloatField { get; set; }
+	public decimal DecimalField { get; set; }   // decimal → double
+	public decimal? NullableDecimalField { get; set; }
+
+	// bool → boolean
+	public bool BoolField { get; set; }
+	public bool? NullableBoolField { get; set; }
+
+	// dates → date
+	public DateTime DateTimeField { get; set; }
+	public DateTime? NullableDateTimeField { get; set; }
+	public DateTimeOffset DateTimeOffsetField { get; set; }
+	public DateTimeOffset? NullableDateTimeOffsetField { get; set; }
+
+	// Guid → keyword
+	public Guid GuidField { get; set; }
+	public Guid? NullableGuidField { get; set; }
+
+	// enum → keyword
+	public ClrInferenceStatus StatusField { get; set; }
+	public ClrInferenceStatus? NullableStatusField { get; set; }
+
+	// nested object → object
+	public ClrInferenceAddress? AddressField { get; set; }
+	public List<ClrInferenceAddress> AddressListField { get; set; } = [];
+}
+
+public enum ClrInferenceStatus { Active, Inactive }
+
+public class ClrInferenceAddress
+{
+	public string Street { get; set; } = string.Empty;
+	public string City { get; set; } = string.Empty;
+}
+
+[ElasticsearchMappingContext]
+[Index<ClrInferenceDocument>(Name = "clr-inference-test")]
+public static partial class ClrInferenceMappingContext;
+
+// ============================================================================
 // EXPLICIT CONTAINER TEST MODEL
 // Exercises the new AddField (multi-field) / AddProperty (sub-property) API.
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds `ClrInferenceDocument` — a plain POCO with no `[Text]`/`[Keyword]`/`[Date]` etc. field attributes — registered via a new `ClrInferenceMappingContext`
- Adds `ClrTypeInferenceTests` with 17 tests covering every CLR→Elasticsearch type mapping in `TypeAnalyzer.InferFieldType`

## Mappings covered

| CLR type | ES type |
|---|---|
| `string`, `string?`, `string[]`, `List<string>` | `text` |
| `int` / `int?` | `integer` |
| `long` / `long?` | `long` |
| `short` / `short?` | `short` |
| `byte` / `byte?` | `byte` |
| `double` / `double?` | `double` |
| `float` / `float?` | `float` |
| `decimal` / `decimal?` | `double` |
| `bool` / `bool?` | `boolean` |
| `DateTime` / `DateTime?` | `date` |
| `DateTimeOffset` / `DateTimeOffset?` | `date` |
| `Guid` / `Guid?` | `keyword` |
| `enum` / `enum?` | `keyword` |
| `object` / `List<object>` | `object` |
| nested sub-properties | recursive `text` inference |

## Test plan

- [x] All 240 tests pass (`dotnet test tests/Elastic.Mapping.Tests/`)
- [x] All 17 new `ClrTypeInferenceTests` are discovered and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)