### PR TITLE
fix(mapping): support Merge() from NameTemplate-based (templated) resolvers

### DIFF
--- a/src/Elastic.Mapping.Generator/Emitters/ContextEmitter.cs
+++ b/src/Elastic.Mapping.Generator/Emitters/ContextEmitter.cs
@@ -150,10 +150,7 @@ internal static class ContextEmitter
 		var templated = IsTemplated(reg);
 
 		sb.AppendLine($"{indent}/// <summary>Generated Elasticsearch resolver for {reg.ResolverName}.</summary>");
-		if (templated)
-			sb.AppendLine($"{indent}public sealed class {reg.ResolverName}Resolver");
-		else
-			sb.AppendLine($"{indent}public sealed class {reg.ResolverName}Resolver : global::Elastic.Mapping.IStaticMappingResolver<global::{typeFqn}>");
+		sb.AppendLine($"{indent}public sealed class {reg.ResolverName}Resolver : global::Elastic.Mapping.IStaticMappingResolver<global::{typeFqn}>");
 		sb.AppendLine($"{indent}{{");
 
 		// Config override field for DI
@@ -196,10 +193,7 @@ internal static class ContextEmitter
 		EmitRuntimeContext(sb, reg, indent + "\t");
 
 		// Context instance
-		if (templated)
-			sb.AppendLine($"{indent}\t/// <summary>Base context with mappings and settings. Use <see cref=\"CreateContext\"/> to resolve the name template.</summary>");
-		else
-			sb.AppendLine($"{indent}\t/// <summary>Elasticsearch context metadata.</summary>");
+		sb.AppendLine($"{indent}\t/// <summary>{(templated ? "Base context with mappings and settings. Use <see cref=\"CreateContext\"/> to resolve the name template." : "Elasticsearch context metadata.")}</summary>");
 		sb.AppendLine($"{indent}\t{contextVisibility} global::Elastic.Mapping.ElasticsearchTypeContext {contextFieldName} {{ get; }} = new(");
 		sb.AppendLine($"{indent}\t\t_GetSettingsJson,");
 		sb.AppendLine($"{indent}\t\t_GetMappingJson,");
@@ -265,6 +259,17 @@ internal static class ContextEmitter
 
 		sb.AppendLine($"{indent}\t);");
 		sb.AppendLine();
+
+		if (templated)
+		{
+			sb.AppendLine($"{indent}\t/// <summary>");
+			sb.AppendLine($"{indent}\t/// Exposes the base context (without a resolved index name) so this resolver");
+			sb.AppendLine($"{indent}\t/// satisfies <see cref=\"global::Elastic.Mapping.IStaticMappingResolver{{T}}\"/>.");
+			sb.AppendLine($"{indent}\t/// For a fully resolved context with concrete index name, call <see cref=\"CreateContext\"/>.");
+			sb.AppendLine($"{indent}\t/// </summary>");
+			sb.AppendLine($"{indent}\tpublic global::Elastic.Mapping.ElasticsearchTypeContext Context => _baseContext;");
+			sb.AppendLine();
+		}
 
 		// Hash accessors — delegate to runtime-computed values that include all overrides
 		sb.AppendLine($"{indent}\t/// <summary>Combined hash of settings and mappings (includes ConfigureMappings, ConfigureAnalysis, IndexSettings).</summary>");

--- a/src/Elastic.Mapping/Analysis/AnalysisBuilder.cs
+++ b/src/Elastic.Mapping/Analysis/AnalysisBuilder.cs
@@ -89,6 +89,21 @@ public sealed class AnalysisBuilder
 	}
 
 	/// <summary>
+	/// Additively merges analysis components from the given <paramref name="context"/> into this builder.
+	/// Useful when the source resolver uses a <c>NameTemplate</c> and you already have a resolved
+	/// <see cref="ElasticsearchTypeContext"/> from <c>CreateContext(...)</c>, or when you want to
+	/// merge from any context without requiring <see cref="IStaticMappingResolver{T}"/>.
+	/// Same conflict semantics: names already present on this builder are left untouched.
+	/// </summary>
+	public AnalysisBuilder Merge(ElasticsearchTypeContext context)
+	{
+		var other = new AnalysisBuilder();
+		context.ConfigureAnalysis?.Invoke(other);
+		_mergeSources.Add(other.Build());
+		return this;
+	}
+
+	/// <summary>
 	/// Builds the analysis settings into an immutable AnalysisSettings object.
 	/// </summary>
 	public AnalysisSettings Build()

--- a/src/Elastic.Mapping/Mappings/MappingsBuilder.cs
+++ b/src/Elastic.Mapping/Mappings/MappingsBuilder.cs
@@ -57,4 +57,29 @@ public sealed class MappingsBuilder<TDocument> : MappingsBuilderBase<MappingsBui
 		var mappingsJson = overrides.MergeIntoMappings(resolver.Context.GetMappingsJson());
 		return base.AddMergeSource(mappingsJson);
 	}
+
+	/// <summary>
+	/// Additively merges mappings from the given <paramref name="context"/> into this builder.
+	/// Useful when the source resolver uses a <c>NameTemplate</c> and you already have a resolved
+	/// <see cref="ElasticsearchTypeContext"/> from <c>CreateContext(...)</c>, or when you want to
+	/// merge from any context without requiring <see cref="IStaticMappingResolver{T}"/>.
+	/// Same conflict semantics: <typeparamref name="TDocument"/> always wins on a path present on both.
+	/// </summary>
+	public MappingsBuilder<TDocument> Merge(ElasticsearchTypeContext context) =>
+		base.AddMergeSource(context.GetMappingsJson());
+
+	/// <summary>
+	/// Additively merges mappings from the given <paramref name="context"/> into this builder,
+	/// as configured by <paramref name="configure"/>. Same conflict semantics:
+	/// <typeparamref name="TDocument"/> always wins on a path present on both.
+	/// </summary>
+	public MappingsBuilder<TDocument> Merge<TOther>(
+		ElasticsearchTypeContext context,
+		Func<MappingsBuilder<TOther>, MappingsBuilder<TOther>> configure)
+		where TOther : class
+	{
+		var overrides = configure(new MappingsBuilder<TOther>()).Build();
+		var mappingsJson = overrides.MergeIntoMappings(context.GetMappingsJson());
+		return base.AddMergeSource(mappingsJson);
+	}
 }

--- a/tests/Elastic.Mapping.Tests/CreateContextTests.cs
+++ b/tests/Elastic.Mapping.Tests/CreateContextTests.cs
@@ -14,12 +14,14 @@ public class CreateContextTests
 	// ── KnowledgeArticle: template with custom + well-known placeholders ──
 
 	[Test]
-	public void TemplatedResolverDoesNotExposeContextProperty()
+	public void TemplatedResolverImplementsIStaticMappingResolver()
 	{
 		var resolver = TemplatedMappingContext.KnowledgeArticle;
-		var type = resolver.GetType();
-		var contextProp = type.GetProperty("Context");
-		contextProp.Should().BeNull("templated resolvers expose CreateContext() instead of Context");
+
+		(resolver is IStaticMappingResolver<KnowledgeArticle>).Should().BeTrue(
+			"templated resolvers now implement IStaticMappingResolver<T>");
+		resolver.Context.Should().NotBeNull();
+		resolver.Context.GetMappingsJson().Should().NotBeNullOrEmpty();
 	}
 
 	[Test]

--- a/tests/Elastic.Mapping.Tests/MergeMappingsTests.cs
+++ b/tests/Elastic.Mapping.Tests/MergeMappingsTests.cs
@@ -144,4 +144,108 @@ public class MergeMappingsTests
 
 		act.Should().NotThrow();
 	}
+
+	// =========================================================================
+	// Templated (NameTemplate-based) merge tests
+	// =========================================================================
+
+	[Test]
+	public void TemplatedResolver_Implements_IStaticMappingResolver()
+	{
+		var resolver = TemplatedMergeTestMappingContext.TemplatedMergeSourceDocument;
+		(resolver is IStaticMappingResolver<TemplatedMergeSourceDocument>).Should().BeTrue();
+		resolver.Context.Should().NotBeNull();
+		resolver.Context.GetMappingsJson().Should().NotBeNullOrEmpty();
+	}
+
+	[Test]
+	public void MappingsBuilder_Merge_TemplatedResolver_ViaInterface_AddsMissingPaths()
+	{
+		var builder = new MappingsBuilder<TemplatedMergeBaseDocument>()
+			.Merge(TemplatedMergeTestMappingContext.TemplatedMergeSourceDocument);
+
+		var overrides = builder.Build();
+		var baseMappings = TemplatedMergeTestMappingContext.TemplatedMergeBaseDocument.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var properties = doc.RootElement.GetProperty("properties");
+		properties.GetProperty("extraField").GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void MappingsBuilder_Merge_TemplatedResolver_ViaInterface_TargetWins()
+	{
+		var builder = new MappingsBuilder<TemplatedMergeBaseDocument>()
+			.Merge(TemplatedMergeTestMappingContext.TemplatedMergeSourceDocument);
+
+		var overrides = builder.Build();
+		var baseMappings = TemplatedMergeTestMappingContext.TemplatedMergeBaseDocument.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var conflictField = doc.RootElement.GetProperty("properties").GetProperty("conflictField");
+		conflictField.GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void MappingsBuilder_Merge_TemplatedResolver_ViaContext_AddsMissingPaths()
+	{
+		var context = TemplatedMergeTestMappingContext.TemplatedMergeSourceDocument
+			.CreateContext("articles", "production");
+
+		var builder = new MappingsBuilder<TemplatedMergeBaseDocument>()
+			.Merge(context);
+
+		var overrides = builder.Build();
+		var baseMappings = TemplatedMergeTestMappingContext.TemplatedMergeBaseDocument.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var properties = doc.RootElement.GetProperty("properties");
+		properties.GetProperty("extraField").GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void MappingsBuilder_Merge_TemplatedResolver_ViaContext_WithConfigure()
+	{
+		var context = TemplatedMergeTestMappingContext.TemplatedMergeSourceDocument
+			.CreateContext("articles", "production");
+
+		var builder = new MappingsBuilder<TemplatedMergeBaseDocument>()
+			.Merge<TemplatedMergeSourceDocument>(context, b => b
+				.AddField("extraConfigured", f => f.Text().Analyzer("standard")));
+
+		var overrides = builder.Build();
+		var baseMappings = TemplatedMergeTestMappingContext.TemplatedMergeBaseDocument.GetMappingJson();
+		var merged = overrides.MergeIntoMappings(baseMappings);
+
+		using var doc = JsonDocument.Parse(merged);
+		var properties = doc.RootElement.GetProperty("properties");
+		properties.GetProperty("extraConfigured").GetProperty("type").GetString().Should().Be("text");
+		properties.GetProperty("extraField").GetProperty("type").GetString().Should().Be("keyword");
+	}
+
+	[Test]
+	public void AnalysisBuilder_Merge_TemplatedResolver_ViaInterface()
+	{
+		var builder = new AnalysisBuilder()
+			.Merge(TemplatedMergeTestMappingContext.TemplatedMergeSourceDocument);
+
+		var settings = builder.Build();
+		settings.Analyzers.Should().ContainKey("templated_source_analyzer");
+	}
+
+	[Test]
+	public void AnalysisBuilder_Merge_TemplatedResolver_ViaContext()
+	{
+		var context = TemplatedMergeTestMappingContext.TemplatedMergeSourceDocument
+			.CreateContext("articles", "production");
+
+		var builder = new AnalysisBuilder()
+			.Merge(context);
+
+		var settings = builder.Build();
+		settings.Analyzers.Should().ContainKey("templated_source_analyzer");
+	}
 }

--- a/tests/Elastic.Mapping.Tests/TestModels.cs
+++ b/tests/Elastic.Mapping.Tests/TestModels.cs
@@ -1062,3 +1062,43 @@ public static partial class MergeTestMappingContext
 			.Tokenizer(BuiltInAnalysis.Tokenizers.Whitespace)
 			.Filters(BuiltInAnalysis.TokenFilters.Lowercase));
 }
+
+// ============================================================================
+// TEMPLATED MERGE TEST TYPES: Merge from NameTemplate-based (env-parameterized) resolvers
+// ============================================================================
+
+/// <summary>Merge target using a fixed Name — merges from a templated source.</summary>
+public class TemplatedMergeBaseDocument
+{
+	[Id]
+	public string Name { get; set; } = string.Empty;
+
+	public long Value { get; set; }
+
+	[Keyword]
+	public string ConflictField { get; set; } = string.Empty;
+}
+
+/// <summary>Merge source using NameTemplate — has extra fields and analysis config.</summary>
+public class TemplatedMergeSourceDocument
+{
+	public long Value { get; set; }
+
+	[Text(Analyzer = "standard")]
+	public string ConflictField { get; set; } = string.Empty;
+
+	[Keyword]
+	public string ExtraField { get; set; } = string.Empty;
+}
+
+[ElasticsearchMappingContext]
+[Index<TemplatedMergeBaseDocument>(Name = "tmb-docs")]
+[Index<TemplatedMergeSourceDocument>(NameTemplate = "tms-{type}-{env}")]
+public static partial class TemplatedMergeTestMappingContext
+{
+	public static AnalysisBuilder ConfigureTemplatedMergeSourceDocumentAnalysis(AnalysisBuilder analysis) => analysis
+		.Analyzer("templated_source_analyzer", a => a
+			.Custom()
+			.Tokenizer(BuiltInAnalysis.Tokenizers.Standard)
+			.Filters(BuiltInAnalysis.TokenFilters.Lowercase));
+}


### PR DESCRIPTION
Closes #196

## Summary

- Templated resolvers (those using `NameTemplate` instead of fixed `Name`) now implement `IStaticMappingResolver<T>`, so existing `Merge<TOther>()` calls work with them directly
- New `Merge(ElasticsearchTypeContext)` overloads on `MappingsBuilder<T>` and `AnalysisBuilder` accept a resolved context for callers who already have a `CreateContext(...)` result

## Examples

### Before (broken — wouldn't compile)

```csharp
// NameTemplate-based resolver — did NOT implement IStaticMappingResolver<T>
[Index<SourceDoc>(NameTemplate = "docs-{type}-{env}")]
public static partial class MyContext;

// ❌ Compile error: no implicit conversion
var builder = new MappingsBuilder<TargetDoc>()
    .Merge(MyContext.SourceDoc);
```

### After — option 1: resolver directly (now works)

```csharp
// Templated resolvers now implement IStaticMappingResolver<T>,
// exposing a Context that carries mappings/settings/hashes.
var builder = new MappingsBuilder<TargetDoc>()
    .Merge(MyContext.SourceDoc);

// Analysis merge works the same way:
var analysis = new AnalysisBuilder()
    .Merge(MyContext.SourceDoc);
```

### After — option 2: resolved context

```csharp
// If you already have a resolved context from CreateContext():
var ctx = MyContext.SourceDoc.CreateContext("semantic", env: "production");

var builder = new MappingsBuilder<TargetDoc>()
    .Merge(ctx);

// With configure overrides:
var builder2 = new MappingsBuilder<TargetDoc>()
    .Merge<SourceDoc>(ctx, b => b
        .AddField("extra", f => f.Text().Analyzer("standard")));

// Analysis:
var analysis = new AnalysisBuilder()
    .Merge(ctx);
```

## Test plan

- [x] Templated resolver implements `IStaticMappingResolver<T>` and exposes `Context`
- [x] `MappingsBuilder.Merge()` via interface adds missing paths from templated source
- [x] `MappingsBuilder.Merge()` via interface — target wins on conflicts
- [x] `MappingsBuilder.Merge(context)` adds missing paths from resolved context
- [x] `MappingsBuilder.Merge<TOther>(context, configure)` captures manual overrides
- [x] `AnalysisBuilder.Merge()` via interface pulls in templated source analyzers
- [x] `AnalysisBuilder.Merge(context)` pulls in analyzers from resolved context
- [x] All 275 existing tests still pass


Made with [Cursor](https://cursor.com)