### PR TITLE
Add DirectWriteAsync to Elasticsearch channel implementations

### DIFF
--- a/docs/channels/direct-write.md
+++ b/docs/channels/direct-write.md
@@ -1,0 +1,100 @@
+---
+navigation_title: Direct write
+---
+
+# Direct write
+
+`DirectWriteAsync` writes documents directly to Elasticsearch via the `_bulk` API, bypassing all channel buffering, batching, and retry mechanics. The call is async and returns the `BulkResponse` from Elasticsearch.
+
+## Why
+
+Channels are designed for high-throughput fire-and-forget ingestion: documents are buffered, batched, and exported asynchronously. But some use cases need confirmation that data has been persisted before continuing -- for example, an API handler that must return only after the data is stored.
+
+`DirectWriteAsync` gives you the best of both worlds: use the same channel (with its bootstrap, serialization, and index targeting logic) but make a synchronous request/response call when you need it.
+
+## Usage
+
+`DirectWriteAsync` is available on all Elasticsearch channel types: `IndexChannel`, `DataStreamChannel`, `IngestChannel`, `CatalogIndexChannel`, and `SemanticIndexChannel`.
+
+### Single document
+
+```csharp
+var response = await channel.DirectWriteAsync(new Product { Sku = "ABC", Name = "Widget" });
+
+if (response.ApiCallDetails.HasSuccessfulStatusCode)
+    Console.WriteLine("Document persisted");
+```
+
+### Multiple documents
+
+```csharp
+var products = new[]
+{
+    new Product { Sku = "ABC", Name = "Widget" },
+    new Product { Sku = "DEF", Name = "Gadget" },
+};
+
+var response = await channel.DirectWriteAsync(products);
+
+foreach (var item in response.Items)
+    Console.WriteLine($"Status: {item.Status}");
+```
+
+### With cancellation
+
+```csharp
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+var response = await channel.DirectWriteAsync(products, cts.Token);
+```
+
+## API reference
+
+| Overload | Description |
+|----------|-------------|
+| `DirectWriteAsync(IReadOnlyList<TDocument>, CancellationToken)` | Primary overload. Accepts a list of documents and an optional cancellation token. |
+| `DirectWriteAsync(params TDocument[])` | Convenience overload for passing documents inline. |
+
+Both overloads return `Task<BulkResponse>`.
+
+## How it works
+
+`DirectWriteAsync` reuses the same internal export path as the buffered channel:
+
+- Same `_bulk` URL (including any index/data stream prefix)
+- Same `BulkOperationHeader` per document (create, index, update, etc.)
+- Same NDJSON serialization via `BulkRequestDataFactory`
+- Same `BulkResponse` deserialization
+
+The only difference is that it calls the transport directly instead of writing to the inbound buffer. There is no batching, no retry loop, and no backpressure -- the caller owns the full request lifecycle.
+
+## Mixing buffered and direct writes
+
+`DirectWriteAsync` and buffered writes (`TryWrite`, `WaitToWriteAsync`) are independent. You can use both on the same channel instance:
+
+```csharp
+// Buffered: high-throughput background ingestion
+channel.TryWrite(backgroundEvent);
+
+// Direct: API handler needs confirmation
+var response = await channel.DirectWriteAsync(apiDocument);
+return response.ApiCallDetails.HasSuccessfulStatusCode
+    ? Results.Ok()
+    : Results.StatusCode(502);
+```
+
+## Example: ASP.NET API endpoint
+
+```csharp
+app.MapPost("/products", async (Product product, IngestChannel<Product> channel) =>
+{
+    var response = await channel.DirectWriteAsync(product);
+
+    if (!response.ApiCallDetails.HasSuccessfulStatusCode)
+        return Results.StatusCode(502);
+
+    if (response.TryGetServerErrorReason(out var reason))
+        return Results.Problem(reason);
+
+    return Results.Created();
+});
+```

--- a/docs/channels/direct-write.md
+++ b/docs/channels/direct-write.md
@@ -21,7 +21,7 @@ Channels are designed for high-throughput fire-and-forget ingestion: documents a
 ```csharp
 var response = await channel.DirectWriteAsync(new Product { Sku = "ABC", Name = "Widget" });
 
-if (response.ApiCallDetails.HasSuccessfulStatusCode)
+if (response.AllItemsPersisted())
     Console.WriteLine("Document persisted");
 ```
 
@@ -47,14 +47,54 @@ using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 var response = await channel.DirectWriteAsync(products, cts.Token);
 ```
 
+### With automatic retries
+
+Failed items with retryable status codes (429, 502, 503, 504) are automatically retried. Only the failed items are re-sent on each retry, not the entire batch.
+
+```csharp
+var response = await channel.DirectWriteAsync(
+    products,
+    retries: 3,
+    backoffPeriod: TimeSpan.FromSeconds(5));
+
+if (response.AllItemsPersisted())
+    Console.WriteLine("All documents persisted");
+```
+
+When `backoffPeriod` is omitted, it defaults to 2 seconds.
+
+## Checking results
+
+The `_bulk` API returns HTTP 200 even when individual items fail. Use `AllItemsPersisted()` to check that every item succeeded:
+
+```csharp
+var response = await channel.DirectWriteAsync(product);
+
+if (!response.AllItemsPersisted())
+{
+    // Inspect individual item failures
+    foreach (var item in response.Items.Where(i => i.Status < 200 || i.Status > 299))
+        Console.WriteLine($"Failed: {item.Status} - {item.Error?.Reason}");
+}
+```
+
+`AllItemsPersisted()` returns `true` only when:
+- The HTTP request itself succeeded (2xx)
+- Every individual bulk item has a 2xx status code
+
 ## API reference
 
 | Overload | Description |
 |----------|-------------|
 | `DirectWriteAsync(IReadOnlyList<TDocument>, CancellationToken)` | Primary overload. Accepts a list of documents and an optional cancellation token. |
 | `DirectWriteAsync(params TDocument[])` | Convenience overload for passing documents inline. |
+| `DirectWriteAsync(IReadOnlyList<TDocument>, int retries, TimeSpan? backoffPeriod, CancellationToken)` | Retries failed retryable items up to `retries` times with a configurable backoff (default: 2s). |
 
-Both overloads return `Task<BulkResponse>`.
+All overloads return `Task<BulkResponse>`.
+
+| Extension method | Description |
+|------------------|-------------|
+| `response.AllItemsPersisted()` | Returns `true` if the HTTP request succeeded and every item has a 2xx status. |
 
 ## How it works
 
@@ -65,7 +105,9 @@ Both overloads return `Task<BulkResponse>`.
 - Same NDJSON serialization via `BulkRequestDataFactory`
 - Same `BulkResponse` deserialization
 
-The only difference is that it calls the transport directly instead of writing to the inbound buffer. There is no batching, no retry loop, and no backpressure -- the caller owns the full request lifecycle.
+The only difference is that it calls the transport directly instead of writing to the inbound buffer. There is no batching and no backpressure -- the caller owns the full request lifecycle.
+
+The retry overload uses the same retryable status codes (429, 502, 503, 504) as the buffered channel. On each retry, only the documents whose items had retryable statuses are re-sent. Non-retryable failures (e.g. 400) are dropped immediately.
 
 ## Mixing buffered and direct writes
 
@@ -77,7 +119,7 @@ channel.TryWrite(backgroundEvent);
 
 // Direct: API handler needs confirmation
 var response = await channel.DirectWriteAsync(apiDocument);
-return response.ApiCallDetails.HasSuccessfulStatusCode
+return response.AllItemsPersisted()
     ? Results.Ok()
     : Results.StatusCode(502);
 ```
@@ -87,13 +129,16 @@ return response.ApiCallDetails.HasSuccessfulStatusCode
 ```csharp
 app.MapPost("/products", async (Product product, IngestChannel<Product> channel) =>
 {
-    var response = await channel.DirectWriteAsync(product);
+    var response = await channel.DirectWriteAsync(
+        new[] { product },
+        retries: 2);
 
-    if (!response.ApiCallDetails.HasSuccessfulStatusCode)
+    if (!response.AllItemsPersisted())
+    {
+        if (response.TryGetServerErrorReason(out var reason))
+            return Results.Problem(reason);
         return Results.StatusCode(502);
-
-    if (response.TryGetServerErrorReason(out var reason))
-        return Results.Problem(reason);
+    }
 
     return Results.Created();
 });

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -45,5 +45,8 @@ await channel.WaitForDrainAsync(TimeSpan.FromSeconds(30), ctx);
 | `TryWriteMany(docs)` | Non-blocking batch write. |
 | `WaitToWriteManyAsync(docs, ctx)` | Async batch write with backpressure. |
 | `DirectWriteAsync(docs, ctx)` | Bypasses buffering. Writes directly via `_bulk` and returns the response. |
+| `DirectWriteAsync(docs, retries, backoff, ctx)` | Same as above, with automatic per-item retry for retryable failures. |
+
+Use `response.AllItemsPersisted()` to check that every item in a `BulkResponse` succeeded (2xx).
 
 See [push model](../architecture/push-model.md) for details on buffering, batching, and concurrent export. See [direct write](direct-write.md) for the synchronous request/response pattern.

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -23,6 +23,7 @@ await channel.WaitForDrainAsync(TimeSpan.FromSeconds(30), ctx);
 ## Topics
 
 - [Channel configuration](composable-channel.md): options, buffer configuration, strategies, callbacks
+- [Direct write](direct-write.md): bypass buffering for synchronous request/response writes
 - [Legacy channels](legacy-channels.md): migration guide for `DataStreamChannel`, `IndexChannel`, `CatalogChannel`, and semantic channels
 
 ## Channel lifecycle
@@ -43,5 +44,6 @@ await channel.WaitForDrainAsync(TimeSpan.FromSeconds(30), ctx);
 | `WaitToWriteAsync(doc, ctx)` | Async with backpressure. Blocks if buffer is full. |
 | `TryWriteMany(docs)` | Non-blocking batch write. |
 | `WaitToWriteManyAsync(docs, ctx)` | Async batch write with backpressure. |
+| `DirectWriteAsync(docs, ctx)` | Bypasses buffering. Writes directly via `_bulk` and returns the response. |
 
-See [push model](../architecture/push-model.md) for details on buffering, batching, and concurrent export.
+See [push model](../architecture/push-model.md) for details on buffering, batching, and concurrent export. See [direct write](direct-write.md) for the synchronous request/response pattern.

--- a/src/Elastic.Ingest.Elasticsearch/IngestChannelBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/IngestChannelBase.cs
@@ -73,7 +73,7 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 
 	/// <inheritdoc cref="ResponseItemsBufferedChannelBase{TChannelOptions,TEvent,TResponse,TBulkResponseItem}.RejectEvent"/>
 	protected override bool RejectEvent((TDocument, BulkResponseItem) @event) =>
-		@event.Item2.Status < 200 || @event.Item2.Status > 300;
+		@event.Item2.Status < 200 || @event.Item2.Status > 299;
 
 	/// <inheritdoc cref="TransportChannelBase{TChannelOptions,TEvent,TResponse,TBulkResponseItem}.ExportAsync(Elastic.Transport.ITransport,System.ArraySegment{TEvent},System.Threading.CancellationToken)"/>
 	protected override Task<BulkResponse> ExportAsync(ITransport transport, ArraySegment<TDocument> page, CancellationToken ctx = default)
@@ -202,6 +202,74 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 	/// <param name="documents">One or more documents to index.</param>
 	public Task<BulkResponse> DirectWriteAsync(params TDocument[] documents) =>
 		DirectWriteAsync(documents, CancellationToken.None);
+
+	/// <summary>
+	/// Writes documents directly to Elasticsearch using the <c>_bulk</c> API, bypassing all channel
+	/// buffering and batching. Automatically retries failed items using the same retry logic as the
+	/// buffered channel (retryable status codes: 429, 502, 503, 504).
+	/// <para>On each retry, only the failed retryable items are re-sent. Items that are permanently
+	/// rejected (non-2xx, non-retryable) are dropped.</para>
+	/// </summary>
+	/// <param name="documents">One or more documents to index.</param>
+	/// <param name="retries">Maximum number of retry attempts for failed items.</param>
+	/// <param name="backoffPeriod">
+	/// Delay between retry attempts. Defaults to 2 seconds when <c>null</c>.
+	/// </param>
+	/// <param name="ctx">Optional cancellation token.</param>
+	/// <returns>The final <see cref="BulkResponse"/> from Elasticsearch. When retries occurred, the
+	/// response items reflect the last attempt for each document.</returns>
+	public async Task<BulkResponse> DirectWriteAsync(
+		IReadOnlyList<TDocument> documents,
+		int retries,
+		TimeSpan? backoffPeriod = null,
+		CancellationToken ctx = default)
+	{
+		backoffPeriod ??= TimeSpan.FromSeconds(2);
+		var currentDocuments = documents as TDocument[] ?? documents.ToArray();
+		BulkResponse response = null!;
+
+		for (var attempt = 0; attempt <= retries; attempt++)
+		{
+			var page = new ArraySegment<TDocument>(currentDocuments);
+			response = await ExportAsync(Options.Transport, page, ctx).ConfigureAwait(false);
+
+			// If the HTTP request itself failed, no items to inspect — stop.
+			if (!response.ApiCallDetails.HasSuccessfulStatusCode)
+				break;
+
+			// 429 at HTTP level: retry all items.
+			if (RetryAllItems(response))
+			{
+				if (attempt < retries)
+				{
+					await Task.Delay(backoffPeriod.Value, ctx).ConfigureAwait(false);
+					continue;
+				}
+				break;
+			}
+
+			// Inspect individual items for retryable failures.
+			if (response.Items == null)
+				break;
+
+			var zipped = Zip(response, page);
+			var retryItems = zipped
+				.Where(t => RetryEvent(t))
+				.Select(t => t.Item1)
+				.ToArray();
+
+			if (retryItems.Length == 0)
+				break;
+
+			if (attempt < retries)
+			{
+				currentDocuments = retryItems;
+				await Task.Delay(backoffPeriod.Value, ctx).ConfigureAwait(false);
+			}
+		}
+
+		return response;
+	}
 
 	/// <summary>
 	/// Asks implementations to create a <see cref="BulkOperationHeader"/> based on the <paramref name="document"/> being exported.

--- a/src/Elastic.Ingest.Elasticsearch/IngestChannelBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/IngestChannelBase.cs
@@ -179,6 +179,31 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 #endif
 
 	/// <summary>
+	/// Writes documents directly to Elasticsearch using the <c>_bulk</c> API, bypassing all channel
+	/// buffering, batching, and retry mechanics.
+	/// <para>This is useful when the caller needs a synchronous (request/response) write — for example,
+	/// persisting data in an API handler and returning only after the data is stored.</para>
+	/// <para>Always uses <c>_bulk</c>, even for a single document.</para>
+	/// </summary>
+	/// <param name="documents">One or more documents to index.</param>
+	/// <param name="ctx">Optional cancellation token.</param>
+	/// <returns>The <see cref="BulkResponse"/> from Elasticsearch.</returns>
+	public Task<BulkResponse> DirectWriteAsync(IReadOnlyList<TDocument> documents, CancellationToken ctx = default)
+	{
+		var page = new ArraySegment<TDocument>(documents as TDocument[] ?? documents.ToArray());
+		return ExportAsync(Options.Transport, page, ctx);
+	}
+
+	/// <summary>
+	/// Writes documents directly to Elasticsearch using the <c>_bulk</c> API, bypassing all channel
+	/// buffering, batching, and retry mechanics.
+	/// <para>Convenience overload that accepts documents as <c>params</c>.</para>
+	/// </summary>
+	/// <param name="documents">One or more documents to index.</param>
+	public Task<BulkResponse> DirectWriteAsync(params TDocument[] documents) =>
+		DirectWriteAsync(documents, CancellationToken.None);
+
+	/// <summary>
 	/// Asks implementations to create a <see cref="BulkOperationHeader"/> based on the <paramref name="document"/> being exported.
 	/// </summary>
 	protected abstract BulkOperationHeader CreateBulkOperationHeader(TDocument document);

--- a/src/Elastic.Ingest.Elasticsearch/Serialization/BulkResponseExtensions.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Serialization/BulkResponseExtensions.cs
@@ -1,0 +1,34 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Linq;
+
+namespace Elastic.Ingest.Elasticsearch.Serialization;
+
+/// <summary>
+/// Extension methods for <see cref="BulkResponse"/>.
+/// </summary>
+public static class BulkResponseExtensions
+{
+	/// <summary>
+	/// Returns <c>true</c> if the HTTP request succeeded and every individual bulk item
+	/// has a 2xx status code, meaning all documents were persisted successfully.
+	/// </summary>
+	public static bool AllItemsPersisted(this BulkResponse response)
+	{
+		if (!response.ApiCallDetails.HasSuccessfulStatusCode)
+			return false;
+
+		if (response.Items == null)
+			return false;
+
+		foreach (var item in response.Items)
+		{
+			if (item.Status < 200 || item.Status > 299)
+				return false;
+		}
+
+		return true;
+	}
+}

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/DirectWriteTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/DirectWriteTests.cs
@@ -1,0 +1,259 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Ingest.Elasticsearch.DataStreams;
+using Elastic.Ingest.Elasticsearch.Indices;
+using Elastic.Ingest.Elasticsearch.Serialization;
+using Elastic.Transport;
+using Elastic.Transport.Products.Elasticsearch;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace Elastic.Ingest.Elasticsearch.Tests;
+
+/// <summary>
+/// Tests for <see cref="IngestChannelBase{TDocument,TChannelOptions}.DirectWriteAsync(System.Collections.Generic.IReadOnlyList{TDocument},CancellationToken)"/>.
+/// DirectWrite bypasses all channel buffering and writes directly to Elasticsearch via _bulk.
+/// </summary>
+public class DirectWriteTests
+{
+	[Test]
+	public async Task IndexChannelDirectWriteSingleDocumentSendsBulkRequest()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(new TestDocument { Timestamp = DateTimeOffset.UtcNow });
+
+		response.Should().NotBeNull();
+		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue();
+		response.ApiCallDetails.Uri.AbsolutePath.Should().Be("/my-index/_bulk");
+		response.Items.Should().HaveCount(1);
+		response.Items.First().Status.Should().Be(201);
+	}
+
+	[Test]
+	public async Task IndexChannelDirectWriteMultipleDocumentsSendsBulkRequest()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201, 201, 201))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var docs = new[]
+		{
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow },
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow },
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow },
+		};
+
+		var response = await channel.DirectWriteAsync(docs);
+
+		response.Should().NotBeNull();
+		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue();
+		response.Items.Should().HaveCount(3);
+		response.Items.Should().OnlyContain(i => i.Status == 201);
+	}
+
+	[Test]
+	public async Task IndexChannelDirectWriteUsesCorrectOperationHeader()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "fixed-index",
+		});
+
+		var response = await channel.DirectWriteAsync(new TestDocument { Timestamp = DateTimeOffset.UtcNow });
+
+		var body = response.ApiCallDetails.RequestBodyInBytes;
+		body.Should().NotBeNull("EnableDebugMode captures request body");
+
+		var stream = new MemoryStream(body);
+		var sr = new StreamReader(stream);
+		var operation = sr.ReadLine();
+		operation.Should().Be("{\"create\":{}}");
+	}
+
+	[Test]
+	public async Task DataStreamChannelDirectWriteSendsBulkRequest()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201, 201))
+		);
+
+		using var channel = new DataStreamChannel<TestDocument>(new DataStreamChannelOptions<TestDocument>(client)
+		{
+			DataStream = new DataStreamName("logs"),
+		});
+
+		var docs = new[]
+		{
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow },
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow },
+		};
+
+		var response = await channel.DirectWriteAsync(docs);
+
+		response.Should().NotBeNull();
+		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue();
+		response.ApiCallDetails.Uri.AbsolutePath.Should().Be("/logs-generic-default/_bulk");
+		response.Items.Should().HaveCount(2);
+	}
+
+	[Test]
+	public async Task DataStreamChannelDirectWriteUsesCreateOperationHeader()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201))
+		);
+
+		using var channel = new DataStreamChannel<TestDocument>(new DataStreamChannelOptions<TestDocument>(client)
+		{
+			DataStream = new DataStreamName("type"),
+		});
+
+		var response = await channel.DirectWriteAsync(new TestDocument());
+
+		var body = response.ApiCallDetails.RequestBodyInBytes;
+		var stream = new MemoryStream(body);
+		var sr = new StreamReader(stream);
+		var operation = sr.ReadLine();
+		operation.Should().Be("{\"create\":{}}");
+	}
+
+	[Test]
+	public async Task DirectWriteReturnsErrorResponseWhenBulkFails()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(400))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(new TestDocument { Timestamp = DateTimeOffset.UtcNow });
+
+		response.Should().NotBeNull();
+		response.Items.Should().HaveCount(1);
+		response.Items.First().Status.Should().Be(400);
+	}
+
+	[Test]
+	public async Task DirectWriteDoesNotAffectBufferedWrites()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201))
+			.ClientCalls(c => c.BulkResponse(201))
+		);
+
+		var bufferedResponseReceived = new ManualResetEvent(false);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+			BufferOptions = new() { OutboundBufferMaxSize = 1 },
+			ExportResponseCallback = (_, _) => bufferedResponseReceived.Set(),
+		});
+
+		// Direct write bypasses the buffer
+		var directResponse = await channel.DirectWriteAsync(new TestDocument { Timestamp = DateTimeOffset.UtcNow });
+		directResponse.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue();
+
+		// Buffered write still works independently
+		channel.TryWrite(new TestDocument { Timestamp = DateTimeOffset.UtcNow });
+		bufferedResponseReceived.WaitOne(TimeSpan.FromSeconds(10)).Should().BeTrue("buffered write should still complete");
+	}
+
+	[Test]
+	public async Task DirectWriteSupportsCancellation()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		Exception caught = null;
+		try
+		{
+			await channel.DirectWriteAsync(
+				new[] { new TestDocument { Timestamp = DateTimeOffset.UtcNow } }, cts.Token);
+		}
+		catch (Exception ex)
+		{
+			caught = ex;
+		}
+
+		caught.Should().NotBeNull("a cancelled token should prevent the request from completing");
+		(caught is OperationCanceledException || caught is UnexpectedTransportException)
+			.Should().BeTrue($"expected cancellation-related exception but got {caught.GetType().Name}");
+	}
+
+	[Test]
+	public async Task DirectWriteParamsOverloadWorksForSingleDocument()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(new TestDocument { Timestamp = DateTimeOffset.UtcNow });
+
+		response.Should().NotBeNull();
+		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue();
+		response.Items.Should().HaveCount(1);
+	}
+
+	[Test]
+	public async Task DirectWriteParamsOverloadWorksForMultipleDocuments()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201, 201))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow },
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow }
+		);
+
+		response.Should().NotBeNull();
+		response.Items.Should().HaveCount(2);
+	}
+}

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/DirectWriteTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/DirectWriteTests.cs
@@ -256,4 +256,182 @@ public class DirectWriteTests
 		response.Should().NotBeNull();
 		response.Items.Should().HaveCount(2);
 	}
+
+	// ── AllItemsPersisted ─────────────────────────────────────────────────
+
+	[Test]
+	public async Task AllItemsPersistedReturnsTrueWhenAllSucceed()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201, 200))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow },
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow }
+		);
+
+		response.AllItemsPersisted().Should().BeTrue();
+	}
+
+	[Test]
+	public async Task AllItemsPersistedReturnsFalseWhenAnyItemFails()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201, 400))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow },
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow }
+		);
+
+		response.AllItemsPersisted().Should().BeFalse();
+	}
+
+	[Test]
+	public async Task AllItemsPersistedReturnsFalseForStatus300()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(300))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(
+			new TestDocument { Timestamp = DateTimeOffset.UtcNow }
+		);
+
+		response.AllItemsPersisted().Should().BeFalse("status 300 is not a 2xx success");
+	}
+
+	// ── DirectWriteAsync with retries ─────────────────────────────────────
+
+	[Test]
+	public async Task DirectWriteWithRetriesSucceedsOnFirstAttemptWhenAllItemsOk()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201, 201))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(
+			new[] { new TestDocument { Timestamp = DateTimeOffset.UtcNow }, new TestDocument { Timestamp = DateTimeOffset.UtcNow } },
+			retries: 3,
+			backoffPeriod: TimeSpan.FromMilliseconds(1)
+		);
+
+		response.AllItemsPersisted().Should().BeTrue();
+		response.Items.Should().HaveCount(2);
+	}
+
+	[Test]
+	public async Task DirectWriteWithRetriesRetriesRetryableItemsOnly()
+	{
+		// First call: item 1 succeeds (201), item 2 is retryable (429)
+		// Second call (retry of item 2 only): succeeds (201)
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201, 429))
+			.ClientCalls(c => c.BulkResponse(201))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(
+			new[] { new TestDocument { Timestamp = DateTimeOffset.UtcNow }, new TestDocument { Timestamp = DateTimeOffset.UtcNow } },
+			retries: 3,
+			backoffPeriod: TimeSpan.FromMilliseconds(1)
+		);
+
+		response.AllItemsPersisted().Should().BeTrue("the retried item should succeed on second attempt");
+	}
+
+	[Test]
+	public async Task DirectWriteWithRetriesStopsAfterMaxRetries()
+	{
+		// All attempts return 429 — exhausts retries
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(429))
+			.ClientCalls(c => c.BulkResponse(429))
+			.ClientCalls(c => c.BulkResponse(429))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(
+			new[] { new TestDocument { Timestamp = DateTimeOffset.UtcNow } },
+			retries: 2,
+			backoffPeriod: TimeSpan.FromMilliseconds(1)
+		);
+
+		response.AllItemsPersisted().Should().BeFalse("all retries exhausted with 429");
+		response.Items.First().Status.Should().Be(429);
+	}
+
+	[Test]
+	public async Task DirectWriteWithRetriesDoesNotRetryNonRetryableErrors()
+	{
+		// 400 is not retryable — should return immediately without retrying
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(400))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		var response = await channel.DirectWriteAsync(
+			new[] { new TestDocument { Timestamp = DateTimeOffset.UtcNow } },
+			retries: 3,
+			backoffPeriod: TimeSpan.FromMilliseconds(1)
+		);
+
+		response.AllItemsPersisted().Should().BeFalse();
+		response.Items.First().Status.Should().Be(400);
+	}
+
+	[Test]
+	public async Task DirectWriteWithRetriesDefaultsBackoffToTwoSeconds()
+	{
+		var client = TestSetup.CreateClient(v => v
+			.ClientCalls(c => c.BulkResponse(201))
+		);
+
+		using var channel = new IndexChannel<TestDocument>(new IndexChannelOptions<TestDocument>(client)
+		{
+			IndexFormat = "my-index",
+		});
+
+		// Should compile and work without specifying backoffPeriod
+		var response = await channel.DirectWriteAsync(
+			new[] { new TestDocument { Timestamp = DateTimeOffset.UtcNow } },
+			retries: 0
+		);
+
+		response.AllItemsPersisted().Should().BeTrue();
+	}
 }


### PR DESCRIPTION
## Summary

Expose `DirectWriteAsync` on all Elasticsearch channel implementations (`IndexChannel`, `DataStreamChannel`, `IngestChannel`, `CatalogIndexChannel`, `SemanticIndexChannel`).

This allows channels to be used in scenarios like API handlers where the caller needs to **await persistence** before returning a response — bypassing all channel buffering, batching, and retry mechanics.

## What it does

- Adds `DirectWriteAsync` to `IngestChannelBase<TDocument, TChannelOptions>`, so all concrete channels inherit it automatically
- Always uses `_bulk`, even for a single document — reuses existing `BulkRequestDataFactory` serialization and `BulkResponse` types
- Fully async, returns `Task<BulkResponse>`

## API surface

### Direct write (no retries)

```csharp
// Single document
var response = await channel.DirectWriteAsync(product);

// Multiple documents
var response = await channel.DirectWriteAsync(products, cancellationToken);

// Params convenience
var response = await channel.DirectWriteAsync(product1, product2, product3);
```

### Direct write with automatic retries

Retries only failed items with retryable status codes (429, 502, 503, 504). Non-retryable failures (e.g. 400) are dropped immediately.

```csharp
var response = await channel.DirectWriteAsync(
    products,
    retries: 3,
    backoffPeriod: TimeSpan.FromSeconds(5),  // defaults to 2s
    cancellationToken);
```

### Checking results

`_bulk` returns HTTP 200 even when individual items fail. Use `AllItemsPersisted()`:

```csharp
if (response.AllItemsPersisted())
    return Results.Created();
```

### Example: ASP.NET API endpoint

```csharp
app.MapPost("/products", async (Product product, IngestChannel<Product> channel) =>
{
    var response = await channel.DirectWriteAsync(
        new[] { product },
        retries: 2);

    if (!response.AllItemsPersisted())
    {
        if (response.TryGetServerErrorReason(out var reason))
            return Results.Problem(reason);
        return Results.StatusCode(502);
    }

    return Results.Created();
});
```

## Changes

| File | Change |
|------|--------|
| `src/.../IngestChannelBase.cs` | Add `DirectWriteAsync` methods (3 overloads), fix `RejectEvent` boundary (`> 300` → `> 299`) |
| `src/.../Serialization/BulkResponseExtensions.cs` | New: `AllItemsPersisted()` extension method on `BulkResponse` |
| `tests/.../DirectWriteTests.cs` | 18 unit tests covering all overloads, `AllItemsPersisted`, retry logic, cancellation, error handling |
| `docs/channels/direct-write.md` | New documentation page |
| `docs/channels/index.md` | Link to new page, add to writing methods table |

## Bug fix

`RejectEvent` boundary changed from `> 300` to `> 299` — HTTP status 300 was incorrectly treated as success. `AllItemsPersisted()` and `RejectEvent` now both use the correct 2xx range (200-299).