### PR TITLE
fix: parse per-document _reindex failures as array instead of string

### DIFF
--- a/src/Elastic.Ingest.Elasticsearch/Helpers/ReindexProgress.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/ReindexProgress.cs
@@ -2,8 +2,14 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 using System;
+using System.Collections.Generic;
 
 namespace Elastic.Ingest.Elasticsearch.Helpers;
+
+/// <summary>
+/// Represents a single per-document failure from a <c>_reindex</c> operation.
+/// </summary>
+public sealed record ReindexFailure(string? Index, string? Id, int? Status, string? CauseType, string? CauseReason);
 
 /// <summary>
 /// Progress snapshot for a server-side _reindex operation.
@@ -51,4 +57,7 @@ public class ReindexProgress
 
 	/// <summary> Error description if the task failed. </summary>
 	public string? Error { get; init; }
+
+	/// <summary> Per-document bulk failures reported by the <c>_reindex</c> operation. Empty when there are no failures. </summary>
+	public IReadOnlyList<ReindexFailure> Failures { get; init; } = [];
 }

--- a/src/Elastic.Ingest.Elasticsearch/Helpers/ServerReindex.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Helpers/ServerReindex.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Transport;
@@ -205,14 +206,26 @@ public sealed class ServerReindex
 		sb.Append('}');
 	}
 
-	internal static ReindexProgress ParseProgress(
-		string taskId, JsonResponse response, ReindexTaskMonitor.ApiShape shape)
+	/// <summary>
+	/// Parses a reindex status <see cref="JsonResponse"/> into a <see cref="ReindexProgress"/> snapshot.
+	/// </summary>
+	/// <param name="taskId">The task identifier.</param>
+	/// <param name="response">The raw JSON response from Elasticsearch.</param>
+	/// <param name="isReindexApi">
+	/// <c>true</c> for the <c>GET /_reindex/{id}</c> shape (9.5.0+);
+	/// <c>false</c> for the legacy <c>GET /_tasks/{id}</c> shape.
+	/// </param>
+	public static ReindexProgress ParseProgress(
+		string taskId, JsonResponse response, bool isReindexApi)
 	{
-		if (shape == ReindexTaskMonitor.ApiShape.ReindexApi)
-			return ParseReindexApiProgress(taskId, response);
-
-		return ParseTaskApiProgress(taskId, response);
+		return isReindexApi
+			? ParseReindexApiProgress(taskId, response)
+			: ParseTaskApiProgress(taskId, response);
 	}
+
+	internal static ReindexProgress ParseProgress(
+		string taskId, JsonResponse response, ReindexTaskMonitor.ApiShape shape) =>
+		ParseProgress(taskId, response, shape == ReindexTaskMonitor.ApiShape.ReindexApi);
 
 	/// <summary>
 	/// Parses the <c>GET /_reindex/{id}</c> response shape (9.5.0+).
@@ -222,13 +235,10 @@ public sealed class ServerReindex
 	{
 		var completed = response.Get<bool>("completed");
 		var error = response.Get<string>("error.reason");
+		var failures = completed ? ParseFailures(response.Body?["response"]?["failures"]) : [];
 
-		if (completed)
-		{
-			var respError = response.Get<string>("response.failures");
-			if (!string.IsNullOrEmpty(respError))
-				error ??= respError;
-		}
+		if (failures.Count > 0)
+			error ??= $"{failures.Count} document(s) failed: {failures[0].CauseReason ?? failures[0].CauseType ?? "unknown"}";
 
 		var id = response.Get<string>("id") ?? taskId;
 		var startMillis = response.Get<long>("start_time_in_millis");
@@ -250,8 +260,32 @@ public sealed class ServerReindex
 			Elapsed = TimeSpan.FromMilliseconds(response.Get<long>("running_time_in_nanos") / 1_000_000.0),
 			Description = response.Get<string>("description"),
 			StartTime = startTime,
-			Error = error
+			Error = error,
+			Failures = failures
 		};
+	}
+
+	private static IReadOnlyList<ReindexFailure> ParseFailures(JsonNode? failuresNode)
+	{
+		if (failuresNode is not JsonArray arr || arr.Count == 0)
+			return [];
+
+		var list = new List<ReindexFailure>(arr.Count);
+		foreach (var item in arr)
+		{
+			if (item is not JsonObject obj)
+				continue;
+
+			var cause = obj["cause"];
+			list.Add(new ReindexFailure(
+				Index: obj["index"]?.GetValue<string>(),
+				Id: obj["id"]?.GetValue<string>(),
+				Status: obj["status"]?.GetValue<int>(),
+				CauseType: cause?["type"]?.GetValue<string>(),
+				CauseReason: cause?["reason"]?.GetValue<string>()
+			));
+		}
+		return list;
 	}
 
 	/// <summary>
@@ -262,13 +296,10 @@ public sealed class ServerReindex
 	{
 		var completed = response.Get<bool>("completed");
 		var error = response.Get<string>("error.reason");
+		var failures = completed ? ParseFailures(response.Body?["response"]?["failures"]) : [];
 
-		if (completed)
-		{
-			var respError = response.Get<string>("response.failures");
-			if (!string.IsNullOrEmpty(respError))
-				error ??= respError;
-		}
+		if (failures.Count > 0)
+			error ??= $"{failures.Count} document(s) failed: {failures[0].CauseReason ?? failures[0].CauseType ?? "unknown"}";
 
 		return new ReindexProgress
 		{
@@ -281,7 +312,8 @@ public sealed class ServerReindex
 			Noops = response.Get<long>("task.status.noops"),
 			VersionConflicts = response.Get<long>("task.status.version_conflicts"),
 			Elapsed = TimeSpan.FromMilliseconds(response.Get<long>("task.running_time_in_nanos") / 1_000_000.0),
-			Error = error
+			Error = error,
+			Failures = failures
 		};
 	}
 }

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/ServerReindexProgressTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/ServerReindexProgressTests.cs
@@ -1,0 +1,261 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text.Json.Nodes;
+using Elastic.Ingest.Elasticsearch.Helpers;
+using Elastic.Transport;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace Elastic.Ingest.Elasticsearch.Tests;
+
+public class ServerReindexProgressTests
+{
+	private static JsonResponse MakeResponse(string json) => new(JsonNode.Parse(json)!);
+
+	[Test]
+	public void ReindexApiParsesDocumentFailures()
+	{
+		var response = MakeResponse("""
+		{
+			"completed": true,
+			"id": "reindex-abc",
+			"status": {
+				"total": 100,
+				"created": 97,
+				"updated": 0,
+				"deleted": 0,
+				"noops": 0,
+				"version_conflicts": 0
+			},
+			"running_time_in_nanos": 5000000000,
+			"response": {
+				"failures": [
+					{
+						"index": "my-index",
+						"id": "doc1",
+						"cause": { "type": "mapper_parsing_exception", "reason": "failed to parse field [age]" },
+						"status": 400
+					},
+					{
+						"index": "my-index",
+						"id": "doc2",
+						"cause": { "type": "mapper_parsing_exception", "reason": "failed to parse field [name]" },
+						"status": 400
+					},
+					{
+						"index": "other-index",
+						"id": "doc3",
+						"cause": { "type": "version_conflict_engine_exception", "reason": "version conflict" },
+						"status": 409
+					}
+				]
+			}
+		}
+		""");
+
+		var progress = ServerReindex.ParseProgress("task-1", response, isReindexApi: true);
+
+		progress.Failures.Should().HaveCount(3);
+		progress.Failures[0].Index.Should().Be("my-index");
+		progress.Failures[0].Id.Should().Be("doc1");
+		progress.Failures[0].Status.Should().Be(400);
+		progress.Failures[0].CauseType.Should().Be("mapper_parsing_exception");
+		progress.Failures[0].CauseReason.Should().Be("failed to parse field [age]");
+
+		progress.Failures[2].Index.Should().Be("other-index");
+		progress.Failures[2].Status.Should().Be(409);
+
+		progress.Error.Should().Contain("3 document(s) failed");
+		progress.Error.Should().Contain("failed to parse field [age]");
+	}
+
+	[Test]
+	public void TaskApiParsesDocumentFailures()
+	{
+		var response = MakeResponse("""
+		{
+			"completed": true,
+			"task": {
+				"status": {
+					"total": 50,
+					"created": 48,
+					"updated": 0,
+					"deleted": 0,
+					"noops": 0,
+					"version_conflicts": 0
+				},
+				"running_time_in_nanos": 2000000000
+			},
+			"response": {
+				"failures": [
+					{
+						"index": "legacy-index",
+						"id": "docA",
+						"cause": { "type": "strict_dynamic_mapping_exception", "reason": "mapping set to strict" },
+						"status": 400
+					}
+				]
+			}
+		}
+		""");
+
+		var progress = ServerReindex.ParseProgress("n:42", response, isReindexApi: false);
+
+		progress.Failures.Should().HaveCount(1);
+		progress.Failures[0].Index.Should().Be("legacy-index");
+		progress.Failures[0].Id.Should().Be("docA");
+		progress.Failures[0].CauseType.Should().Be("strict_dynamic_mapping_exception");
+		progress.Failures[0].CauseReason.Should().Be("mapping set to strict");
+
+		progress.Error.Should().Contain("1 document(s) failed");
+	}
+
+	[Test]
+	public void TaskLevelErrorTakesPrecedenceOverFailures()
+	{
+		var response = MakeResponse("""
+		{
+			"completed": true,
+			"error": { "reason": "task-level failure" },
+			"status": {
+				"total": 10,
+				"created": 0,
+				"updated": 0,
+				"deleted": 0,
+				"noops": 0,
+				"version_conflicts": 0
+			},
+			"running_time_in_nanos": 1000000000,
+			"response": {
+				"failures": [
+					{
+						"index": "idx",
+						"id": "d1",
+						"cause": { "type": "some_error", "reason": "per-doc error" },
+						"status": 400
+					}
+				]
+			}
+		}
+		""");
+
+		var progress = ServerReindex.ParseProgress("t:1", response, isReindexApi: true);
+
+		progress.Error.Should().Be("task-level failure");
+		progress.Failures.Should().HaveCount(1);
+	}
+
+	[Test]
+	public void NoFailuresProducesEmptyList()
+	{
+		var response = MakeResponse("""
+		{
+			"completed": true,
+			"status": {
+				"total": 10,
+				"created": 10,
+				"updated": 0,
+				"deleted": 0,
+				"noops": 0,
+				"version_conflicts": 0
+			},
+			"running_time_in_nanos": 500000000,
+			"response": {
+				"failures": []
+			}
+		}
+		""");
+
+		var progress = ServerReindex.ParseProgress("t:1", response, isReindexApi: true);
+
+		progress.Failures.Should().BeEmpty();
+		progress.Error.Should().BeNull();
+	}
+
+	[Test]
+	public void MissingFailuresFieldProducesEmptyList()
+	{
+		var response = MakeResponse("""
+		{
+			"completed": true,
+			"status": {
+				"total": 10,
+				"created": 10,
+				"updated": 0,
+				"deleted": 0,
+				"noops": 0,
+				"version_conflicts": 0
+			},
+			"running_time_in_nanos": 500000000,
+			"response": {}
+		}
+		""");
+
+		var progress = ServerReindex.ParseProgress("t:1", response, isReindexApi: true);
+
+		progress.Failures.Should().BeEmpty();
+		progress.Error.Should().BeNull();
+	}
+
+	[Test]
+	public void InProgressTaskDoesNotParseFailures()
+	{
+		var response = MakeResponse("""
+		{
+			"completed": false,
+			"status": {
+				"total": 100,
+				"created": 50,
+				"updated": 0,
+				"deleted": 0,
+				"noops": 0,
+				"version_conflicts": 0
+			},
+			"running_time_in_nanos": 3000000000
+		}
+		""");
+
+		var progress = ServerReindex.ParseProgress("t:1", response, isReindexApi: true);
+
+		progress.Failures.Should().BeEmpty();
+		progress.IsCompleted.Should().BeFalse();
+	}
+
+	[Test]
+	public void FailureWithMissingFieldsHandledGracefully()
+	{
+		var response = MakeResponse("""
+		{
+			"completed": true,
+			"status": {
+				"total": 5,
+				"created": 4,
+				"updated": 0,
+				"deleted": 0,
+				"noops": 0,
+				"version_conflicts": 0
+			},
+			"running_time_in_nanos": 100000000,
+			"response": {
+				"failures": [
+					{ "index": "idx" }
+				]
+			}
+		}
+		""");
+
+		var progress = ServerReindex.ParseProgress("t:1", response, isReindexApi: true);
+
+		progress.Failures.Should().HaveCount(1);
+		progress.Failures[0].Index.Should().Be("idx");
+		progress.Failures[0].Id.Should().BeNull();
+		progress.Failures[0].Status.Should().BeNull();
+		progress.Failures[0].CauseType.Should().BeNull();
+		progress.Failures[0].CauseReason.Should().BeNull();
+
+		progress.Error.Should().Contain("1 document(s) failed");
+		progress.Error.Should().Contain("unknown");
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #198

- `response.failures` in the Elasticsearch `_reindex`/task-completion payload is a JSON array of objects, but `Get<string>("response.failures")` was used to read it — which always returned `null`, silently dropping all per-document bulk failures.
- Added `ReindexFailure` record (`Index`, `Id`, `Status`, `CauseType`, `CauseReason`) and `IReadOnlyList<ReindexFailure> Failures` property on `ReindexProgress` so callers can inspect the actual cause of each failed document.
- When per-document failures exist and no task-level error is present, `Error` is now populated with a summary (e.g. `"3 document(s) failed: failed to parse field [age]"`) for backward compatibility with callers checking `Error != null`.
- Added a public `ParseProgress(string, JsonResponse, bool)` overload for external consumers.

## Test plan

- [x] 7 new unit tests covering: reindex API shape, task API (legacy) shape, task-level error precedence, empty/missing failures, in-progress tasks, and failures with missing optional fields
- [x] All 132 existing tests pass

Made with [Cursor](https://cursor.com)