### PR TITLE
feat(mapping): add Merge<TOther>() to MappingsBuilder and AnalysisBuilder

### DIFF
--- a/src/Elastic.Mapping/Analysis/AnalysisBuilder.cs
+++ b/src/Elastic.Mapping/Analysis/AnalysisBuilder.cs
@@ -18,6 +18,7 @@ public sealed class AnalysisBuilder
 	private readonly List<(string Name, ITokenFilterDefinition Definition)> _tokenFilters = [];
 	private readonly List<(string Name, INormalizerDefinition Definition)> _normalizers = [];
 	private readonly List<(string Name, ICharFilterDefinition Definition)> _charFilters = [];
+	private readonly List<AnalysisSettings> _mergeSources = [];
 
 	/// <summary>Configures a named analyzer.</summary>
 	public AnalysisBuilder Analyzer(string name, Func<AnalyzerBuilder, AnalyzerBuilder> configure)
@@ -70,16 +71,54 @@ public sealed class AnalysisBuilder
 	}
 
 	/// <summary>
+	/// Additively merges <typeparamref name="TOther"/>'s analysis components into this builder: any
+	/// analyzer/tokenizer/token filter/normalizer/char filter name not already defined on this builder
+	/// is added. A name already present — whether from an explicit call above or an earlier
+	/// <see cref="Merge{TOther}"/> call — is left untouched and never throws, unlike <see cref="Build"/>'s
+	/// normal duplicate-name behavior.
+	/// </summary>
+	/// <param name="resolver">The generated static mapping resolver for <typeparamref name="TOther"/>
+	/// (e.g. <c>SomeContext.SomeOtherDocument</c>).</param>
+	public AnalysisBuilder Merge<TOther>(IStaticMappingResolver<TOther> resolver)
+		where TOther : class
+	{
+		var other = new AnalysisBuilder();
+		resolver.Context.ConfigureAnalysis?.Invoke(other);
+		_mergeSources.Add(other.Build());
+		return this;
+	}
+
+	/// <summary>
 	/// Builds the analysis settings into an immutable AnalysisSettings object.
 	/// </summary>
-	public AnalysisSettings Build() =>
-		new(
-			_analyzers.ToDictionary(x => x.Name, x => x.Definition),
-			_tokenizers.ToDictionary(x => x.Name, x => x.Definition),
-			_tokenFilters.ToDictionary(x => x.Name, x => x.Definition),
-			_normalizers.ToDictionary(x => x.Name, x => x.Definition),
-			_charFilters.ToDictionary(x => x.Name, x => x.Definition)
-		);
+	public AnalysisSettings Build()
+	{
+		var analyzers = _analyzers.ToDictionary(x => x.Name, x => x.Definition);
+		var tokenizers = _tokenizers.ToDictionary(x => x.Name, x => x.Definition);
+		var tokenFilters = _tokenFilters.ToDictionary(x => x.Name, x => x.Definition);
+		var normalizers = _normalizers.ToDictionary(x => x.Name, x => x.Definition);
+		var charFilters = _charFilters.ToDictionary(x => x.Name, x => x.Definition);
+
+		foreach (var source in _mergeSources)
+		{
+			AddMissing(analyzers, source.Analyzers);
+			AddMissing(tokenizers, source.Tokenizers);
+			AddMissing(tokenFilters, source.TokenFilters);
+			AddMissing(normalizers, source.Normalizers);
+			AddMissing(charFilters, source.CharFilters);
+		}
+
+		return new(analyzers, tokenizers, tokenFilters, normalizers, charFilters);
+
+		static void AddMissing<TDefinition>(Dictionary<string, TDefinition> target, IReadOnlyDictionary<string, TDefinition> source)
+		{
+			foreach (var kvp in source)
+			{
+				if (!target.ContainsKey(kvp.Key))
+					target[kvp.Key] = kvp.Value;
+			}
+		}
+	}
 
 	/// <summary>Returns true if any analysis components have been configured.</summary>
 	public bool HasConfiguration =>
@@ -87,5 +126,6 @@ public sealed class AnalysisBuilder
 		_tokenizers.Count > 0 ||
 		_tokenFilters.Count > 0 ||
 		_normalizers.Count > 0 ||
-		_charFilters.Count > 0;
+		_charFilters.Count > 0 ||
+		_mergeSources.Any(s => s.HasConfiguration);
 }

--- a/src/Elastic.Mapping/Mappings/MappingOverrides.cs
+++ b/src/Elastic.Mapping/Mappings/MappingOverrides.cs
@@ -26,23 +26,32 @@ public sealed class MappingOverrides
 	/// <summary>The container intent per field path (internal; not part of the public contract).</summary>
 	internal IReadOnlyDictionary<string, FieldContainer> FieldContainers { get; }
 
+	/// <summary>
+	/// Full mapping JSON documents merged in via <see cref="Mappings.MappingsBuilder{TDocument}.Merge{TOther}(IStaticMappingResolver{TOther})"/>.
+	/// Applied after <see cref="Fields"/> so that paths already present on this builder are never overwritten.
+	/// </summary>
+	internal IReadOnlyList<string> MergeSources { get; }
+
 	internal MappingOverrides(
 		IReadOnlyDictionary<string, IFieldDefinition> fields,
 		IReadOnlyDictionary<string, RuntimeFieldDefinition> runtimeFields,
 		IReadOnlyList<DynamicTemplateDefinition> dynamicTemplates,
-		IReadOnlyDictionary<string, FieldContainer>? fieldContainers = null)
+		IReadOnlyDictionary<string, FieldContainer>? fieldContainers = null,
+		IReadOnlyList<string>? mergeSources = null)
 	{
 		Fields = fields;
 		RuntimeFields = runtimeFields;
 		DynamicTemplates = dynamicTemplates;
 		FieldContainers = fieldContainers ?? new Dictionary<string, FieldContainer>();
+		MergeSources = mergeSources ?? [];
 	}
 
 	/// <summary>Returns true if any mapping overrides are configured.</summary>
 	public bool HasConfiguration =>
 		Fields.Count > 0 ||
 		RuntimeFields.Count > 0 ||
-		DynamicTemplates.Count > 0;
+		DynamicTemplates.Count > 0 ||
+		MergeSources.Count > 0;
 
 	/// <summary>
 	/// Merges these mapping overrides into an existing mappings JSON string.
@@ -106,7 +115,79 @@ public sealed class MappingOverrides
 				templates.Add((JsonNode)template.ToJson());
 		}
 
+		// Merge sources (from Merge<TOther>()) are applied last, additively: any path/key
+		// already present on this mapping (base shape or an explicit override above) wins.
+		foreach (var source in MergeSources)
+		{
+			var sourceNode = JsonNode.Parse(source)?.AsObject();
+			if (sourceNode == null)
+				continue;
+
+			if (sourceNode["properties"]?.AsObject() is { } sourceProperties)
+			{
+				var properties = node["properties"]?.AsObject();
+				if (properties == null)
+				{
+					properties = [];
+					node["properties"] = properties;
+				}
+				MergeFieldsContainer(properties, sourceProperties);
+			}
+
+			if (sourceNode["runtime"]?.AsObject() is { } sourceRuntime)
+			{
+				var runtime = node["runtime"]?.AsObject();
+				if (runtime == null)
+				{
+					runtime = [];
+					node["runtime"] = runtime;
+				}
+				MergeFieldsContainer(runtime, sourceRuntime);
+			}
+		}
+
 		return node.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+	}
+
+	/// <summary>
+	/// Additively folds a source field-name-to-definition map (e.g. a <c>properties</c> or <c>fields</c>
+	/// container) into the target's: field names absent on the target are deep-cloned in wholesale.
+	/// A field name already present on the target is never reconciled at the definition level — its
+	/// own keys (<c>type</c>, <c>analyzer</c>, etc.) are left completely untouched, target always wins —
+	/// only its nested <c>properties</c>/<c>fields</c> sub-containers are recursed into, so a missing
+	/// child of an existing object/nested field can still be added.
+	/// </summary>
+	private static void MergeFieldsContainer(JsonObject target, JsonObject source)
+	{
+		foreach (var kvp in source)
+		{
+			if (!target.TryGetPropertyValue(kvp.Key, out var existingValue) || existingValue is not JsonObject existingDef)
+			{
+				target[kvp.Key] = kvp.Value?.DeepClone();
+				continue;
+			}
+
+			if (kvp.Value is not JsonObject sourceDef)
+				continue;
+
+			MergeNestedContainer(existingDef, sourceDef, "properties");
+			MergeNestedContainer(existingDef, sourceDef, "fields");
+		}
+	}
+
+	private static void MergeNestedContainer(JsonObject targetDef, JsonObject sourceDef, string containerKey)
+	{
+		if (sourceDef[containerKey]?.AsObject() is not { } sourceContainer)
+			return;
+
+		var targetContainer = targetDef[containerKey]?.AsObject();
+		if (targetContainer == null)
+		{
+			targetDef[containerKey] = sourceContainer.DeepClone();
+			return;
+		}
+
+		MergeFieldsContainer(targetContainer, sourceContainer);
 	}
 
 	private static readonly HashSet<string> ObjectTypes = ["object", "nested"];

--- a/src/Elastic.Mapping/Mappings/MappingsBuilder.cs
+++ b/src/Elastic.Mapping/Mappings/MappingsBuilder.cs
@@ -26,4 +26,35 @@ public sealed class MappingsBuilder<TDocument> : MappingsBuilderBase<MappingsBui
 	/// <inheritdoc cref="MappingsBuilderBase{TSelf}.MergeNestedFields"/>
 	public new void MergeNestedFields(IReadOnlyList<(string Path, IFieldDefinition Definition)> fields) =>
 		base.MergeNestedFields(fields);
+
+	/// <summary>
+	/// Additively merges <typeparamref name="TOther"/>'s generated mapping into this builder: every
+	/// field path present on <typeparamref name="TOther"/> that is not already present on
+	/// <typeparamref name="TDocument"/> (via its own generated shape or an explicit call on this
+	/// builder) is added. A path that exists on both is left completely untouched —
+	/// <typeparamref name="TDocument"/> always wins, this operation never overwrites or reconciles
+	/// a conflicting definition for the same path.
+	/// </summary>
+	/// <param name="resolver">The generated static mapping resolver for <typeparamref name="TOther"/>
+	/// (e.g. <c>SomeContext.SomeOtherDocument</c>).</param>
+	public MappingsBuilder<TDocument> Merge<TOther>(IStaticMappingResolver<TOther> resolver)
+		where TOther : class =>
+		base.AddMergeSource(resolver.Context.GetMappingsJson());
+
+	/// <summary>
+	/// Additively merges <typeparamref name="TOther"/>'s mapping into this builder, as configured by
+	/// <paramref name="configure"/> — the equivalent of merging in an already fully-configured sibling
+	/// builder (including its own <c>AddProperty</c>/<c>AddField</c> overrides), not just its bare
+	/// generated defaults. Same conflict semantics as <see cref="Merge{TOther}(IStaticMappingResolver{TOther})"/>:
+	/// <typeparamref name="TDocument"/> always wins on a path present on both.
+	/// </summary>
+	public MappingsBuilder<TDocument> Merge<TOther>(
+		IStaticMappingResolver<TOther> resolver,
+		Func<MappingsBuilder<TOther>, MappingsBuilder<TOther>> configure)
+		where TOther : class
+	{
+		var overrides = configure(new MappingsBuilder<TOther>()).Build();
+		var mappingsJson = overrides.MergeIntoMappings(resolver.Context.GetMappingsJson());
+		return base.AddMergeSource(mappingsJson);
+	}
 }

--- a/src/Elastic.Mapping/Mappings/MappingsBuilderBase.cs
+++ b/src/Elastic.Mapping/Mappings/MappingsBuilderBase.cs
@@ -18,6 +18,7 @@ public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBa
 	private readonly List<(string Path, Action<FieldBuilder> Action, FieldContainer Container)> _fieldActions = [];
 	private readonly List<(string Name, RuntimeFieldDefinition Definition)> _runtimeFields = [];
 	private readonly List<DynamicTemplateDefinition> _dynamicTemplates = [];
+	private readonly List<string> _mergeSources = [];
 
 	private TSelf AddFieldCore(string path, Func<FieldBuilder, FieldBuilder> configure, FieldContainer container)
 	{
@@ -50,6 +51,17 @@ public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBa
 	{
 		foreach (var (path, def) in fields)
 			_fieldActions.Add((path, fb => fb.SetDefinition(def), FieldContainer.Auto));
+	}
+
+	/// <summary>
+	/// Adds a full mapping JSON document as a merge source. Applied additively after all field
+	/// overrides at <see cref="Build"/>-merge time: paths already present on this builder's own
+	/// shape always win. Called by <see cref="MappingsBuilder{TDocument}.Merge{TOther}(IStaticMappingResolver{TOther})"/>.
+	/// </summary>
+	protected TSelf AddMergeSource(string mappingsJson)
+	{
+		_mergeSources.Add(mappingsJson);
+		return (TSelf)this;
 	}
 
 	/// <summary>
@@ -101,7 +113,8 @@ public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBa
 	public bool HasConfiguration =>
 		_fieldActions.Count > 0 ||
 		_runtimeFields.Count > 0 ||
-		_dynamicTemplates.Count > 0;
+		_dynamicTemplates.Count > 0 ||
+		_mergeSources.Count > 0;
 
 	/// <summary>
 	/// Builds the mapping overrides from all configured fields, runtime fields, and dynamic templates.
@@ -127,6 +140,6 @@ public abstract class MappingsBuilderBase<TSelf> where TSelf : MappingsBuilderBa
 		foreach (var (name, def) in _runtimeFields)
 			runtimeFields[name] = def;
 
-		return new(fields, runtimeFields, [.. _dynamicTemplates], containers);
+		return new(fields, runtimeFields, [.. _dynamicTemplates], containers, [.. _mergeSources]);
 	}
 }

--- a/tests/Elastic.Mapping.Tests/MergeMappingsTests.cs
+++ b/tests/Elastic.Mapping.Tests/MergeMappingsTests.cs
@@ -1,0 +1,147 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json;
+using Elastic.Mapping.Analysis;
+using Elastic.Mapping.Mappings;
+
+namespace Elastic.Mapping.Tests;
+
+public class MergeMappingsTests
+{
+	[Test]
+	public void MappingsBuilder_Merge_NoOverlap_AddsMissingPaths()
+	{
+		var builder = new MappingsBuilder<MergeBaseDocument>()
+			.Merge(MergeTestMappingContext.MergeSourceDocument);
+
+		var overrides = builder.Build();
+		var baseMappings = MergeTestMappingContext.MergeBaseDocument.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var properties = doc.RootElement.GetProperty("properties");
+		properties.GetProperty("extraField").GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void MappingsBuilder_Merge_FullOverlap_IsNoOp()
+	{
+		var builder = new MappingsBuilder<MergeBaseDocument>()
+			.Merge(MergeTestMappingContext.MergeSourceDocument);
+
+		var overrides = builder.Build();
+		var baseMappings = MergeTestMappingContext.MergeBaseDocument.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var value = doc.RootElement.GetProperty("properties").GetProperty("value");
+		value.GetProperty("type").GetString().Should().Be("long");
+	}
+
+	[Test]
+	public void MappingsBuilder_Merge_GenuineConflict_TargetWins()
+	{
+		var builder = new MappingsBuilder<MergeBaseDocument>()
+			.Merge(MergeTestMappingContext.MergeSourceDocument);
+
+		var overrides = builder.Build();
+		var baseMappings = MergeTestMappingContext.MergeBaseDocument.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var conflictField = doc.RootElement.GetProperty("properties").GetProperty("conflictField");
+		conflictField.GetProperty("type").GetString().Should().Be("keyword",
+			"MergeBaseDocument's own type must win over MergeSourceDocument's conflicting type");
+		conflictField.TryGetProperty("analyzer", out _).Should().BeFalse(
+			"the source's text-specific config must not leak into the target's keyword definition");
+	}
+
+	[Test]
+	public void MappingsBuilder_Merge_GenuineConflict_ExplicitOverrideAlsoWins()
+	{
+		// The target explicitly declares "conflictField" itself (not just via its generated
+		// baseline) before merging — the explicit call must win the same way the baseline does.
+		var builder = new MappingsBuilder<MergeBaseDocument>()
+			.AddField("conflictField", f => f.Keyword().IgnoreAbove(64))
+			.Merge(MergeTestMappingContext.MergeSourceDocument);
+
+		var overrides = builder.Build();
+		var baseMappings = MergeTestMappingContext.MergeBaseDocument.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var conflictField = doc.RootElement.GetProperty("properties").GetProperty("conflictField");
+		conflictField.GetProperty("type").GetString().Should().Be("keyword");
+		conflictField.GetProperty("ignore_above").GetInt32().Should().Be(64);
+	}
+
+	[Test]
+	public void MappingsBuilder_Merge_ConfigureOverload_CapturesManualOverrides()
+	{
+		var builder = new MappingsBuilder<MergeBaseDocument>()
+			.Merge(MergeTestMappingContext.MergeSourceDocument, b => b
+				.AddField("extraConfigured", f => f.Text().Analyzer("standard")));
+
+		var overrides = builder.Build();
+		var baseMappings = MergeTestMappingContext.MergeBaseDocument.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var properties = doc.RootElement.GetProperty("properties");
+
+		// The manual AddField from the configure lambda is present...
+		var extraConfigured = properties.GetProperty("extraConfigured");
+		extraConfigured.GetProperty("type").GetString().Should().Be("text");
+		extraConfigured.GetProperty("analyzer").GetString().Should().Be("standard");
+
+		// ...alongside MergeSourceDocument's own generated defaults.
+		properties.GetProperty("extraField").GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void MappingsBuilder_Merge_HasConfiguration_TrueAfterMerge()
+	{
+		var builder = new MappingsBuilder<MergeBaseDocument>()
+			.Merge(MergeTestMappingContext.MergeSourceDocument);
+
+		builder.HasConfiguration.Should().BeTrue();
+	}
+
+	[Test]
+	public void AnalysisBuilder_Merge_NoOverlap_AddsMissingAnalyzer()
+	{
+		var builder = new AnalysisBuilder()
+			.Merge(MergeTestMappingContext.MergeSourceDocument);
+
+		var settings = builder.Build();
+		settings.Analyzers.Should().ContainKey("source_only_analyzer");
+	}
+
+	[Test]
+	public void AnalysisBuilder_Merge_NameConflict_TargetWins()
+	{
+		var builder = new AnalysisBuilder()
+			.Analyzer("shared_analyzer", a => a
+				.Custom()
+				.Tokenizer(BuiltInAnalysis.Tokenizers.Standard)
+				.Filters(BuiltInAnalysis.TokenFilters.Lowercase))
+			.Merge(MergeTestMappingContext.MergeSourceDocument);
+
+		var settings = builder.Build();
+		var json = settings.ToJson().ToJsonString();
+		json.Should().Contain("standard").And.NotContain("whitespace");
+	}
+
+	[Test]
+	public void AnalysisBuilder_Merge_DoesNotThrowOnDuplicateName()
+	{
+		var act = () => new AnalysisBuilder()
+			.Analyzer("shared_analyzer", a => a.Custom().Tokenizer(BuiltInAnalysis.Tokenizers.Standard))
+			.Merge(MergeTestMappingContext.MergeSourceDocument)
+			.Build();
+
+		act.Should().NotThrow();
+	}
+}

--- a/tests/Elastic.Mapping.Tests/TestModels.cs
+++ b/tests/Elastic.Mapping.Tests/TestModels.cs
@@ -1011,3 +1011,54 @@ public static class SharedNestedMappingHelpers
 	public static MappingsBuilder<IndependentNestedDoc> ConfigureOtherMeta(MappingsBuilder<IndependentNestedDoc> m) =>
 		m.OtherMeta((SharedNestedMetaNestedBuilder meta) => meta.Key(k => k).Value(v => v));
 }
+
+// ============================================================================
+// MERGE TEST TYPES: MappingsBuilder<T>.Merge<TOther>() / AnalysisBuilder.Merge<TOther>()
+// ============================================================================
+
+/// <summary>Merge target ("T"): unrelated to <see cref="MergeSourceDocument"/> beyond sharing field names.</summary>
+public class MergeBaseDocument
+{
+	[Id]
+	public string Name { get; set; } = string.Empty;
+
+	// Overlaps MergeSourceDocument.Value with the same type — full-overlap merge should be a no-op.
+	public long Value { get; set; }
+
+	// Overlaps MergeSourceDocument.ConflictField with a DIFFERENT type — merge must keep this (keyword) type.
+	[Keyword]
+	public string ConflictField { get; set; } = string.Empty;
+}
+
+/// <summary>Merge source ("TOther"): has its own extra field plus fields that collide with <see cref="MergeBaseDocument"/>.</summary>
+public class MergeSourceDocument
+{
+	// Same path + type as MergeBaseDocument.Value — verifies full overlap is a no-op.
+	public long Value { get; set; }
+
+	// Same path as MergeBaseDocument.ConflictField but a different type (text vs keyword) —
+	// verifies a genuine conflict leaves the target's definition untouched.
+	[Text(Analyzer = "standard")]
+	public string ConflictField { get; set; } = string.Empty;
+
+	// No counterpart on MergeBaseDocument — verifies merge adds genuinely new paths.
+	[Keyword]
+	public string ExtraField { get; set; } = string.Empty;
+}
+
+[ElasticsearchMappingContext]
+[Index<MergeBaseDocument>(Name = "merge-base-docs")]
+[Index<MergeSourceDocument>(Name = "merge-source-docs")]
+public static partial class MergeTestMappingContext
+{
+	/// <summary>Analysis registered only on the merge source, to verify <c>AnalysisBuilder.Merge</c> pulls it in.</summary>
+	public static AnalysisBuilder ConfigureMergeSourceDocumentAnalysis(AnalysisBuilder analysis) => analysis
+		.Analyzer("source_only_analyzer", a => a
+			.Custom()
+			.Tokenizer(BuiltInAnalysis.Tokenizers.Standard)
+			.Filters(BuiltInAnalysis.TokenFilters.Lowercase))
+		.Analyzer("shared_analyzer", a => a
+			.Custom()
+			.Tokenizer(BuiltInAnalysis.Tokenizers.Whitespace)
+			.Filters(BuiltInAnalysis.TokenFilters.Lowercase));
+}


### PR DESCRIPTION
## Summary

Elastic.Mapping's source generator builds a document type's mapping from its own declared properties plus its base-class chain only — never sibling types. This breaks down when two unrelated document types share a base but each adds its own fields, and documents of one type get reindexed into an index mapped for the other.

Adds an **additive-only** `.Merge<TOther>()` to both `MappingsBuilder<T>` and `AnalysisBuilder`:

- Pulls in `TOther`'s field paths / analysis components that aren't already present on the current builder.
- Never overwrites or reconciles a conflicting definition for a path/name that already exists — the target (`T`) always wins, whether the conflict comes from `T`'s attribute-declared baseline or an explicit `AddField`/`AddProperty`/`Analyzer` call.
- `Merge<TOther>` takes the generated static resolver for `TOther` (`IStaticMappingResolver<TOther>`, e.g. `SomeContext.SomeOtherDocument`), so it works across contexts without requiring any inheritance relationship between `T` and `TOther`.
- A `configure` overload on `MappingsBuilder<T>.Merge` lets you merge in an already fully-configured sibling builder (its own manual overrides), not just its bare generated defaults.

No source-generator changes were required — both `resolver.Context.GetMappingsJson()` and `resolver.Context.ConfigureAnalysis` were already public.

### Example usage

```csharp
// WebsiteSearchDocument and DocumentationDocument are unrelated document types
// that both get indexed into "search-content", but only DocumentationDocument
// declares `Applies` -> "appliesTo".
[ElasticsearchMappingContext]
[Index<WebsiteSearchDocument>(Name = "search-content")]
[Index<DocumentationDocument>(Name = "search-content")]
public static partial class SearchMappingContext
{
    // Give WebsiteSearchDocument's mapping topology for the fields DocumentationDocument
    // adds (e.g. appliesTo), without inheriting from DocumentationDocument.
    public static MappingsBuilder<WebsiteSearchDocument> ConfigureWebsiteSearchDocumentMappings(
        MappingsBuilder<WebsiteSearchDocument> mappings) =>
        mappings.Merge(SearchMappingContext.DocumentationDocument);

    // Same idea for analysis: pull in DocumentationDocument's analyzers/filters by name.
    public static AnalysisBuilder ConfigureWebsiteSearchDocumentAnalysis(AnalysisBuilder analysis) =>
        analysis.Merge(SearchMappingContext.DocumentationDocument);
}
```

To also merge in a sibling's manual overrides (not just its generated defaults):

```csharp
mappings.Merge(SearchMappingContext.DocumentationDocument, b => b
    .AddProperty("appliesTo.version", f => f.Keyword()));
```

## Test plan

- [x] `dotnet build` — full solution builds clean
- [x] `dotnet test tests/Elastic.Mapping.Tests` — 268/268 passing, including 9 new tests in `MergeMappingsTests.cs` covering: no overlap, full overlap (no-op), genuine conflict via baseline, genuine conflict via explicit override, the `configure` overload, and analysis merge (add + skip-on-duplicate-name, never throws)

🤖 Generated with [Claude Code](https://claude.com/claude-code)