### PR TITLE
feat(mapping): add stemmer_override token filter and keyword copy_to

### DIFF
--- a/src/Elastic.Mapping/Analysis/Builders/TokenFilterBuilder.cs
+++ b/src/Elastic.Mapping/Analysis/Builders/TokenFilterBuilder.cs
@@ -20,6 +20,9 @@ public sealed class TokenFilterBuilder
 	/// <summary>Creates a stemmer token filter.</summary>
 	public StemmerFilterBuilder Stemmer() => new(this);
 
+	/// <summary>Creates a stemmer_override token filter.</summary>
+	public StemmerOverrideFilterBuilder StemmerOverride() => new(this);
+
 	/// <summary>Creates a shingle token filter.</summary>
 	public ShingleFilterBuilder Shingle() => new(this);
 
@@ -255,6 +258,37 @@ public sealed class StemmerFilterBuilder
 	public static implicit operator TokenFilterBuilder(StemmerFilterBuilder builder)
 	{
 		builder._parent.SetDefinition(new StemmerFilterDefinition(builder._language));
+		return builder._parent;
+	}
+}
+
+/// <summary>Builder for stemmer_override token filters.</summary>
+public sealed class StemmerOverrideFilterBuilder
+{
+	private readonly TokenFilterBuilder _parent;
+	private List<string>? _rules;
+	private string? _rulesPath;
+
+	internal StemmerOverrideFilterBuilder(TokenFilterBuilder parent) => _parent = parent;
+
+	/// <summary>Sets the override rules inline, e.g. "configuration => config".</summary>
+	public StemmerOverrideFilterBuilder Rules(params string[] rules)
+	{
+		_rules = [.. rules];
+		return this;
+	}
+
+	/// <summary>Sets the path to the rules file.</summary>
+	public StemmerOverrideFilterBuilder RulesPath(string path)
+	{
+		_rulesPath = path;
+		return this;
+	}
+
+	/// <summary>Implicit conversion finalizes the builder and returns the parent.</summary>
+	public static implicit operator TokenFilterBuilder(StemmerOverrideFilterBuilder builder)
+	{
+		builder._parent.SetDefinition(new StemmerOverrideFilterDefinition(builder._rules, builder._rulesPath));
 		return builder._parent;
 	}
 }

--- a/src/Elastic.Mapping/Analysis/Definitions/ITokenFilterDefinition.cs
+++ b/src/Elastic.Mapping/Analysis/Definitions/ITokenFilterDefinition.cs
@@ -290,6 +290,26 @@ public sealed record SynonymGraphFilterDefinition(
 	}
 }
 
+/// <summary>A stemmer_override token filter definition — applies curated stemming exceptions ahead of a stemmer.</summary>
+public sealed record StemmerOverrideFilterDefinition(
+	IReadOnlyList<string>? Rules = null,
+	string? RulesPath = null
+) : ITokenFilterDefinition
+{
+	public JsonObject ToJson()
+	{
+		var obj = new JsonObject { ["type"] = "stemmer_override" };
+
+		if (Rules is { Count: > 0 })
+			obj["rules"] = new JsonArray(Rules.Select(s => JsonValue.Create(s)).ToArray());
+
+		if (RulesPath != null)
+			obj["rules_path"] = RulesPath;
+
+		return obj;
+	}
+}
+
 /// <summary>A lowercase token filter definition.</summary>
 public sealed record LowercaseFilterDefinition(string? Language = null) : ITokenFilterDefinition
 {

--- a/src/Elastic.Mapping/Mappings/Builders/FieldTypeBuilders.cs
+++ b/src/Elastic.Mapping/Mappings/Builders/FieldTypeBuilders.cs
@@ -111,6 +111,7 @@ public sealed class KeywordFieldBuilder
 	private int? _ignoreAbove;
 	private bool? _docValues;
 	private bool? _index;
+	private string? _copyTo;
 	private readonly Dictionary<string, IFieldDefinition> _multiFields = [];
 
 	internal KeywordFieldBuilder(FieldBuilder parent) => _parent = parent;
@@ -143,6 +144,13 @@ public sealed class KeywordFieldBuilder
 		return this;
 	}
 
+	/// <summary>Sets the copy_to target field.</summary>
+	public KeywordFieldBuilder CopyTo(string copyTo)
+	{
+		_copyTo = copyTo;
+		return this;
+	}
+
 	/// <summary>Adds a multi-field. If a multi-field with the same name already exists, it is overwritten.</summary>
 	public KeywordFieldBuilder MultiField(string name, Func<MultiFieldBuilder, MultiFieldBuilder> configure)
 	{
@@ -159,6 +167,7 @@ public sealed class KeywordFieldBuilder
 		_ignoreAbove = null;
 		_docValues = null;
 		_index = null;
+		_copyTo = null;
 		_multiFields.Clear();
 		return this;
 	}
@@ -171,6 +180,7 @@ public sealed class KeywordFieldBuilder
 			builder._ignoreAbove,
 			builder._docValues,
 			builder._index,
+			builder._copyTo,
 			builder._multiFields.Count > 0
 				? new Dictionary<string, IFieldDefinition>(builder._multiFields)
 				: null

--- a/src/Elastic.Mapping/Mappings/Definitions/IFieldDefinition.cs
+++ b/src/Elastic.Mapping/Mappings/Definitions/IFieldDefinition.cs
@@ -69,6 +69,7 @@ public sealed record KeywordFieldDefinition(
 	int? IgnoreAbove = null,
 	bool? DocValues = null,
 	bool? Index = null,
+	string? CopyTo = null,
 	IReadOnlyDictionary<string, IFieldDefinition>? MultiFields = null
 ) : IFieldDefinition
 {
@@ -89,6 +90,9 @@ public sealed record KeywordFieldDefinition(
 
 		if (Index.HasValue)
 			obj["index"] = Index.Value;
+
+		if (CopyTo != null)
+			obj["copy_to"] = CopyTo;
 
 		if (MultiFields is { Count: > 0 })
 		{

--- a/tests/Elastic.Mapping.Tests/TokenFilterAndCopyToSerializationTests.cs
+++ b/tests/Elastic.Mapping.Tests/TokenFilterAndCopyToSerializationTests.cs
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Mapping.Analysis;
+using Elastic.Mapping.Analysis.Definitions;
+using Elastic.Mapping.Mappings.Builders;
+using Elastic.Mapping.Mappings.Definitions;
+
+namespace Elastic.Mapping.Tests;
+
+/// <summary>
+/// Serialization coverage for the <c>stemmer_override</c> token filter and keyword-field
+/// <c>copy_to</c> support — both added to unblock relevance work in the website-search-data
+/// consumer repo (curated morphology overrides + content_type/navigation_section routing
+/// into a shared content_tags field).
+/// </summary>
+public class TokenFilterAndCopyToSerializationTests
+{
+	[Test]
+	public void StemmerOverrideFilterDefinition_SerializesRules()
+	{
+		var definition = new StemmerOverrideFilterDefinition(Rules: ["configuration => config", "installation => install"]);
+		var json = definition.ToJson();
+
+		json["type"]!.GetValue<string>().Should().Be("stemmer_override");
+		json["rules"]!.AsArray().Select(n => n!.GetValue<string>())
+			.Should().BeEquivalentTo(["configuration => config", "installation => install"]);
+		json["rules_path"].Should().BeNull();
+	}
+
+	[Test]
+	public void StemmerOverrideFilterDefinition_SerializesRulesPath()
+	{
+		var definition = new StemmerOverrideFilterDefinition(RulesPath: "analysis/stemmer_override.txt");
+		var json = definition.ToJson();
+
+		json["rules_path"]!.GetValue<string>().Should().Be("analysis/stemmer_override.txt");
+		json["rules"].Should().BeNull();
+	}
+
+	[Test]
+	public void TokenFilterBuilder_StemmerOverride_BuildsExpectedDefinition()
+	{
+		var analysis = new AnalysisBuilder()
+			.TokenFilter("morphology_override", tf => tf.StemmerOverride().Rules("auth => authentication"))
+			.Build();
+
+		var definition = (StemmerOverrideFilterDefinition)analysis.TokenFilters["morphology_override"];
+		definition.Rules.Should().ContainSingle().Which.Should().Be("auth => authentication");
+	}
+
+	[Test]
+	public void KeywordFieldDefinition_SerializesCopyTo()
+	{
+		var definition = new KeywordFieldDefinition(CopyTo: "content_tags");
+		var json = definition.ToJson();
+
+		json["copy_to"]!.GetValue<string>().Should().Be("content_tags");
+	}
+
+	[Test]
+	public void KeywordFieldDefinition_OmitsCopyTo_WhenNotSet()
+	{
+		var definition = new KeywordFieldDefinition();
+		var json = definition.ToJson();
+
+		json["copy_to"].Should().BeNull();
+	}
+
+	[Test]
+	public void FieldBuilder_Keyword_CopyTo_BuildsExpectedDefinition()
+	{
+		var builder = new FieldBuilder();
+		FieldBuilder result = builder.Keyword().Normalizer("keyword_normalizer").CopyTo("content_tags");
+
+		var definition = (KeywordFieldDefinition)result.GetDefinition();
+		definition.Normalizer.Should().Be("keyword_normalizer");
+		definition.CopyTo.Should().Be("content_tags");
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a fluent `StemmerOverride()` token filter builder (`StemmerOverrideFilterDefinition` + `StemmerOverrideFilterBuilder`), mirroring the existing `SynonymGraph` builder shape.
- Adds `copy_to` support to keyword fields (`KeywordFieldDefinition.CopyTo` + `KeywordFieldBuilder.CopyTo(string)`), mirroring the existing `TextFieldBuilder.CopyTo`.

Both are purely additive — no existing public API signatures change (the two positional-constructor call sites for `KeywordFieldDefinition` are unaffected since the new parameter is appended before `MultiFields`, after all existing positional args used elsewhere).

## Why
`website-search-data` is moving relevance logic out of a hand-maintained downstream query and into native Elasticsearch analysis/mappings:
- `stemmer_override` is needed to fold curated morphological pairs (`config`/`configuration`, `install`/`installation`, `auth`/`authentication`) that the conservative `kstem` filter does not fold.
- Keyword `copy_to` is needed to route `content_type`/`navigation_section` (both `[Keyword]`) into a shared `content_tags` text field for native term→type boosting.

Neither was previously expressible via the fluent builder API in 0.48.0 — confirmed against the packaged DLL (only a `BuiltInAnalysis.TokenFilters.StemmerOverride` string constant existed, with no matching builder/definition, and `CopyTo` existed only on `TextFieldBuilder`/`TextFieldDefinition`).

## Test plan
- [x] `dotnet build src/Elastic.Mapping/Elastic.Mapping.csproj -c Release` succeeds
- [x] `dotnet test tests/Elastic.Mapping.Tests/Elastic.Mapping.Tests.csproj -c Release` — 259/259 passed (253 existing + 6 new)
- [x] `dotnet format --verify-no-changes` shows no new violations introduced by the changed/added files (pre-existing violations elsewhere in the repo are unrelated to this change, confirmed via `git stash` diff against `main`)