### PR TITLE
fix(generator): merge nested-type shapes so first-context-wins race can't drop members

### DIFF
--- a/src/Elastic.Mapping.Generator/Emitters/MappingsBuilderEmitter.cs
+++ b/src/Elastic.Mapping.Generator/Emitters/MappingsBuilderEmitter.cs
@@ -40,7 +40,17 @@ internal static class MappingsBuilderEmitter
 	/// Tracks nested builder class names already emitted in this namespace to avoid
 	/// duplicate definitions when multiple document types reference the same nested type.
 	/// </param>
-	public static string EmitForContext(ContextMappingModel context, TypeRegistration reg, HashSet<string> emittedNestedBuilders)
+	/// <param name="mergedNestedTypes">
+	/// Canonical, compilation-wide merged shape per nested type name — used instead of this
+	/// registration's own (possibly context-narrowed) analysis when emitting the class body,
+	/// so the winner of the <paramref name="emittedNestedBuilders"/> dedup race always exposes
+	/// the full member surface regardless of which registration got there first.
+	/// </param>
+	public static string EmitForContext(
+		ContextMappingModel context,
+		TypeRegistration reg,
+		HashSet<string> emittedNestedBuilders,
+		IReadOnlyDictionary<string, NestedTypeModel> mergedNestedTypes)
 	{
 		var sb = new StringBuilder();
 
@@ -52,7 +62,7 @@ internal static class MappingsBuilderEmitter
 			sb.AppendLine();
 		}
 
-		EmitExtensionMethodsClass(sb, reg.TypeModel, reg.TypeFullyQualifiedName, reg.TypeName, reg.AnalysisComponents, emittedNestedBuilders);
+		EmitExtensionMethodsClass(sb, reg.TypeModel, reg.TypeFullyQualifiedName, reg.TypeName, reg.AnalysisComponents, emittedNestedBuilders, mergedNestedTypes);
 
 		return sb.ToString();
 	}
@@ -111,7 +121,8 @@ internal static class MappingsBuilderEmitter
 		string typeFqn,
 		string resolverName,
 		AnalysisComponentsModel analysisComponents,
-		HashSet<string> globalEmittedNestedBuilders
+		HashSet<string> globalEmittedNestedBuilders,
+		IReadOnlyDictionary<string, NestedTypeModel> mergedNestedTypes
 	)
 	{
 		var builderType = $"{MappingsBuilderFqn}<global::{typeFqn}>";
@@ -153,7 +164,10 @@ internal static class MappingsBuilderEmitter
 		foreach (var (propertyName, fieldName, nestedType) in nestedBuilders)
 		{
 			if (globalEmittedNestedBuilders.Add(nestedType.TypeName))
-				EmitNestedBuilderClass(sb, resolverName, propertyName, fieldName, nestedType);
+			{
+				var effectiveNestedType = mergedNestedTypes.TryGetValue(nestedType.TypeName, out var merged) ? merged : nestedType;
+				EmitNestedBuilderClass(sb, resolverName, propertyName, fieldName, effectiveNestedType);
+			}
 		}
 	}
 
@@ -302,7 +316,8 @@ internal static class MappingsBuilderEmitter
 		string declaringTypeName,
 		string declaringTypeFullyQualifiedName,
 		IReadOnlyList<PropertyMappingModel> props,
-		HashSet<string> emittedNestedBuilders
+		HashSet<string> emittedNestedBuilders,
+		IReadOnlyDictionary<string, NestedTypeModel> mergedNestedTypes
 	)
 	{
 		var sb = new StringBuilder();
@@ -357,7 +372,10 @@ internal static class MappingsBuilderEmitter
 		foreach (var (propertyName, fieldName, nestedType) in nestedBuilders)
 		{
 			if (emittedNestedBuilders.Add(nestedType.TypeName))
-				EmitNestedBuilderClass(sb, declaringTypeName, propertyName, fieldName, nestedType);
+			{
+				var effectiveNestedType = mergedNestedTypes.TryGetValue(nestedType.TypeName, out var merged) ? merged : nestedType;
+				EmitNestedBuilderClass(sb, declaringTypeName, propertyName, fieldName, effectiveNestedType);
+			}
 		}
 
 		return sb.ToString();

--- a/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
+++ b/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
@@ -712,6 +712,28 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		// reference the same nested type (e.g. IndexedProduct).
 		var emittedNestedBuilders = new HashSet<string>();
 
+		// A nested/object-typed property can be analyzed differently by different contexts
+		// (e.g. per-context DefaultIgnoreCondition), even when it's the same CLR type reached
+		// via inheritance or via two unrelated document types. Merge every observation of a
+		// given nested type name into one canonical shape up front, so whichever registration
+		// "wins" the emittedNestedBuilders race always emits the full, complete member surface.
+		var mergedNestedTypes = new Dictionary<string, NestedTypeModel>();
+		foreach (var model in models)
+		{
+			foreach (var reg in model.TypeRegistrations)
+			{
+				foreach (var prop in reg.TypeModel.Properties)
+				{
+					if (prop.IsIgnored || prop.NestedType == null)
+						continue;
+
+					mergedNestedTypes[prop.NestedType.TypeName] = mergedNestedTypes.TryGetValue(prop.NestedType.TypeName, out var existing)
+						? existing.MergeWith(prop.NestedType)
+						: prop.NestedType;
+				}
+			}
+		}
+
 		// Track emitted generic-constrained base-type extension classes globally.
 		// Keyed by "{declaringNamespace}::{declaringTypeFullyQualifiedName}" so each
 		// base type's methods are emitted exactly once regardless of how many concrete
@@ -818,7 +840,7 @@ public class MappingSourceGenerator : IIncrementalGenerator
 				var extensionKey = $"{model.Namespace}.{reg.TypeFullyQualifiedName}";
 				if (emittedExtensionKeys.Add(extensionKey))
 				{
-					var mappingsExtensionsSource = MappingsBuilderEmitter.EmitForContext(model, reg, emittedNestedBuilders);
+					var mappingsExtensionsSource = MappingsBuilderEmitter.EmitForContext(model, reg, emittedNestedBuilders, mergedNestedTypes);
 					context.AddSource($"{model.ContextTypeName}.{reg.TypeName}MappingsExtensions.g.cs", mappingsExtensionsSource);
 				}
 
@@ -836,7 +858,7 @@ public class MappingSourceGenerator : IIncrementalGenerator
 					if (emittedBaseExtensionKeys.Add(baseKey))
 					{
 						var baseExtSource = MappingsBuilderEmitter.EmitBaseExtensionsClass(
-							declaringNs, declaringName, declaringFqn, group.ToList(), emittedNestedBuilders);
+							declaringNs, declaringName, declaringFqn, group.ToList(), emittedNestedBuilders, mergedNestedTypes);
 						context.AddSource($"{declaringName}MappingsExtensions.g.cs", baseExtSource);
 					}
 				}

--- a/src/Elastic.Mapping.Generator/Model/PropertyMappingModel.cs
+++ b/src/Elastic.Mapping.Generator/Model/PropertyMappingModel.cs
@@ -13,7 +13,30 @@ internal sealed record NestedTypeModel(
 	string TypeName,
 	string FullyQualifiedName,
 	ImmutableArray<PropertyMappingModel> Properties
-);
+)
+{
+	/// <summary>
+	/// Merges this model with another analysis of the same CLR type, unioning properties by name.
+	/// Two contexts can analyze the same nested type differently (e.g. differing per-context
+	/// <c>DefaultIgnoreCondition</c>), so the emitted nested-builder class must expose the union
+	/// of every property ever observed as NOT ignored for this type name — not just whichever
+	/// analysis "won" a global dedup race. When a property is ignored in one analysis but not
+	/// another, the non-ignored version wins so the property still gets a builder method.
+	/// </summary>
+	public NestedTypeModel MergeWith(NestedTypeModel other)
+	{
+		var byName = new Dictionary<string, PropertyMappingModel>(StringComparer.Ordinal);
+		foreach (var prop in Properties)
+			byName[prop.PropertyName] = prop;
+		foreach (var prop in other.Properties)
+		{
+			if (!byName.TryGetValue(prop.PropertyName, out var existing) || (existing.IsIgnored && !prop.IsIgnored))
+				byName[prop.PropertyName] = prop;
+		}
+
+		return this with { Properties = byName.Values.ToImmutableArray() };
+	}
+};
 
 /// <summary>
 /// Represents a property's mapping information extracted from source.

--- a/tests/Elastic.Mapping.Tests/TestModels.cs
+++ b/tests/Elastic.Mapping.Tests/TestModels.cs
@@ -910,3 +910,104 @@ public static class SearchMappingHelpers
 [Index<SearchArticle>(Name = "search-articles", Configuration = typeof(SearchArticleConfig))]
 [Index<SearchProduct>(Name = "search-products", Configuration = typeof(SearchProductConfig))]
 public static partial class DelegationTestMappingContext;
+
+// ============================================================================
+// SHARED NESTED TYPE TEST MODELS: regression for nested-builder dedup racing
+// across the base-type extension emission path and the own-property emission
+// path when both reference the same nested record type by name.
+// ============================================================================
+
+/// <summary>
+/// Nested type referenced from both a base-type property and an unrelated top-level property.
+/// <see cref="Value"/> has no explicit [JsonIgnore], so under a context whose JsonContext sets
+/// <c>DefaultIgnoreCondition = Always</c> it is analyzed as ignored — a *different* member shape
+/// for the exact same CLR type than a context with no such default. <see cref="Key"/> pins itself
+/// to always-included via an explicit Condition=Never so both contexts agree on it.
+/// </summary>
+public class SharedNestedMeta
+{
+	[JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+	[Keyword]
+	public string Key { get; set; } = string.Empty;
+
+	[Text]
+	public string Value { get; set; } = string.Empty;
+}
+
+/// <summary>Base type declaring the [Object] property — emitted via EmitBaseExtensionsClass for each derived type.</summary>
+public abstract class SharedNestedBase
+{
+	[JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+	[Id]
+	[Keyword]
+	public string Id { get; set; } = string.Empty;
+
+	[JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+	[Object]
+	public SharedNestedMeta? Meta { get; set; }
+}
+
+/// <summary>
+/// First subclass, registered under a context whose JsonContext narrows the analyzed shape of
+/// <see cref="SharedNestedMeta"/> (DefaultIgnoreCondition = Always drops <c>Value</c>).
+/// </summary>
+public class SharedNestedDocA : SharedNestedBase
+{
+	[JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+	[Text]
+	public string TitleA { get; set; } = string.Empty;
+}
+
+/// <summary>Second subclass, registered under a context with the default (unrestricted) shape.</summary>
+public class SharedNestedDocB : SharedNestedBase
+{
+	[Text]
+	public string TitleB { get; set; } = string.Empty;
+}
+
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.Always)]
+[JsonSerializable(typeof(SharedNestedDocA))]
+public partial class SharedNestedJsonContextA : JsonSerializerContext;
+
+[ElasticsearchMappingContext(JsonContext = typeof(SharedNestedJsonContextA))]
+[Index<SharedNestedDocA>(Name = "shared-nested-a")]
+public static partial class SharedNestedContextA;
+
+[ElasticsearchMappingContext]
+[Index<SharedNestedDocB>(Name = "shared-nested-b")]
+public static partial class SharedNestedContextB;
+
+/// <summary>
+/// Unrelated top-level type that independently declares its own property of the same
+/// nested record type — exercises the EmitForContext (own-property) emission path for
+/// a nested type name that is also emitted via EmitBaseExtensionsClass above.
+/// </summary>
+public class IndependentNestedDoc
+{
+	[Id]
+	public string Id { get; set; } = string.Empty;
+
+	[Object]
+	public SharedNestedMeta? OtherMeta { get; set; }
+}
+
+[ElasticsearchMappingContext]
+[Index<IndependentNestedDoc>(Name = "independent-nested")]
+public static partial class IndependentNestedMappingContext;
+
+/// <summary>
+/// Compile-time reachability test for the generated <c>SharedNestedMetaNestedBuilder</c>.
+/// This compiles ONLY if the winner of the nested-builder dedup race exposes BOTH <c>Key</c>
+/// and <c>Value</c> — regardless of whether that winner was SharedNestedContextA's narrowed
+/// analysis (which alone would drop <c>Value</c>) or another registration's full analysis.
+/// A build failure here (CS1061: 'SharedNestedMetaNestedBuilder' does not contain a definition
+/// for 'Value') means the generator regressed to emitting whichever shape won first.
+/// </summary>
+public static class SharedNestedMappingHelpers
+{
+	public static MappingsBuilder<T> ConfigureSharedMeta<T>(MappingsBuilder<T> m) where T : SharedNestedBase =>
+		m.Meta((SharedNestedMetaNestedBuilder meta) => meta.Key(k => k).Value(v => v));
+
+	public static MappingsBuilder<IndependentNestedDoc> ConfigureOtherMeta(MappingsBuilder<IndependentNestedDoc> m) =>
+		m.OtherMeta((SharedNestedMetaNestedBuilder meta) => meta.Key(k => k).Value(v => v));
+}


### PR DESCRIPTION
## Summary
- `Elastic.Mapping.Generator` deduplicates `{Type}NestedBuilder` classes globally by bare type name, but the *set of properties* analyzed for a nested `[Object]`/`[Nested]` type can differ per context (e.g. differing per-context `JsonContext`/`DefaultIgnoreCondition`). Whichever registration won the dedup race baked its own (possibly narrower) shape into the single emitted class, silently dropping members that other consumers of the same nested type expected — surfacing as `CS1061`/`CS1929` in downstream code referencing the same nested record type via inheritance or via two independent document types.
- Fix: merge every observation of a nested type name into one canonical shape (preferring the non-ignored variant per property) before emission, so whichever registration wins the dedup race always emits the full, complete member surface.
- Confirmed the fix is necessary by reverting it locally and reproducing the exact `CS1929: '...NestedBuilder' does not contain a definition for 'Value'` failure against the new regression test, then restoring the fix.

## Test plan
- [x] Added `SharedNestedBase`/`SharedNestedDocA`/`SharedNestedDocB` (nested type shared via inheritance across two contexts with differing `DefaultIgnoreCondition`) + `IndependentNestedDoc` (same nested type referenced independently) + `SharedNestedMappingHelpers` exercising both builders' full member surface in `tests/Elastic.Mapping.Tests/TestModels.cs`
- [x] `dotnet test tests/Elastic.Mapping.Tests` — 259/259 passing on a clean rebuild (`rm -rf obj/bin`)
- [x] Verified other generator consumers (`Elastic.Ingest.IncrementalSync.Example`, `Elastic.Ingest.MultiChannel`) still build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01378A5cgSkmoabGvXd8EmE9