### PR TITLE
fix(generator): make nested builder ctor and GetFields() public for cross-assembly use

### DIFF
--- a/elastic-ingest-dotnet.slnx
+++ b/elastic-ingest-dotnet.slnx
@@ -52,6 +52,8 @@
     <Project Path="tests/Elastic.Ingest.Elasticsearch.IntegrationTests/Elastic.Ingest.Elasticsearch.IntegrationTests.csproj" />
     <Project Path="tests/Elastic.Ingest.Elasticsearch.Tests/Elastic.Ingest.Elasticsearch.Tests.csproj" />
     <Project Path="tests/Elastic.Mapping.Tests/Elastic.Mapping.Tests.csproj" />
+    <Project Path="tests/Elastic.Mapping.Tests.Contracts/Elastic.Mapping.Tests.Contracts.csproj" />
+    <Project Path="tests/Elastic.Mapping.Tests.CrossAssembly/Elastic.Mapping.Tests.CrossAssembly.csproj" />
   </Folder>
   <Project Path="docs/docs.csproj" />
 </Solution>

--- a/src/Elastic.Mapping.Generator/Emitters/MappingsBuilderEmitter.cs
+++ b/src/Elastic.Mapping.Generator/Emitters/MappingsBuilderEmitter.cs
@@ -253,7 +253,7 @@ internal static class MappingsBuilderEmitter
 		sb.AppendLine("\tprivate readonly string _parentPath;");
 		sb.AppendLine($"\tprivate readonly global::System.Collections.Generic.List<(string Path, global::Elastic.Mapping.Mappings.Definitions.IFieldDefinition Definition)> _fields = [];");
 		sb.AppendLine();
-		sb.AppendLine($"\tinternal {nestedBuilderClassName}(string parentPath) => _parentPath = parentPath;");
+		sb.AppendLine($"\tpublic {nestedBuilderClassName}(string parentPath) => _parentPath = parentPath;");
 		sb.AppendLine();
 
 		var nestedProps = nestedType.Properties.Where(p => !p.IsIgnored).ToList();
@@ -267,7 +267,7 @@ internal static class MappingsBuilderEmitter
 		}
 
 		sb.AppendLine();
-		sb.AppendLine($"\tinternal global::System.Collections.Generic.IReadOnlyList<(string Path, global::Elastic.Mapping.Mappings.Definitions.IFieldDefinition Definition)> GetFields() => _fields;");
+		sb.AppendLine($"\tpublic global::System.Collections.Generic.IReadOnlyList<(string Path, global::Elastic.Mapping.Mappings.Definitions.IFieldDefinition Definition)> GetFields() => _fields;");
 		sb.AppendLine("}");
 		sb.AppendLine();
 	}

--- a/tests/Elastic.Mapping.Tests.Contracts/ContractTypes.cs
+++ b/tests/Elastic.Mapping.Tests.Contracts/ContractTypes.cs
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Serialization;
+using Elastic.Mapping;
+using Elastic.Mapping.Mappings;
+
+namespace Elastic.Mapping.Tests.Contracts;
+
+/// <summary>
+/// Nested type shared across base and derived document types.
+/// When the generator emits the NestedBuilder for this type, its constructor
+/// and GetFields() must be public so cross-assembly consumers can use them.
+/// </summary>
+public class SharedProduct
+{
+	[Keyword(Normalizer = "keyword_normalizer")]
+	public string Id { get; set; } = string.Empty;
+
+	[Text]
+	public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Base document declaring an [Object]-typed property of <see cref="SharedProduct"/>.
+/// The generator emits a <c>SharedProductNestedBuilder</c> when processing this type.
+/// </summary>
+public abstract class ContractDocumentBase
+{
+	[Id]
+	[Keyword]
+	public string DocId { get; set; } = string.Empty;
+
+	[Object]
+	public SharedProduct? Product { get; set; }
+}
+
+/// <summary>
+/// Derived type registered in the contracts assembly's own context.
+/// Exercises the within-assembly path — this always worked.
+/// </summary>
+public class ContractDocument : ContractDocumentBase
+{
+	[Text]
+	public string Description { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Mapping context in the contracts assembly. Compiles SharedProductNestedBuilder
+/// into this assembly with the constructor and GetFields() visibility set by the generator.
+/// </summary>
+[ElasticsearchMappingContext]
+[Index<ContractDocument>(Name = "contract-docs")]
+public static partial class ContractMappingContext;

--- a/tests/Elastic.Mapping.Tests.Contracts/Elastic.Mapping.Tests.Contracts.csproj
+++ b/tests/Elastic.Mapping.Tests.Contracts/Elastic.Mapping.Tests.Contracts.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<NoWarn>$(NoWarn);CA1707</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="$(SolutionRoot)\src\Elastic.Mapping\Elastic.Mapping.csproj" />
+		<ProjectReference Include="$(SolutionRoot)\src\Elastic.Mapping.Generator\Elastic.Mapping.Generator.csproj"
+						  OutputItemType="Analyzer"
+						  ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+</Project>

--- a/tests/Elastic.Mapping.Tests.CrossAssembly/CrossAssemblyNestedBuilderTests.cs
+++ b/tests/Elastic.Mapping.Tests.CrossAssembly/CrossAssemblyNestedBuilderTests.cs
@@ -1,0 +1,142 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Mapping.Mappings;
+using Elastic.Mapping.Tests.Contracts;
+
+namespace Elastic.Mapping.Tests.CrossAssembly;
+
+// ============================================================================
+// CROSS-ASSEMBLY TYPES
+//
+// The nested-builder visibility bug triggers when:
+// 1. EmitForContext processes a type with an OWN [Object] property of the same
+//    nested type, emitting SharedProductNestedBuilder into THIS namespace.
+// 2. EmitBaseExtensionsClass then processes inherited properties referencing the
+//    same nested type, finds the name already claimed in emittedNestedBuilders,
+//    and skips emitting the class — but its extension method still references
+//    SharedProductNestedBuilder by unqualified name.
+// 3. In the base-extensions file (emitted into the contracts assembly's namespace),
+//    the unqualified name resolves to the contracts assembly's already-compiled
+//    copy whose ctor/GetFields were internal.
+//
+// Before the fix: CS1729 (no accessible constructor) + CS1061 (GetFields not found).
+// After the fix: public ctor/GetFields → cross-assembly binding works.
+// ============================================================================
+
+/// <summary>
+/// Type with its OWN [Object] SharedProduct property (not inherited).
+/// Registered first in the context so EmitForContext emits the nested builder
+/// into the consumer's namespace, winning the dedup race.
+/// </summary>
+public class IndependentConsumerDocument
+{
+	[Id]
+	[Keyword]
+	public string Id { get; set; } = string.Empty;
+
+	[Object]
+	public SharedProduct? Product { get; set; }
+}
+
+/// <summary>
+/// Inherits [Object] SharedProduct from <see cref="ContractDocumentBase"/>.
+/// When EmitBaseExtensionsClass runs for ContractDocumentBase, it finds
+/// SharedProductNestedBuilder already claimed and skips class emission.
+/// Its generated extension method references SharedProductNestedBuilder
+/// unqualified in the Elastic.Mapping.Tests.Contracts namespace, which
+/// resolves to the contracts assembly's copy.
+/// </summary>
+public class ConsumerDocument : ContractDocumentBase
+{
+	[Text]
+	public string Summary { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Mapping context in the consumer assembly. Registers IndependentConsumerDocument
+/// FIRST (so its EmitForContext pass claims SharedProductNestedBuilder in this namespace)
+/// and ConsumerDocument SECOND (so its EmitBaseExtensionsClass pass encounters the
+/// dedup collision and references the cross-assembly type).
+/// </summary>
+[ElasticsearchMappingContext]
+[Index<IndependentConsumerDocument>(Name = "independent-consumer")]
+[Index<ConsumerDocument>(Name = "consumer-docs")]
+public static partial class ConsumerMappingContext;
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+/// <summary>
+/// Regression tests for the cross-assembly nested-builder visibility bug.
+///
+/// The primary assertion is that this project COMPILES — before the fix,
+/// the generated ContractDocumentBaseMappingsExtensions.g.cs would reference
+/// SharedProductNestedBuilder from the contracts assembly (internal ctor and
+/// GetFields), producing CS1729 and CS1061.
+/// </summary>
+public class CrossAssemblyNestedBuilderTests
+{
+	[Test]
+	public void IndependentConsumer_Compiles_And_ProducesMappingJson()
+	{
+		var json = ConsumerMappingContext.IndependentConsumerDocument.GetMappingJson();
+		json.Should().NotBeNullOrEmpty();
+
+		using var doc = System.Text.Json.JsonDocument.Parse(json);
+		var props = doc.RootElement.GetProperty("properties");
+		var product = props.GetProperty("product");
+		product.GetProperty("type").GetString().Should().Be("object");
+
+		var subProps = product.GetProperty("properties");
+		subProps.GetProperty("id").GetProperty("type").GetString().Should().Be("keyword");
+		subProps.GetProperty("name").GetProperty("type").GetString().Should().Be("text");
+	}
+
+	[Test]
+	public void ConsumerDocument_Compiles_And_ProducesMappingJson()
+	{
+		var json = ConsumerMappingContext.ConsumerDocument.GetMappingJson();
+		json.Should().NotBeNullOrEmpty();
+	}
+
+	[Test]
+	public void ConsumerDocument_MappingJson_ContainsInheritedProductField()
+	{
+		var json = ConsumerMappingContext.ConsumerDocument.GetMappingJson();
+		using var doc = System.Text.Json.JsonDocument.Parse(json);
+		var props = doc.RootElement.GetProperty("properties");
+
+		var product = props.GetProperty("product");
+		product.GetProperty("type").GetString().Should().Be("object");
+
+		var subProps = product.GetProperty("properties");
+		subProps.GetProperty("id").GetProperty("type").GetString().Should().Be("keyword");
+		subProps.GetProperty("name").GetProperty("type").GetString().Should().Be("text");
+	}
+
+	[Test]
+	public void ConsumerDocument_MappingJson_ContainsOwnField()
+	{
+		var json = ConsumerMappingContext.ConsumerDocument.GetMappingJson();
+		using var doc = System.Text.Json.JsonDocument.Parse(json);
+		var props = doc.RootElement.GetProperty("properties");
+
+		props.GetProperty("summary").GetProperty("type").GetString().Should().Be("text");
+	}
+
+	[Test]
+	public void ContractDocument_StillWorksFromContractsAssembly()
+	{
+		var json = ContractMappingContext.ContractDocument.GetMappingJson();
+		json.Should().NotBeNullOrEmpty();
+
+		using var doc = System.Text.Json.JsonDocument.Parse(json);
+		var props = doc.RootElement.GetProperty("properties");
+
+		var product = props.GetProperty("product");
+		product.GetProperty("type").GetString().Should().Be("object");
+	}
+}

--- a/tests/Elastic.Mapping.Tests.CrossAssembly/Elastic.Mapping.Tests.CrossAssembly.csproj
+++ b/tests/Elastic.Mapping.Tests.CrossAssembly/Elastic.Mapping.Tests.CrossAssembly.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+		<NoWarn>$(NoWarn);CA1707;CS0436</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AwesomeAssertions" Version="9.3.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="$(SolutionRoot)\src\Elastic.Mapping\Elastic.Mapping.csproj" />
+		<ProjectReference Include="$(SolutionRoot)\src\Elastic.Mapping.Generator\Elastic.Mapping.Generator.csproj"
+						  OutputItemType="Analyzer"
+						  ReferenceOutputAssembly="false" />
+		<ProjectReference Include="$(SolutionRoot)\tests\Elastic.Mapping.Tests.Contracts\Elastic.Mapping.Tests.Contracts.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/tests/Elastic.Mapping.Tests.CrossAssembly/Usings.cs
+++ b/tests/Elastic.Mapping.Tests.CrossAssembly/Usings.cs
@@ -1,0 +1,8 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+global using TUnit.Core;
+global using AwesomeAssertions;
+global using Elastic.Mapping;
+global using System.Text.Json.Serialization;


### PR DESCRIPTION
## Summary

- The generated `{Type}NestedBuilder` class was `public sealed` but its constructor and `GetFields()` were `internal`. When a consumer assembly references a library that already compiled its own copy of the nested builder, and the generator's dedup race causes the base-extensions file to skip emitting the class locally, the unqualified reference binds to the library's copy — whose `internal` members are inaccessible cross-assembly, producing **CS1729** and **CS1061**.
- Changed both members from `internal` to `public` in `EmitNestedBuilderClass` (2 lines in `MappingsBuilderEmitter.cs`).
- Added a two-project regression test (`Elastic.Mapping.Tests.Contracts` library + `Elastic.Mapping.Tests.CrossAssembly` consumer) that reproduces the exact CS1729/CS1061 failure before the fix and passes after.

## Test plan

- [x] Verified the bug reproduces without the fix (CS1729 + CS1061 on cross-assembly build)
- [x] Verified the fix resolves it (cross-assembly project builds and all 5 new tests pass)
- [x] Verified all 259 existing `Elastic.Mapping.Tests` pass with no regressions


Made with [Cursor](https://cursor.com)