### PR TITLE
Add version-aware bootstrap guards (MappingVersion)

### DIFF
--- a/docs/strategies/bootstrap.md
+++ b/docs/strategies/bootstrap.md
@@ -124,3 +124,84 @@ new DefaultBootstrapStrategy(
 ## Hash-based short-circuit
 
 `IndexTemplateStep` and `DataStreamTemplateStep` check if the existing template's `_meta.hash` matches the current channel hash. If it matches, the template PUT is skipped, avoiding unnecessary API calls.
+
+## Version-aware bootstrap guards
+
+By default, bootstrap uses **hash-only** comparison: if the template hash matches, skip; if it differs, re-bootstrap. This works well for single-version deployments, but can cause problems during rolling upgrades.
+
+### The problem
+
+Consider a pool of pods running behind a load balancer. You deploy version N, which upgrades the index template with new mappings. A pod still on version N-1 restarts, computes a different hash (its mappings are older), and re-bootstraps — **overwriting version N's templates** with version N-1's mappings.
+
+### The solution: `MappingVersion`
+
+Set `MappingVersion` on your index or data stream attribute. When configured, the version is stored in `_meta.mapping_version` on all templates. During bootstrap, if the remote template was deployed by a **newer** version, bootstrap is skipped — the older pod refuses to downgrade.
+
+:::{note}
+`MappingVersion` is **opt-in**. When omitted, behavior is unchanged — pure hash-based comparison.
+
+This is separate from `_meta.assembly_version`, which always reflects the library version and is purely informational.
+:::
+
+### Usage
+
+There are three modes:
+
+**Default — hash-only (no version guard):**
+
+```csharp
+[Index<Product>(Name = "products")]
+```
+
+No `MappingVersion` is set. Templates are updated whenever the hash changes, regardless of which version is deploying. This is the existing behavior.
+
+**Library or application version:**
+
+```csharp
+[Index<Product>(Name = "products", MappingVersion = "1.0.0")]
+```
+
+Set `MappingVersion` to a [semver](https://semver.org/) string. During bootstrap, if the cluster already has a template with a higher `mapping_version`, the bootstrap is skipped. Bump the version when you release mapping changes.
+
+**Data stream example:**
+
+```csharp
+[DataStream<LogEntry>(Type = "logs", Dataset = "myapp", MappingVersion = "2.1.0")]
+```
+
+### Decision logic
+
+When `MappingVersion` is set, bootstrap evaluates in this order:
+
+1. **Version guard**: If the remote template has a `mapping_version` that is **greater** than the local one (compared as `System.Version`), **skip** bootstrap. The remote was deployed by a newer release.
+2. **Hash check**: If the hashes match, **skip**. Nothing changed.
+3. Otherwise, **proceed** with bootstrap.
+
+When `MappingVersion` is *not* set (null), only step 2 applies — the original hash-only behavior.
+
+### Programmatic usage
+
+When not using attributes, set `MappingVersion` directly on `ElasticsearchTypeContext`:
+
+```csharp
+var context = new ElasticsearchTypeContext(
+    getSettingsJson, getMappingsJson, getIndexJson,
+    hash, settingsHash, mappingsHash,
+    indexStrategy, searchStrategy,
+    EntityTarget.Index,
+    MappingVersion: "1.2.0"
+);
+```
+
+Or set it on `BootstrapContext` when using custom bootstrap strategies:
+
+```csharp
+var bootstrapContext = new BootstrapContext
+{
+    Transport = transport,
+    BootstrapMethod = BootstrapMethod.Failure,
+    TemplateName = "my-template",
+    TemplateWildcard = "my-index-*",
+    MappingVersion = "1.2.0"
+};
+```

--- a/docs/strategies/bootstrap.md
+++ b/docs/strategies/bootstrap.md
@@ -153,7 +153,7 @@ This is separate from `_meta.assembly_version`, which always reflects the librar
 
 No `MappingVersion` is set. Templates are updated whenever the hash changes, regardless of which version is deploying. This is the existing behavior.
 
-**Hardcoded version (via attribute):**
+**Explicit version (via attribute):**
 
 ```csharp
 [Index<Product>(Name = "products", MappingVersion = "1.0.0")]
@@ -163,35 +163,30 @@ No `MappingVersion` is set. Templates are updated whenever the hash changes, reg
 
 Set `MappingVersion` to a version string parseable by `System.Version` (e.g. `"1.0.0"`, `"2.3.1"`). Bump it when you release mapping changes.
 
-:::{note}
-Attribute properties must be compile-time constants. To use a runtime value such as your application's assembly version, use the programmatic approach below instead.
-:::
+**Application assembly version (via attribute):**
 
-**Application assembly version (programmatic):**
-
-Since attributes require compile-time constants, use `ElasticsearchTypeContext.WithMappingVersion()` or set `MappingVersion` on `BootstrapContext` directly to use your application's assembly version at runtime:
+Use `MappingVersionFromAssembly` to automatically resolve the version from your application's assembly at runtime. The source generator emits code that reads `typeof(YourMappingContext).Assembly.GetName().Version` — so the version tracks your project's `<Version>` or `<AssemblyVersion>` MSBuild property:
 
 ```csharp
-using System.Reflection;
+[Index<Product>(Name = "products", MappingVersionFromAssembly = true)]
 
-// Get your app's version at runtime
-var appVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.0.0";
-
-// Option 1: override the type context from your source-generated resolver
-var context = MyMappingContext.Product.Context with { MappingVersion = appVersion };
-var options = new IngestChannelOptions<Product>(transport, context);
-
-// Option 2: set it on ElasticsearchTypeContext directly
-var context = new ElasticsearchTypeContext(
-    getSettingsJson, getMappingsJson, getIndexJson,
-    hash, settingsHash, mappingsHash,
-    indexStrategy, searchStrategy,
-    EntityTarget.Index,
-    MappingVersion: appVersion
-);
+[DataStream<LogEntry>(Type = "logs", Dataset = "myapp", MappingVersionFromAssembly = true)]
 ```
 
-**Custom strategies (BootstrapContext):**
+When both `MappingVersionFromAssembly` and `MappingVersion` are set, `MappingVersionFromAssembly` takes precedence.
+
+**Programmatic usage:**
+
+When not using attributes, set `MappingVersion` directly on `ElasticsearchTypeContext` or override a source-generated context:
+
+```csharp
+// Override a source-generated context with a runtime version
+var appVersion = typeof(MyMappingContext).Assembly.GetName().Version?.ToString();
+var context = MyMappingContext.Product.Context with { MappingVersion = appVersion };
+var options = new IngestChannelOptions<Product>(transport, context);
+```
+
+Or set it on `BootstrapContext` when using custom bootstrap strategies:
 
 ```csharp
 var bootstrapContext = new BootstrapContext

--- a/docs/strategies/bootstrap.md
+++ b/docs/strategies/bootstrap.md
@@ -145,8 +145,6 @@ This is separate from `_meta.assembly_version`, which always reflects the librar
 
 ### Usage
 
-There are three modes:
-
 **Default — hash-only (no version guard):**
 
 ```csharp
@@ -155,45 +153,45 @@ There are three modes:
 
 No `MappingVersion` is set. Templates are updated whenever the hash changes, regardless of which version is deploying. This is the existing behavior.
 
-**Library or application version:**
+**Hardcoded version (via attribute):**
 
 ```csharp
 [Index<Product>(Name = "products", MappingVersion = "1.0.0")]
-```
 
-Set `MappingVersion` to a [semver](https://semver.org/) string. During bootstrap, if the cluster already has a template with a higher `mapping_version`, the bootstrap is skipped. Bump the version when you release mapping changes.
-
-**Data stream example:**
-
-```csharp
 [DataStream<LogEntry>(Type = "logs", Dataset = "myapp", MappingVersion = "2.1.0")]
 ```
 
-### Decision logic
+Set `MappingVersion` to a version string parseable by `System.Version` (e.g. `"1.0.0"`, `"2.3.1"`). Bump it when you release mapping changes.
 
-When `MappingVersion` is set, bootstrap evaluates in this order:
+:::{note}
+Attribute properties must be compile-time constants. To use a runtime value such as your application's assembly version, use the programmatic approach below instead.
+:::
 
-1. **Version guard**: If the remote template has a `mapping_version` that is **greater** than the local one (compared as `System.Version`), **skip** bootstrap. The remote was deployed by a newer release.
-2. **Hash check**: If the hashes match, **skip**. Nothing changed.
-3. Otherwise, **proceed** with bootstrap.
+**Application assembly version (programmatic):**
 
-When `MappingVersion` is *not* set (null), only step 2 applies — the original hash-only behavior.
-
-### Programmatic usage
-
-When not using attributes, set `MappingVersion` directly on `ElasticsearchTypeContext`:
+Since attributes require compile-time constants, use `ElasticsearchTypeContext.WithMappingVersion()` or set `MappingVersion` on `BootstrapContext` directly to use your application's assembly version at runtime:
 
 ```csharp
+using System.Reflection;
+
+// Get your app's version at runtime
+var appVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.0.0";
+
+// Option 1: override the type context from your source-generated resolver
+var context = MyMappingContext.Product.Context with { MappingVersion = appVersion };
+var options = new IngestChannelOptions<Product>(transport, context);
+
+// Option 2: set it on ElasticsearchTypeContext directly
 var context = new ElasticsearchTypeContext(
     getSettingsJson, getMappingsJson, getIndexJson,
     hash, settingsHash, mappingsHash,
     indexStrategy, searchStrategy,
     EntityTarget.Index,
-    MappingVersion: "1.2.0"
+    MappingVersion: appVersion
 );
 ```
 
-Or set it on `BootstrapContext` when using custom bootstrap strategies:
+**Custom strategies (BootstrapContext):**
 
 ```csharp
 var bootstrapContext = new BootstrapContext
@@ -205,3 +203,25 @@ var bootstrapContext = new BootstrapContext
     MappingVersion = "1.2.0"
 };
 ```
+
+### Decision logic
+
+When `MappingVersion` is set, bootstrap checks two conditions. **Both** must pass for bootstrap to be skipped — if either indicates a change is needed, bootstrap proceeds:
+
+| Remote version vs local | Hash | Result |
+|------------------------|------|--------|
+| Remote **newer** than local | _any_ | **Skip** — don't downgrade |
+| Equal or local newer | **Matches** | **Skip** — nothing changed |
+| Equal or local newer | **Differs** | **Proceed** — templates changed, upgrade |
+| Remote has no version | **Matches** | **Skip** — hash says nothing changed |
+| Remote has no version | **Differs** | **Proceed** — hash says templates changed |
+
+In other words:
+
+1. **Version guard**: If the remote `mapping_version` is **strictly greater** than the local one (compared as `System.Version`), **skip**. The cluster already has a newer deployment's templates — don't overwrite them.
+2. **Hash check**: If the content hashes match, **skip**. The templates are identical.
+3. Otherwise: **proceed** with bootstrap. The local version is equal or newer and the templates have actually changed.
+
+Bootstrap only proceeds when the hash differs **and** the remote version is not newer. This is the key protection: an older pod sees a different hash (because its mappings are older) but also sees that the remote version is higher, so it backs off.
+
+When `MappingVersion` is *not* set (null), only the hash check applies — the original behavior.

--- a/src/Elastic.Ingest.Elasticsearch/Catalog/CatalogIndexChannel.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Catalog/CatalogIndexChannel.cs
@@ -114,18 +114,18 @@ public abstract class CatalogIndexChannel<TDocument, TChannelOptions> : IndexCha
 		GenerateChannelHash(bootstrapMethod, out _, out _, out _, out _);
 
 		var indexTemplateExists = await IndexTemplateExistsAsync(TemplateName, ctx).ConfigureAwait(false);
-		var indexTemplateMatchesHash = indexTemplateExists && await IndexTemplateMatchesHashAsync(ChannelHash, ctx).ConfigureAwait(false);
+		var shouldSkip = indexTemplateExists && await ShouldSkipBootstrapAsync(ChannelHash, ctx).ConfigureAwait(false);
 
 		var latestAlias = string.Format(InvariantCulture, Options.IndexFormat, "latest");
 		var matchingIndices = string.Format(InvariantCulture, Options.IndexFormat, "*");
 		var currentIndex = await ShouldRemovePreviousAliasAsync(matchingIndices, latestAlias, ctx).ConfigureAwait(false);
 		// ensure we index to the latest index unless we have no previous versions, or the index template has changed
-		if (string.IsNullOrEmpty(currentIndex) || !indexTemplateExists || !indexTemplateMatchesHash)
+		if (string.IsNullOrEmpty(currentIndex) || !indexTemplateExists || !shouldSkip)
 			return await base.BootstrapElasticsearchAsync(bootstrapMethod, ctx).ConfigureAwait(false);
 
 		// When doing scripted hash upsert lookup, we need to override the bulk path and query to use the current index
 		// if the index template has changed, we index to the index name determined in the constructor
-		if (TryReuseIndex && indexTemplateExists && indexTemplateMatchesHash)
+		if (TryReuseIndex && indexTemplateExists && shouldSkip)
 		{
 			IndexName = currentIndex;
 			_ingestStrategy.UpdateIndexName(currentIndex, base.BulkPathAndQuery);
@@ -140,18 +140,18 @@ public abstract class CatalogIndexChannel<TDocument, TChannelOptions> : IndexCha
 		GenerateChannelHash(bootstrapMethod, out _, out _, out _, out _);
 
 		var indexTemplateExists = IndexTemplateExists(TemplateName);
-		var indexTemplateMatchesHash = indexTemplateExists && IndexTemplateMatchesHash(ChannelHash);
+		var shouldSkip = indexTemplateExists && ShouldSkipBootstrap(ChannelHash);
 
 		var latestAlias = string.Format(InvariantCulture, Options.IndexFormat, "latest");
 		var matchingIndices = string.Format(InvariantCulture, Options.IndexFormat, "*");
 		var currentIndex = ShouldRemovePreviousAlias(matchingIndices, latestAlias);
 		// ensure we index to the latest index unless we have no previous versions, or the index template has changed
-		if (string.IsNullOrEmpty(currentIndex) || !indexTemplateExists || !indexTemplateMatchesHash)
+		if (string.IsNullOrEmpty(currentIndex) || !indexTemplateExists || !shouldSkip)
 			return base.BootstrapElasticsearch(bootstrapMethod);
 
 		// When doing scripted hash upsert lookup, we need to override the bulk path and query to use the current index
 		// if the index template has changed, we index to the index name determined in the constructor
-		if (TryReuseIndex && indexTemplateExists && indexTemplateMatchesHash)
+		if (TryReuseIndex && indexTemplateExists && shouldSkip)
 		{
 			IndexName = currentIndex;
 			_ingestStrategy.UpdateIndexName(currentIndex, base.BulkPathAndQuery);

--- a/src/Elastic.Ingest.Elasticsearch/DeltaSyncOrchestrator.cs
+++ b/src/Elastic.Ingest.Elasticsearch/DeltaSyncOrchestrator.cs
@@ -192,7 +192,8 @@ public class DeltaSyncOrchestrator<TEvent> : ISyncOrchestrator<TEvent>
 					new Dictionary<string, string> { [BatchIndexDateField] = _batchTimestamp.ToString("o") });
 		}
 
-		var primaryServerHash = await _primaryChannel.GetIndexTemplateHashAsync(ctx).ConfigureAwait(false) ?? string.Empty;
+		var primaryMeta = await _primaryChannel.GetIndexTemplateMetaAsync(ctx).ConfigureAwait(false);
+		var primaryServerHash = primaryMeta.Hash ?? string.Empty;
 		await _primaryChannel.BootstrapElasticsearchAsync(method, ctx).ConfigureAwait(false);
 
 		if (reusePrimary != null && primaryServerHash != _primaryChannel.ChannelHash)
@@ -225,7 +226,8 @@ public class DeltaSyncOrchestrator<TEvent> : ISyncOrchestrator<TEvent>
 		_secondaryChannel = new IngestChannel<TEvent>(secondaryOpts);
 
 		_secondaryIndexName = _secondaryChannel.IndexName;
-		var secondaryServerHash = await _secondaryChannel.GetIndexTemplateHashAsync(ctx).ConfigureAwait(false) ?? string.Empty;
+		var secondaryMeta = await _secondaryChannel.GetIndexTemplateMetaAsync(ctx).ConfigureAwait(false);
+		var secondaryServerHash = secondaryMeta.Hash ?? string.Empty;
 		await _secondaryChannel.BootstrapElasticsearchAsync(method, ctx).ConfigureAwait(false);
 
 		if (reuseSecondary != null && secondaryServerHash != _secondaryChannel.ChannelHash)
@@ -535,12 +537,9 @@ public class DeltaSyncOrchestrator<TEvent> : ISyncOrchestrator<TEvent>
 			return null;
 
 		var templateName = $"{tc.IndexStrategy.WriteTarget}-template";
-		var hashResponse = await _transport.RequestAsync<StringResponse>(
-			HttpMethod.GET,
-			$"/_index_template/{templateName}?filter_path=index_templates.index_template._meta.hash",
-			cancellationToken: ctx).ConfigureAwait(false);
+		var meta = await Strategies.TemplateMetadataHelper.FetchMetaAsync(_transport, templateName, ctx).ConfigureAwait(false);
 
-		if (!hashResponse.ApiCallDetails.HasSuccessfulStatusCode || string.IsNullOrEmpty(hashResponse.Body))
+		if (string.IsNullOrEmpty(meta.Hash))
 			return null;
 
 		return await ResolveExistingIndexAsync(writeAlias, ctx).ConfigureAwait(false);

--- a/src/Elastic.Ingest.Elasticsearch/IncrementalSyncOrchestrator.cs
+++ b/src/Elastic.Ingest.Elasticsearch/IncrementalSyncOrchestrator.cs
@@ -215,7 +215,8 @@ public class IncrementalSyncOrchestrator<TEvent> : ISyncOrchestrator<TEvent>
 					});
 		}
 
-		var primaryServerHash = await _primaryChannel.GetIndexTemplateHashAsync(ctx).ConfigureAwait(false) ?? string.Empty;
+		var primaryMeta = await _primaryChannel.GetIndexTemplateMetaAsync(ctx).ConfigureAwait(false);
+		var primaryServerHash = primaryMeta.Hash ?? string.Empty;
 		await _primaryChannel.BootstrapElasticsearchAsync(method, ctx).ConfigureAwait(false);
 
 		// If we optimistically chose reuse but the hash now differs (template evolved),
@@ -253,7 +254,8 @@ public class IncrementalSyncOrchestrator<TEvent> : ISyncOrchestrator<TEvent>
 		_secondaryChannel = new IngestChannel<TEvent>(secondaryOpts);
 
 		_secondaryIndexName = _secondaryChannel.IndexName;
-		var secondaryServerHash = await _secondaryChannel.GetIndexTemplateHashAsync(ctx).ConfigureAwait(false) ?? string.Empty;
+		var secondaryMeta = await _secondaryChannel.GetIndexTemplateMetaAsync(ctx).ConfigureAwait(false);
+		var secondaryServerHash = secondaryMeta.Hash ?? string.Empty;
 		await _secondaryChannel.BootstrapElasticsearchAsync(method, ctx).ConfigureAwait(false);
 
 		if (reuseSecondary != null && secondaryServerHash != _secondaryChannel.ChannelHash)
@@ -537,12 +539,9 @@ public class IncrementalSyncOrchestrator<TEvent> : ISyncOrchestrator<TEvent>
 			return null;
 
 		var templateName = $"{tc.IndexStrategy.WriteTarget}-template";
-		var hashResponse = await _transport.RequestAsync<StringResponse>(
-			HttpMethod.GET,
-			$"/_index_template/{templateName}?filter_path=index_templates.index_template._meta.hash",
-			cancellationToken: ctx).ConfigureAwait(false);
+		var meta = await Strategies.TemplateMetadataHelper.FetchMetaAsync(_transport, templateName, ctx).ConfigureAwait(false);
 
-		if (!hashResponse.ApiCallDetails.HasSuccessfulStatusCode || string.IsNullOrEmpty(hashResponse.Body))
+		if (string.IsNullOrEmpty(meta.Hash))
 			return null;
 
 		return await ResolveExistingIndexAsync(writeAlias, ctx).ConfigureAwait(false);

--- a/src/Elastic.Ingest.Elasticsearch/IngestChannel.cs
+++ b/src/Elastic.Ingest.Elasticsearch/IngestChannel.cs
@@ -163,6 +163,7 @@ public class IngestChannel<TEvent> : IngestChannelBase<TEvent, IngestChannelOpti
 		string name, string match, string mappingsName, string settingsName, string hash)
 	{
 		// Not used in strategy-based bootstrap flow, but required by abstract base
+		var mappingVersionFragment = Strategies.TemplateMetadataHelper.BuildMappingVersionFragment(Options.TypeContext?.MappingVersion);
 		var indexTemplateBody = @$"{{
                 ""index_patterns"": [""{match}""],
                 ""composed_of"": [ ""{mappingsName}"", ""{settingsName}"" ],
@@ -170,7 +171,7 @@ public class IngestChannel<TEvent> : IngestChannelBase<TEvent, IngestChannelOpti
                 ""_meta"": {{
                     ""description"": ""Template installed by .NET ingest libraries (https://github.com/elastic/elastic-ingest-dotnet)"",
                     ""assembly_version"": ""{LibraryVersion.Current}"",
-                    ""hash"": ""{hash}""
+                    ""hash"": ""{hash}""{mappingVersionFragment}
                 }}
             }}";
 		return (name, indexTemplateBody);
@@ -186,6 +187,7 @@ public class IngestChannel<TEvent> : IngestChannelBase<TEvent, IngestChannelOpti
 			GetMappingsJson = _strategy.GetMappingsJson,
 			GetMappingSettings = _strategy.GetMappingSettings,
 			DataStreamType = _strategy.DataStreamType,
-			IndexSettings = Options.TypeContext?.IndexSettings
+			IndexSettings = Options.TypeContext?.IndexSettings,
+			MappingVersion = Options.TypeContext?.MappingVersion
 		};
 }

--- a/src/Elastic.Ingest.Elasticsearch/IngestChannelBase.Bootstrap.cs
+++ b/src/Elastic.Ingest.Elasticsearch/IngestChannelBase.Bootstrap.cs
@@ -30,6 +30,14 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 	public string ChannelHash { get; protected set; } = string.Empty;
 
 	/// <summary>
+	/// Optional mapping version for version-aware bootstrap guards.
+	/// When set, stored in <c>_meta.mapping_version</c> and compared during bootstrap to prevent
+	/// older versions from overwriting newer templates. When <see langword="null"/> (the default),
+	/// bootstrap uses hash-only comparison.
+	/// </summary>
+	protected virtual string? MappingVersion => null;
+
+	/// <summary>
 	/// Returns a minimal default index template for an <see cref="IngestChannelBase{TEvent, TChannelOptions}"/> implementation
 	/// </summary>
 	/// <returns>A tuple of (name, body) describing the index template</returns>
@@ -49,8 +57,14 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 		if (bootstrapMethod == BootstrapMethod.None) return true;
 
 		var indexTemplateExists = await IndexTemplateExistsAsync(TemplateName, ctx).ConfigureAwait(false);
-		var indexTemplateMatchesHash = indexTemplateExists && await IndexTemplateMatchesHashAsync(ChannelHash, ctx).ConfigureAwait(false);
-		if (indexTemplateExists && !AlwaysBootstrapComponentTemplates && indexTemplateMatchesHash)
+		var shouldSkip = false;
+		if (indexTemplateExists)
+		{
+			var meta = await Strategies.TemplateMetadataHelper.FetchMetaAsync(Options.Transport, TemplateName, ctx).ConfigureAwait(false);
+			shouldSkip = Strategies.TemplateMetadataHelper.ShouldSkipBootstrap(meta, ChannelHash, MappingVersion);
+		}
+
+		if (indexTemplateExists && !AlwaysBootstrapComponentTemplates && shouldSkip)
 			return true;
 
 		if (!await PutComponentTemplateAsync(bootstrapMethod, settingsName, settingsBody, ctx).ConfigureAwait(false))
@@ -59,7 +73,7 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 		if (!await PutComponentTemplateAsync(bootstrapMethod, mappingsName, mappingsBody, ctx).ConfigureAwait(false))
 			return false;
 
-		if (indexTemplateExists && indexTemplateMatchesHash)
+		if (indexTemplateExists && shouldSkip)
 			return true;
 
 		var (indexTemplateName, indexTemplateBody) = GetDefaultIndexTemplate(TemplateName, TemplateWildcard, mappingsName, settingsName, ChannelHash);
@@ -95,10 +109,15 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 
 		if (bootstrapMethod == BootstrapMethod.None) return true;
 
-		//if the index template already exists and has the same hash, we don't need to re-register the component templates'
 		var indexTemplateExists = IndexTemplateExists(TemplateName);
-		var indexTemplateMatchesHash = indexTemplateExists && IndexTemplateMatchesHash(ChannelHash);
-		if (indexTemplateExists && !AlwaysBootstrapComponentTemplates && indexTemplateMatchesHash)
+		var shouldSkip = false;
+		if (indexTemplateExists)
+		{
+			var meta = Strategies.TemplateMetadataHelper.FetchMeta(Options.Transport, TemplateName);
+			shouldSkip = Strategies.TemplateMetadataHelper.ShouldSkipBootstrap(meta, ChannelHash, MappingVersion);
+		}
+
+		if (indexTemplateExists && !AlwaysBootstrapComponentTemplates && shouldSkip)
 			return true;
 
 		if (!PutComponentTemplate(bootstrapMethod, settingsName, settingsBody))
@@ -107,7 +126,7 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 		if (!PutComponentTemplate(bootstrapMethod, mappingsName, mappingsBody))
 			return false;
 
-		if (indexTemplateExists && indexTemplateMatchesHash)
+		if (indexTemplateExists && shouldSkip)
 			return true;
 
 		var (indexTemplateName, indexTemplateBody) = GetDefaultIndexTemplate(TemplateName, TemplateWildcard, mappingsName, settingsName, ChannelHash);
@@ -117,48 +136,27 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 		return true;
 	}
 
-	/// <summary> Checks if the stored hash matches</summary>
-	public bool IndexTemplateMatchesHash(string hash)
+	/// <summary> Checks if bootstrap should be skipped based on hash and optional version guard. </summary>
+	public bool ShouldSkipBootstrap(string hash)
 	{
-		var metaHash = GetIndexTemplateHash();
-		// if the hash is empty, we don't have a hash stored, so we don't match
-		if (string.IsNullOrWhiteSpace(metaHash))
-			return false;
-	 	return metaHash == hash;
+		var meta = Strategies.TemplateMetadataHelper.FetchMeta(Options.Transport, TemplateName);
+		return Strategies.TemplateMetadataHelper.ShouldSkipBootstrap(meta, hash, MappingVersion);
 	}
 
-	/// <summary> Gets the stored hash of the index template and its generated components </summary>
-	public async Task<bool> IndexTemplateMatchesHashAsync(string hash, CancellationToken ctx = default)
+	/// <summary> Checks if bootstrap should be skipped based on hash and optional version guard (async). </summary>
+	public async Task<bool> ShouldSkipBootstrapAsync(string hash, CancellationToken ctx = default)
 	{
-		var metaHash = await GetIndexTemplateHashAsync(ctx).ConfigureAwait(false);
-		if (string.IsNullOrWhiteSpace(metaHash))
-			return false;
-		return metaHash == hash;
+		var meta = await Strategies.TemplateMetadataHelper.FetchMetaAsync(Options.Transport, TemplateName, ctx).ConfigureAwait(false);
+		return Strategies.TemplateMetadataHelper.ShouldSkipBootstrap(meta, hash, MappingVersion);
 	}
 
+	/// <summary> Get the stored metadata on the index template if available </summary>
+	public Strategies.TemplateMetadata GetIndexTemplateMeta() =>
+		Strategies.TemplateMetadataHelper.FetchMeta(Options.Transport, TemplateName);
 
-	/// <summary> Get the stored hash on the index template if available </summary>
-	public string? GetIndexTemplateHash()
-	{
-		var template = Options.Transport.Request<StringResponse>(HttpMethod.GET, $"/_index_template/{TemplateName}?filter_path=index_templates.index_template._meta.hash");
-		if (!template.ApiCallDetails.HasSuccessfulStatusCode)
-			return string.Empty;
-		return ReadMetaHash(template);
-	}
-
-	private static string? ReadMetaHash(StringResponse template)
-	{
-		var metaHash = template.Body.Replace("""{"index_templates":[{"index_template":{"_meta":{"hash":""", "").Trim('\"').Split('\"').FirstOrDefault();
-		return metaHash;
-	}
-
-	/// <summary> Get the stored hash on the index template if available </summary>
-	public async Task<string?> GetIndexTemplateHashAsync(CancellationToken ctx)
-	{
-		var template = await Options.Transport.RequestAsync<StringResponse>(HttpMethod.GET, $"/_index_template/{TemplateName}?filter_path=index_templates.index_template._meta.hash", ctx)
-			.ConfigureAwait(false);
-		return ReadMetaHash(template);
-	}
+	/// <summary> Get the stored metadata on the index template if available (async) </summary>
+	public Task<Strategies.TemplateMetadata> GetIndexTemplateMetaAsync(CancellationToken ctx = default) =>
+		Strategies.TemplateMetadataHelper.FetchMetaAsync(Options.Transport, TemplateName, ctx);
 
 	private bool? _isServerless;
 	/// Detects whether we are running against serverless or not
@@ -300,13 +298,14 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 		settings.Append('}');
 
 		var settingsName = $"{indexTemplateName}-settings";
+		var mappingVersionFragment = Strategies.TemplateMetadataHelper.BuildMappingVersionFragment(MappingVersion);
 		var settingsBody = $@"{{
               ""template"": {{
                 ""settings"": {settings}
               }},
               ""_meta"": {{
                 ""description"": ""Template installed by .NET ingest libraries (https://github.com/elastic/elastic-ingest-dotnet)"",
-                ""assembly_version"": ""{LibraryVersion.Current}""
+                ""assembly_version"": ""{LibraryVersion.Current}""{mappingVersionFragment}
               }}
             }}";
 		return (settingsName, settingsBody);
@@ -324,6 +323,7 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
 		var settingsName = $"{indexTemplateName}-mappings";
 		var mappings = GetMappings() ?? "{}";
 		var settings = GetMappingSettings() ?? "{}";
+		var mappingVersionFragment = Strategies.TemplateMetadataHelper.BuildMappingVersionFragment(MappingVersion);
 		var settingsBody = $@"{{
               ""template"": {{
                 ""settings"": {settings},
@@ -331,7 +331,7 @@ public abstract partial class IngestChannelBase<TDocument, TChannelOptions>
               }},
               ""_meta"": {{
                 ""description"": ""Template installed by .NET ingest libraries (https://github.com/elastic/elastic-ingest-dotnet)"",
-                ""assembly_version"": ""{LibraryVersion.Current}""
+                ""assembly_version"": ""{LibraryVersion.Current}""{mappingVersionFragment}
               }}
             }}";
 		return (settingsName, settingsBody);

--- a/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/BootstrapContext.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/BootstrapContext.cs
@@ -61,4 +61,17 @@ public class BootstrapContext
 	/// Set by <c>DataStreamLifecycleStep</c> for <c>DataStreamTemplateStep</c> to embed.
 	/// </summary>
 	public string? DataStreamLifecycleRetention { get; internal set; }
+
+	/// <summary>
+	/// Optional mapping version for version-aware bootstrap guards.
+	/// <para>
+	/// When set, the version is stored in <c>_meta.mapping_version</c> on templates. During bootstrap,
+	/// if the remote template has a higher <c>mapping_version</c> than the local one, bootstrap is
+	/// skipped to prevent an older deployment from overwriting a newer one's templates.
+	/// </para>
+	/// <para>
+	/// When <see langword="null"/> (the default), bootstrap uses hash-only comparison — the existing behavior.
+	/// </para>
+	/// </summary>
+	public string? MappingVersion { get; init; }
 }

--- a/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/Steps/ComponentTemplateStep.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/Steps/ComponentTemplateStep.cs
@@ -84,13 +84,14 @@ public class ComponentTemplateStep : IBootstrapStep
 		settings.Append('}');
 
 		var settingsName = $"{context.TemplateName}-settings";
+		var mappingVersionFragment = TemplateMetadataHelper.BuildMappingVersionFragment(context.MappingVersion);
 		var settingsBody = $@"{{
               ""template"": {{
                 ""settings"": {settings}
               }},
               ""_meta"": {{
                 ""description"": ""Template installed by .NET ingest libraries (https://github.com/elastic/elastic-ingest-dotnet)"",
-                ""assembly_version"": ""{LibraryVersion.Current}""
+                ""assembly_version"": ""{LibraryVersion.Current}""{mappingVersionFragment}
               }}
             }}";
 		return (settingsName, settingsBody);
@@ -101,6 +102,7 @@ public class ComponentTemplateStep : IBootstrapStep
 		var mappingsName = $"{context.TemplateName}-mappings";
 		var mappings = context.GetMappingsJson?.Invoke() ?? "{}";
 		var settings = context.GetMappingSettings?.Invoke() ?? "{}";
+		var mappingVersionFragment = TemplateMetadataHelper.BuildMappingVersionFragment(context.MappingVersion);
 		var mappingsBody = $@"{{
               ""template"": {{
                 ""settings"": {settings},
@@ -108,7 +110,7 @@ public class ComponentTemplateStep : IBootstrapStep
               }},
               ""_meta"": {{
                 ""description"": ""Template installed by .NET ingest libraries (https://github.com/elastic/elastic-ingest-dotnet)"",
-                ""assembly_version"": ""{LibraryVersion.Current}""
+                ""assembly_version"": ""{LibraryVersion.Current}""{mappingVersionFragment}
               }}
             }}";
 		return (mappingsName, mappingsBody);

--- a/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/Steps/DataStreamTemplateStep.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/Steps/DataStreamTemplateStep.cs
@@ -27,6 +27,7 @@ public class DataStreamTemplateStep : IndexTemplateStep
 		var additionalComponentsJson = string.Join(", ", additionalComponents.Select(a => $"\"{a}\""));
 
 		var lifecycleBlock = GetLifecycleBlock(context);
+		var mappingVersionFragment = TemplateMetadataHelper.BuildMappingVersionFragment(context.MappingVersion);
 
 		return @$"{{
                 ""index_patterns"": [""{context.TemplateWildcard}""],
@@ -36,7 +37,7 @@ public class DataStreamTemplateStep : IndexTemplateStep
                 ""_meta"": {{
                     ""description"": ""Template installed by .NET ingest libraries (https://github.com/elastic/elastic-ingest-dotnet)"",
                     ""assembly_version"": ""{LibraryVersion.Current}"",
-                    ""hash"": ""{context.ChannelHash}""
+                    ""hash"": ""{context.ChannelHash}""{mappingVersionFragment}
                 }}
             }}";
 	}

--- a/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/Steps/IndexTemplateStep.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/Steps/IndexTemplateStep.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Ingest.Transport;
@@ -13,7 +12,8 @@ namespace Elastic.Ingest.Elasticsearch.Strategies.BootstrapSteps;
 
 /// <summary>
 /// Bootstrap step that creates an index template (without data_stream).
-/// Includes hash-based short-circuit: if the template already exists with matching hash, skip.
+/// Includes hash-based (and optional version-based) short-circuit: if the template
+/// already exists with matching hash, or was deployed by a newer mapping version, skip.
 /// </summary>
 public class IndexTemplateStep : IBootstrapStep
 {
@@ -26,8 +26,8 @@ public class IndexTemplateStep : IBootstrapStep
 		var templateExists = await IndexTemplateExistsAsync(context.Transport, context.TemplateName, ctx).ConfigureAwait(false);
 		if (templateExists)
 		{
-			var matches = await IndexTemplateMatchesHashAsync(context.Transport, context.TemplateName, context.ChannelHash, ctx).ConfigureAwait(false);
-			if (matches)
+			var meta = await TemplateMetadataHelper.FetchMetaAsync(context.Transport, context.TemplateName, ctx).ConfigureAwait(false);
+			if (TemplateMetadataHelper.ShouldSkipBootstrap(meta, context.ChannelHash, context.MappingVersion))
 				return true;
 		}
 
@@ -41,8 +41,8 @@ public class IndexTemplateStep : IBootstrapStep
 		var templateExists = IndexTemplateExists(context.Transport, context.TemplateName);
 		if (templateExists)
 		{
-			var matches = IndexTemplateMatchesHash(context.Transport, context.TemplateName, context.ChannelHash);
-			if (matches)
+			var meta = TemplateMetadataHelper.FetchMeta(context.Transport, context.TemplateName);
+			if (TemplateMetadataHelper.ShouldSkipBootstrap(meta, context.ChannelHash, context.MappingVersion))
 				return true;
 		}
 
@@ -57,6 +57,7 @@ public class IndexTemplateStep : IBootstrapStep
 	{
 		var settingsName = $"{context.TemplateName}-settings";
 		var mappingsName = $"{context.TemplateName}-mappings";
+		var mappingVersionFragment = TemplateMetadataHelper.BuildMappingVersionFragment(context.MappingVersion);
 
 		return @$"{{
                 ""index_patterns"": [""{context.TemplateWildcard}""],
@@ -65,7 +66,7 @@ public class IndexTemplateStep : IBootstrapStep
                 ""_meta"": {{
                     ""description"": ""Template installed by .NET ingest libraries (https://github.com/elastic/elastic-ingest-dotnet)"",
                     ""assembly_version"": ""{LibraryVersion.Current}"",
-                    ""hash"": ""{context.ChannelHash}""
+                    ""hash"": ""{context.ChannelHash}""{mappingVersionFragment}
                 }}
             }}";
 	}
@@ -81,33 +82,6 @@ public class IndexTemplateStep : IBootstrapStep
 		var response = transport.Request<StringResponse>(HttpMethod.HEAD, $"_index_template/{name}");
 		return response.ApiCallDetails.HttpStatusCode is 200;
 	}
-
-	private static async Task<bool> IndexTemplateMatchesHashAsync(ITransport transport, string name, string hash, CancellationToken ctx)
-	{
-		var response = await transport.RequestAsync<StringResponse>(
-			HttpMethod.GET, $"/_index_template/{name}?filter_path=index_templates.index_template._meta.hash", ctx
-		).ConfigureAwait(false);
-		if (!response.ApiCallDetails.HasSuccessfulStatusCode)
-			return false;
-		return ReadMetaHash(response) == hash;
-	}
-
-	private static bool IndexTemplateMatchesHash(ITransport transport, string name, string hash)
-	{
-		var response = transport.Request<StringResponse>(
-			HttpMethod.GET, $"/_index_template/{name}?filter_path=index_templates.index_template._meta.hash"
-		);
-		if (!response.ApiCallDetails.HasSuccessfulStatusCode)
-			return false;
-		return ReadMetaHash(response) == hash;
-	}
-
-	private static string? ReadMetaHash(StringResponse template) =>
-		template.Body
-			.Replace("""{"index_templates":[{"index_template":{"_meta":{"hash":""", "")
-			.Trim('"')
-			.Split('"')
-			.FirstOrDefault();
 
 	private static async Task<bool> PutIndexTemplateAsync(BootstrapContext context, string name, string body, CancellationToken ctx)
 	{

--- a/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/TemplateMetadata.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/TemplateMetadata.cs
@@ -80,12 +80,23 @@ public static class TemplateMetadataHelper
 
 	/// <summary>
 	/// Determines whether bootstrap should be skipped based on remote metadata and local state.
-	/// <list type="bullet">
-	/// <item>If <paramref name="localMappingVersion"/> is null: pure hash check (default behavior).</item>
-	/// <item>If both local and remote mapping versions parse as <see cref="Version"/> and remote &gt; local: skip (don't downgrade).</item>
-	/// <item>If hash matches: skip (nothing changed).</item>
-	/// <item>Otherwise: proceed with bootstrap.</item>
+	/// <para>
+	/// Bootstrap is skipped (returns <see langword="true"/>) when <b>either</b> condition is met:
+	/// </para>
+	/// <list type="number">
+	/// <item><b>Version guard</b>: both local and remote have a parseable <c>mapping_version</c>
+	/// and remote is strictly greater than local — the cluster already has a newer deployment's
+	/// templates, so the older pod must not overwrite them.</item>
+	/// <item><b>Hash check</b>: the content hashes match — templates are identical, nothing to do.</item>
 	/// </list>
+	/// <para>
+	/// Bootstrap proceeds (returns <see langword="false"/>) only when the hash differs <b>and</b>
+	/// the remote version is not newer than the local version.
+	/// </para>
+	/// <para>
+	/// When <paramref name="localMappingVersion"/> is <see langword="null"/>, only the hash check
+	/// applies — the original hash-only behavior.
+	/// </para>
 	/// </summary>
 	public static bool ShouldSkipBootstrap(
 		TemplateMetadata remote, string localHash, string? localMappingVersion)

--- a/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/TemplateMetadata.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Strategies/Bootstrap/TemplateMetadata.cs
@@ -1,0 +1,131 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Transport;
+
+namespace Elastic.Ingest.Elasticsearch.Strategies;
+
+/// <summary>
+/// Parsed <c>_meta</c> fields from an existing index template.
+/// </summary>
+public record TemplateMetadata(string? Hash, string? MappingVersion)
+{
+	/// <summary> An empty metadata instance (no template found or no _meta). </summary>
+	public static readonly TemplateMetadata Empty = new(null, null);
+}
+
+/// <summary>
+/// Shared helpers for reading index template <c>_meta</c> and deciding whether bootstrap should proceed.
+/// </summary>
+public static class TemplateMetadataHelper
+{
+	private const string FilterPath = "index_templates.index_template._meta.hash,index_templates.index_template._meta.mapping_version";
+
+	/// <summary>
+	/// Fetches the <c>_meta</c> from an existing index template (async).
+	/// </summary>
+	public static async Task<TemplateMetadata> FetchMetaAsync(
+		ITransport transport, string templateName, CancellationToken ctx = default)
+	{
+		var response = await transport.RequestAsync<StringResponse>(
+			HttpMethod.GET, $"/_index_template/{templateName}?filter_path={FilterPath}", ctx
+		).ConfigureAwait(false);
+
+		if (!response.ApiCallDetails.HasSuccessfulStatusCode || string.IsNullOrEmpty(response.Body))
+			return TemplateMetadata.Empty;
+
+		return ReadMeta(response.Body);
+	}
+
+	/// <summary>
+	/// Fetches the <c>_meta</c> from an existing index template (sync).
+	/// </summary>
+	public static TemplateMetadata FetchMeta(ITransport transport, string templateName)
+	{
+		var response = transport.Request<StringResponse>(
+			HttpMethod.GET, $"/_index_template/{templateName}?filter_path={FilterPath}"
+		);
+
+		if (!response.ApiCallDetails.HasSuccessfulStatusCode || string.IsNullOrEmpty(response.Body))
+			return TemplateMetadata.Empty;
+
+		return ReadMeta(response.Body);
+	}
+
+	/// <summary>
+	/// Parses <c>hash</c> and <c>mapping_version</c> from the filtered <c>_meta</c> response body.
+	/// Expected shape: <c>{"index_templates":[{"index_template":{"_meta":{"hash":"...","mapping_version":"..."}}}]}</c>
+	/// </summary>
+	public static TemplateMetadata ReadMeta(string responseBody)
+	{
+		// Strip the envelope to get the _meta object contents
+		const string prefix = """{"index_templates":[{"index_template":{"_meta":{""";
+		if (!responseBody.StartsWith(prefix, StringComparison.Ordinal))
+			return TemplateMetadata.Empty;
+
+		var inner = responseBody.Substring(prefix.Length).TrimEnd('}', ']');
+		// inner is now something like: "hash":"abc123","mapping_version":"1.0.0"
+		// or just "hash":"abc123"
+
+		var hash = ExtractJsonStringValue(inner, "hash");
+		var mappingVersion = ExtractJsonStringValue(inner, "mapping_version");
+
+		return new TemplateMetadata(hash, mappingVersion);
+	}
+
+	/// <summary>
+	/// Determines whether bootstrap should be skipped based on remote metadata and local state.
+	/// <list type="bullet">
+	/// <item>If <paramref name="localMappingVersion"/> is null: pure hash check (default behavior).</item>
+	/// <item>If both local and remote mapping versions parse as <see cref="Version"/> and remote &gt; local: skip (don't downgrade).</item>
+	/// <item>If hash matches: skip (nothing changed).</item>
+	/// <item>Otherwise: proceed with bootstrap.</item>
+	/// </list>
+	/// </summary>
+	public static bool ShouldSkipBootstrap(
+		TemplateMetadata remote, string localHash, string? localMappingVersion)
+	{
+		// Version guard: if both sides have a parseable mapping_version and remote is newer, skip
+		if (localMappingVersion != null
+			&& remote.MappingVersion != null
+			&& Version.TryParse(remote.MappingVersion, out var remoteVersion)
+			&& Version.TryParse(localMappingVersion, out var localVersion)
+			&& remoteVersion > localVersion)
+		{
+			return true;
+		}
+
+		// Hash check: if hashes match, nothing changed
+		if (!string.IsNullOrWhiteSpace(remote.Hash) && remote.Hash == localHash)
+			return true;
+
+		return false;
+	}
+
+	/// <summary>
+	/// Builds the optional <c>mapping_version</c> JSON fragment for inclusion in <c>_meta</c>.
+	/// Returns empty string when <paramref name="mappingVersion"/> is null.
+	/// </summary>
+	public static string BuildMappingVersionFragment(string? mappingVersion) =>
+		mappingVersion != null
+			? $@",
+                    ""mapping_version"": ""{mappingVersion}"""
+			: string.Empty;
+
+	private static string? ExtractJsonStringValue(string json, string key)
+	{
+		var marker = $"\"{key}\":\"";
+		var start = json.IndexOf(marker, StringComparison.Ordinal);
+		if (start < 0)
+			return null;
+
+		start += marker.Length;
+		var end = json.IndexOf('"', start);
+		return end < 0 ? null : json.Substring(start, end - start);
+	}
+}

--- a/src/Elastic.Ingest.Elasticsearch/Strategies/Provisioning/HashBasedReuseProvisioning.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Strategies/Provisioning/HashBasedReuseProvisioning.cs
@@ -18,13 +18,14 @@ public class HashBasedReuseProvisioning : IIndexProvisioningStrategy
 	/// <inheritdoc />
 	public async Task<ProvisioningDecision> DecideAsync(BootstrapContext context, CancellationToken ctx = default)
 	{
-		// Check if template exists and matches hash - if so, we might reuse
 		var templateExists = await TemplateExistsAsync(context.Transport, context.TemplateName, ctx).ConfigureAwait(false);
 		if (!templateExists)
 			return ProvisioningDecision.CreateNew;
 
-		var matches = await TemplateMatchesHashAsync(context.Transport, context.TemplateName, context.ChannelHash, ctx).ConfigureAwait(false);
-		return matches ? ProvisioningDecision.ReuseExisting : ProvisioningDecision.CreateNew;
+		var meta = await TemplateMetadataHelper.FetchMetaAsync(context.Transport, context.TemplateName, ctx).ConfigureAwait(false);
+		return TemplateMetadataHelper.ShouldSkipBootstrap(meta, context.ChannelHash, context.MappingVersion)
+			? ProvisioningDecision.ReuseExisting
+			: ProvisioningDecision.CreateNew;
 	}
 
 	/// <inheritdoc />
@@ -34,8 +35,10 @@ public class HashBasedReuseProvisioning : IIndexProvisioningStrategy
 		if (!templateExists)
 			return ProvisioningDecision.CreateNew;
 
-		var matches = TemplateMatchesHash(context.Transport, context.TemplateName, context.ChannelHash);
-		return matches ? ProvisioningDecision.ReuseExisting : ProvisioningDecision.CreateNew;
+		var meta = TemplateMetadataHelper.FetchMeta(context.Transport, context.TemplateName);
+		return TemplateMetadataHelper.ShouldSkipBootstrap(meta, context.ChannelHash, context.MappingVersion)
+			? ProvisioningDecision.ReuseExisting
+			: ProvisioningDecision.CreateNew;
 	}
 
 	/// <inheritdoc />
@@ -82,29 +85,4 @@ public class HashBasedReuseProvisioning : IIndexProvisioningStrategy
 		return response.ApiCallDetails.HttpStatusCode is 200;
 	}
 
-	private static async Task<bool> TemplateMatchesHashAsync(ITransport transport, string name, string hash, CancellationToken ctx)
-	{
-		var response = await transport.RequestAsync<StringResponse>(
-			HttpMethod.GET, $"/_index_template/{name}?filter_path=index_templates.index_template._meta.hash", ctx
-		).ConfigureAwait(false);
-		if (!response.ApiCallDetails.HasSuccessfulStatusCode)
-			return false;
-		var metaHash = response.Body
-			.Replace("""{"index_templates":[{"index_template":{"_meta":{"hash":""", "")
-			.Trim('"').Split('"')[0];
-		return metaHash == hash;
-	}
-
-	private static bool TemplateMatchesHash(ITransport transport, string name, string hash)
-	{
-		var response = transport.Request<StringResponse>(
-			HttpMethod.GET, $"/_index_template/{name}?filter_path=index_templates.index_template._meta.hash"
-		);
-		if (!response.ApiCallDetails.HasSuccessfulStatusCode)
-			return false;
-		var metaHash = response.Body
-			.Replace("""{"index_templates":[{"index_template":{"_meta":{"hash":""", "")
-			.Trim('"').Split('"')[0];
-		return metaHash == hash;
-	}
 }

--- a/src/Elastic.Mapping.Generator/Emitters/ContextEmitter.cs
+++ b/src/Elastic.Mapping.Generator/Emitters/ContextEmitter.cs
@@ -258,8 +258,13 @@ internal static class ContextEmitter
 			sb.AppendLine($"{indent}\t\tAiEnrichmentProvider: null,");
 
 		// MappingVersion from [Index] or [DataStream] attribute
+		// MappingVersionFromAssembly takes precedence over MappingVersion
+		var useAssemblyVersion = (reg.IndexConfig?.MappingVersionFromAssembly ?? false)
+			|| (reg.DataStreamConfig?.MappingVersionFromAssembly ?? false);
 		var mappingVersion = reg.IndexConfig?.MappingVersion ?? reg.DataStreamConfig?.MappingVersion;
-		if (mappingVersion != null)
+		if (useAssemblyVersion)
+			sb.AppendLine($"{indent}\t\tMappingVersion: typeof({model.ContextTypeName}).Assembly.GetName().Version?.ToString()");
+		else if (mappingVersion != null)
 			sb.AppendLine($"{indent}\t\tMappingVersion: \"{mappingVersion}\"");
 		else
 			sb.AppendLine($"{indent}\t\tMappingVersion: null");

--- a/src/Elastic.Mapping.Generator/Emitters/ContextEmitter.cs
+++ b/src/Elastic.Mapping.Generator/Emitters/ContextEmitter.cs
@@ -253,9 +253,16 @@ internal static class ContextEmitter
 		if (model.AiEnrichment != null
 			&& model.AiEnrichment.DocumentTypeFullyQualifiedName == reg.TypeFullyQualifiedName
 			&& (model.AiEnrichment.IndexVariant == null || model.AiEnrichment.IndexVariant == reg.Variant))
-			sb.AppendLine($"{indent}\t\tAiEnrichmentProvider: new {model.AiEnrichment.DocumentTypeName}AiEnrichmentProvider()");
+			sb.AppendLine($"{indent}\t\tAiEnrichmentProvider: new {model.AiEnrichment.DocumentTypeName}AiEnrichmentProvider(),");
 		else
-			sb.AppendLine($"{indent}\t\tAiEnrichmentProvider: null");
+			sb.AppendLine($"{indent}\t\tAiEnrichmentProvider: null,");
+
+		// MappingVersion from [Index] or [DataStream] attribute
+		var mappingVersion = reg.IndexConfig?.MappingVersion ?? reg.DataStreamConfig?.MappingVersion;
+		if (mappingVersion != null)
+			sb.AppendLine($"{indent}\t\tMappingVersion: \"{mappingVersion}\"");
+		else
+			sb.AppendLine($"{indent}\t\tMappingVersion: null");
 
 		sb.AppendLine($"{indent}\t);");
 		sb.AppendLine();

--- a/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
+++ b/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
@@ -200,7 +200,8 @@ public class MappingSourceGenerator : IIncrementalGenerator
 			GetNamedArg<int>(attr, "Replicas", -1),
 			GetNamedArg<string>(attr, "RefreshInterval"),
 			GetNamedArg<bool>(attr, "Dynamic", true),
-			GetNamedArg<string>(attr, "MappingVersion")
+			GetNamedArg<string>(attr, "MappingVersion"),
+			GetNamedArg<bool>(attr, "MappingVersionFromAssembly", false)
 		);
 
 		var ingestProperties = AnalyzeIngestProperties(targetType, stjConfig);
@@ -234,7 +235,8 @@ public class MappingSourceGenerator : IIncrementalGenerator
 				type!,
 				dataset!,
 				GetNamedArg<string>(attr, "Namespace"),
-				GetNamedArg<string>(attr, "MappingVersion")
+				GetNamedArg<string>(attr, "MappingVersion"),
+				GetNamedArg<bool>(attr, "MappingVersionFromAssembly", false)
 			);
 		}
 

--- a/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
+++ b/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
@@ -199,7 +199,8 @@ public class MappingSourceGenerator : IIncrementalGenerator
 			GetNamedArg<int>(attr, "Shards", -1),
 			GetNamedArg<int>(attr, "Replicas", -1),
 			GetNamedArg<string>(attr, "RefreshInterval"),
-			GetNamedArg<bool>(attr, "Dynamic", true)
+			GetNamedArg<bool>(attr, "Dynamic", true),
+			GetNamedArg<string>(attr, "MappingVersion")
 		);
 
 		var ingestProperties = AnalyzeIngestProperties(targetType, stjConfig);
@@ -232,7 +233,8 @@ public class MappingSourceGenerator : IIncrementalGenerator
 			dataStreamConfig = new DataStreamConfigModel(
 				type!,
 				dataset!,
-				GetNamedArg<string>(attr, "Namespace")
+				GetNamedArg<string>(attr, "Namespace"),
+				GetNamedArg<string>(attr, "MappingVersion")
 			);
 		}
 

--- a/src/Elastic.Mapping.Generator/Model/TypeMappingModel.cs
+++ b/src/Elastic.Mapping.Generator/Model/TypeMappingModel.cs
@@ -48,7 +48,8 @@ internal sealed record IndexConfigModel(
 	int Replicas,
 	string? RefreshInterval,
 	bool Dynamic,
-	string? MappingVersion = null
+	string? MappingVersion = null,
+	bool MappingVersionFromAssembly = false
 );
 
 /// <summary>
@@ -58,7 +59,8 @@ internal sealed record DataStreamConfigModel(
 	string Type,
 	string Dataset,
 	string? Namespace,
-	string? MappingVersion = null
+	string? MappingVersion = null,
+	bool MappingVersionFromAssembly = false
 )
 {
 	public string? FullName => Namespace != null ? $"{Type}-{Dataset}-{Namespace}" : null;

--- a/src/Elastic.Mapping.Generator/Model/TypeMappingModel.cs
+++ b/src/Elastic.Mapping.Generator/Model/TypeMappingModel.cs
@@ -47,7 +47,8 @@ internal sealed record IndexConfigModel(
 	int Shards,
 	int Replicas,
 	string? RefreshInterval,
-	bool Dynamic
+	bool Dynamic,
+	string? MappingVersion = null
 );
 
 /// <summary>
@@ -56,7 +57,8 @@ internal sealed record IndexConfigModel(
 internal sealed record DataStreamConfigModel(
 	string Type,
 	string Dataset,
-	string? Namespace
+	string? Namespace,
+	string? MappingVersion = null
 )
 {
 	public string? FullName => Namespace != null ? $"{Type}-{Dataset}-{Namespace}" : null;

--- a/src/Elastic.Mapping/Attributes/Index/DataStreamAttribute.cs
+++ b/src/Elastic.Mapping/Attributes/Index/DataStreamAttribute.cs
@@ -74,4 +74,17 @@ public sealed class DataStreamAttribute<T> : Attribute where T : class
 	/// </para>
 	/// </summary>
 	public string? Variant { get; init; }
+
+	/// <summary>
+	/// Optional mapping version for version-aware bootstrap guards.
+	/// <para>
+	/// When set, the version is stored in <c>_meta.mapping_version</c> on templates. During
+	/// bootstrap, if the remote template has a higher <c>mapping_version</c> than the local one,
+	/// bootstrap is skipped to prevent an older deployment from overwriting a newer one's templates.
+	/// </para>
+	/// <para>
+	/// When omitted (the default), bootstrap uses hash-only comparison.
+	/// </para>
+	/// </summary>
+	public string? MappingVersion { get; init; }
 }

--- a/src/Elastic.Mapping/Attributes/Index/DataStreamAttribute.cs
+++ b/src/Elastic.Mapping/Attributes/Index/DataStreamAttribute.cs
@@ -84,7 +84,18 @@ public sealed class DataStreamAttribute<T> : Attribute where T : class
 	/// </para>
 	/// <para>
 	/// When omitted (the default), bootstrap uses hash-only comparison.
+	/// Overridden by <see cref="MappingVersionFromAssembly"/> when that is <see langword="true"/>.
 	/// </para>
 	/// </summary>
 	public string? MappingVersion { get; init; }
+
+	/// <summary>
+	/// When <see langword="true"/>, uses the assembly version of the assembly containing the
+	/// mapping context class as the <c>mapping_version</c>. This is resolved at runtime via
+	/// <c>typeof(ContextClass).Assembly.GetName().Version</c>.
+	/// <para>
+	/// Takes precedence over <see cref="MappingVersion"/> when both are set.
+	/// </para>
+	/// </summary>
+	public bool MappingVersionFromAssembly { get; init; }
 }

--- a/src/Elastic.Mapping/Attributes/Index/IndexAttribute.cs
+++ b/src/Elastic.Mapping/Attributes/Index/IndexAttribute.cs
@@ -135,15 +135,28 @@ public sealed class IndexAttribute<T> : Attribute where T : class
 	/// </para>
 	/// <para>
 	/// When omitted (the default), bootstrap uses hash-only comparison.
+	/// Overridden by <see cref="MappingVersionFromAssembly"/> when that is <see langword="true"/>.
 	/// </para>
 	/// <example>
-	/// Use the library version:
+	/// Explicit version:
 	/// <code>[Index&lt;Product&gt;(Name = "products", MappingVersion = "1.0.0")]</code>
-	/// Use your application version:
-	/// <code>[Index&lt;Product&gt;(Name = "products", MappingVersion = "2.3.1")]</code>
 	/// Hash-only (default):
 	/// <code>[Index&lt;Product&gt;(Name = "products")]</code>
 	/// </example>
 	/// </summary>
 	public string? MappingVersion { get; init; }
+
+	/// <summary>
+	/// When <see langword="true"/>, uses the assembly version of the assembly containing the
+	/// mapping context class as the <c>mapping_version</c>. This is resolved at runtime via
+	/// <c>typeof(ContextClass).Assembly.GetName().Version</c>.
+	/// <para>
+	/// Takes precedence over <see cref="MappingVersion"/> when both are set.
+	/// </para>
+	/// <example>
+	/// Use your application's assembly version:
+	/// <code>[Index&lt;Product&gt;(Name = "products", MappingVersionFromAssembly = true)]</code>
+	/// </example>
+	/// </summary>
+	public bool MappingVersionFromAssembly { get; init; }
 }

--- a/src/Elastic.Mapping/Attributes/Index/IndexAttribute.cs
+++ b/src/Elastic.Mapping/Attributes/Index/IndexAttribute.cs
@@ -125,4 +125,25 @@ public sealed class IndexAttribute<T> : Attribute where T : class
 	/// </para>
 	/// </summary>
 	public string? Variant { get; init; }
+
+	/// <summary>
+	/// Optional mapping version for version-aware bootstrap guards.
+	/// <para>
+	/// When set, the version is stored in <c>_meta.mapping_version</c> on templates. During
+	/// bootstrap, if the remote template has a higher <c>mapping_version</c> than the local one,
+	/// bootstrap is skipped to prevent an older deployment from overwriting a newer one's templates.
+	/// </para>
+	/// <para>
+	/// When omitted (the default), bootstrap uses hash-only comparison.
+	/// </para>
+	/// <example>
+	/// Use the library version:
+	/// <code>[Index&lt;Product&gt;(Name = "products", MappingVersion = "1.0.0")]</code>
+	/// Use your application version:
+	/// <code>[Index&lt;Product&gt;(Name = "products", MappingVersion = "2.3.1")]</code>
+	/// Hash-only (default):
+	/// <code>[Index&lt;Product&gt;(Name = "products")]</code>
+	/// </example>
+	/// </summary>
+	public string? MappingVersion { get; init; }
 }

--- a/src/Elastic.Mapping/ElasticsearchTypeContext.cs
+++ b/src/Elastic.Mapping/ElasticsearchTypeContext.cs
@@ -65,7 +65,8 @@ public record ElasticsearchTypeContext(
 	Action<object, DateTimeOffset>? SetLastUpdated = null,
 	string? BatchIndexDateFieldName = null,
 	string? LastUpdatedFieldName = null,
-	IAiEnrichmentProvider? AiEnrichmentProvider = null
+	IAiEnrichmentProvider? AiEnrichmentProvider = null,
+	string? MappingVersion = null
 )
 {
 	// ── Resolve methods ──────────────────────────────────────────────────

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/StrategyFactoryTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/StrategyFactoryTests.cs
@@ -66,6 +66,28 @@ public class StrategyFactoryTests
 			MappedType: typeof(TestDocument)
 		);
 
+	private static ElasticsearchTypeContext CreateIndexContextWithMappingVersion(string version) =>
+		new(
+			() => "{}", () => "{}", () => "{}",
+			"hash", "sh", "mh",
+			new IndexStrategy { WriteTarget = "versioned-docs" },
+			new SearchStrategy(),
+			EntityTarget.Index,
+			MappedType: typeof(TestDocument),
+			MappingVersion: version
+		);
+
+	private static ElasticsearchTypeContext CreateDataStreamContextWithMappingVersion(string version) =>
+		new(
+			() => "{}", () => "{}", () => "{}",
+			"hash", "sh", "mh",
+			new IndexStrategy { Type = "logs", Dataset = "myapp", Namespace = "default", DataStreamName = "logs-myapp-default" },
+			new SearchStrategy(),
+			EntityTarget.DataStream,
+			MappedType: typeof(TestDocument),
+			MappingVersion: version
+		);
+
 	// --- IngestStrategies.ForContext ---
 
 	[Test]
@@ -316,5 +338,42 @@ public class StrategyFactoryTests
 		);
 
 		strategy.Steps.Should().HaveCount(4);
+	}
+
+	// --- MappingVersion propagation ---
+
+	[Test]
+	public void MappingVersionFlowsThroughIndexContext()
+	{
+		var tc = CreateIndexContextWithMappingVersion("2.1.0");
+
+		tc.MappingVersion.Should().Be("2.1.0");
+	}
+
+	[Test]
+	public void MappingVersionFlowsThroughDataStreamContext()
+	{
+		var tc = CreateDataStreamContextWithMappingVersion("1.0.0");
+
+		tc.MappingVersion.Should().Be("1.0.0");
+	}
+
+	[Test]
+	public void MappingVersionDefaultsToNull()
+	{
+		var tc = CreateIndexContext();
+
+		tc.MappingVersion.Should().BeNull(
+			"MappingVersion is not set, so default hash-only behavior applies");
+	}
+
+	[Test]
+	public void MappingVersionPreservedThroughWithNamespace()
+	{
+		var tc = CreateDataStreamContextWithMappingVersion("1.5.0");
+		var withNs = tc.WithNamespace("production");
+
+		withNs.MappingVersion.Should().Be("1.5.0",
+			"WithNamespace should preserve MappingVersion from the original context");
 	}
 }

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/TemplateMetadataTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/TemplateMetadataTests.cs
@@ -1,0 +1,308 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Ingest.Elasticsearch.Strategies;
+using FluentAssertions;
+
+namespace Elastic.Ingest.Elasticsearch.Tests;
+
+public class TemplateMetadataReadMetaTests
+{
+	private const string Envelope = "{\"index_templates\":[{\"index_template\":{\"_meta\":{";
+
+	private static string Meta(string inner) => Envelope + inner + "}}}]}";
+
+	[Test]
+	public void ParsesHashOnly()
+	{
+		var meta = TemplateMetadataHelper.ReadMeta(Meta("\"hash\":\"abc123\""));
+
+		meta.Hash.Should().Be("abc123");
+		meta.MappingVersion.Should().BeNull();
+	}
+
+	[Test]
+	public void ParsesHashAndMappingVersion()
+	{
+		var meta = TemplateMetadataHelper.ReadMeta(
+			Meta("\"hash\":\"abc123\",\"mapping_version\":\"2.0.0\""));
+
+		meta.Hash.Should().Be("abc123");
+		meta.MappingVersion.Should().Be("2.0.0");
+	}
+
+	[Test]
+	public void ParsesMappingVersionOnly()
+	{
+		var meta = TemplateMetadataHelper.ReadMeta(Meta("\"mapping_version\":\"1.5.0\""));
+
+		meta.Hash.Should().BeNull();
+		meta.MappingVersion.Should().Be("1.5.0");
+	}
+
+	[Test]
+	public void ParsesMappingVersionBeforeHash()
+	{
+		var meta = TemplateMetadataHelper.ReadMeta(
+			Meta("\"mapping_version\":\"3.0.0\",\"hash\":\"def456\""));
+
+		meta.Hash.Should().Be("def456");
+		meta.MappingVersion.Should().Be("3.0.0");
+	}
+
+	[Test]
+	public void ReturnsEmptyForEmptyString()
+	{
+		var meta = TemplateMetadataHelper.ReadMeta("");
+		meta.Should().Be(TemplateMetadata.Empty);
+	}
+
+	[Test]
+	public void ReturnsEmptyForMalformedJson()
+	{
+		var meta = TemplateMetadataHelper.ReadMeta("{not valid json at all}");
+		meta.Should().Be(TemplateMetadata.Empty);
+	}
+
+	[Test]
+	public void ReturnsEmptyForWrongPrefix()
+	{
+		var meta = TemplateMetadataHelper.ReadMeta("{\"something_else\":[]}");
+		meta.Should().Be(TemplateMetadata.Empty);
+	}
+
+	[Test]
+	public void ReturnsEmptyForEmptyMeta()
+	{
+		var meta = TemplateMetadataHelper.ReadMeta(Meta(""));
+
+		meta.Hash.Should().BeNull();
+		meta.MappingVersion.Should().BeNull();
+	}
+
+	[Test]
+	public void HandlesEmptyHashValue()
+	{
+		var meta = TemplateMetadataHelper.ReadMeta(Meta("\"hash\":\"\""));
+
+		meta.Hash.Should().Be("");
+	}
+}
+
+public class TemplateMetadataShouldSkipBootstrapTests
+{
+	// ── Hash-only mode (localMappingVersion = null) ─────────────────────
+
+	[Test]
+	public void HashOnlyHashMatchesSkips()
+	{
+		var remote = new TemplateMetadata("abc123", null);
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "abc123", null)
+			.Should().BeTrue("hash matches and no version guard is active");
+	}
+
+	[Test]
+	public void HashOnlyHashDiffersProceeds()
+	{
+		var remote = new TemplateMetadata("abc123", null);
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "different", null)
+			.Should().BeFalse("hash differs and no version guard is active");
+	}
+
+	[Test]
+	public void HashOnlyRemoteHashNullProceeds()
+	{
+		var remote = new TemplateMetadata(null, null);
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "abc123", null)
+			.Should().BeFalse("remote has no hash");
+	}
+
+	[Test]
+	public void HashOnlyRemoteHashEmptyProceeds()
+	{
+		var remote = new TemplateMetadata("", null);
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "abc123", null)
+			.Should().BeFalse("remote hash is empty");
+	}
+
+	[Test]
+	public void HashOnlyRemoteIsEmptyProceeds()
+	{
+		TemplateMetadataHelper.ShouldSkipBootstrap(TemplateMetadata.Empty, "abc123", null)
+			.Should().BeFalse("remote metadata is empty");
+	}
+
+	// ── Version guard (localMappingVersion is set) ──────────────────────
+
+	[Test]
+	public void VersionGuardRemoteNewerSkips()
+	{
+		var remote = new TemplateMetadata("different_hash", "2.0.0");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "local_hash", "1.0.0")
+			.Should().BeTrue("remote version 2.0.0 > local version 1.0.0, don't downgrade");
+	}
+
+	[Test]
+	public void VersionGuardRemoteNewerPatchSkips()
+	{
+		var remote = new TemplateMetadata("different_hash", "1.0.1");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "local_hash", "1.0.0")
+			.Should().BeTrue("remote patch version 1.0.1 > local 1.0.0");
+	}
+
+	[Test]
+	public void VersionGuardRemoteNewerMajorSkips()
+	{
+		var remote = new TemplateMetadata("different_hash", "3.0.0");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "local_hash", "1.5.2")
+			.Should().BeTrue("remote major version 3.0.0 > local 1.5.2");
+	}
+
+	[Test]
+	public void VersionGuardSameVersionHashMatchesSkips()
+	{
+		var remote = new TemplateMetadata("abc123", "1.0.0");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "abc123", "1.0.0")
+			.Should().BeTrue("same version and hash matches");
+	}
+
+	[Test]
+	public void VersionGuardSameVersionHashDiffersProceeds()
+	{
+		var remote = new TemplateMetadata("old_hash", "1.0.0");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "new_hash", "1.0.0")
+			.Should().BeFalse("same version but hash differs — templates changed");
+	}
+
+	[Test]
+	public void VersionGuardLocalNewerHashDiffersProceeds()
+	{
+		var remote = new TemplateMetadata("old_hash", "1.0.0");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "new_hash", "2.0.0")
+			.Should().BeFalse("local is newer and hash differs — upgrade");
+	}
+
+	[Test]
+	public void LocalNewerVersionHashMatchesStillSkips()
+	{
+		var remote = new TemplateMetadata("same_hash", "1.0.0");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "same_hash", "2.0.0")
+			.Should().BeTrue("hash still matches even though versions differ");
+	}
+
+	[Test]
+	public void RemoteHasNoVersionFallsBackToHashAndMatches()
+	{
+		var remote = new TemplateMetadata("abc123", null);
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "abc123", "1.0.0")
+			.Should().BeTrue("remote has no version, but hash matches");
+	}
+
+	[Test]
+	public void RemoteHasNoVersionFallsBackToHashAndDiffers()
+	{
+		var remote = new TemplateMetadata("old_hash", null);
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "new_hash", "1.0.0")
+			.Should().BeFalse("remote has no version and hash differs");
+	}
+
+	[Test]
+	public void UnparseableRemoteVersionFallsBackToHash()
+	{
+		var remote = new TemplateMetadata("abc123", "not-a-version");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "abc123", "1.0.0")
+			.Should().BeTrue("unparseable remote version, falls back to hash which matches");
+	}
+
+	[Test]
+	public void UnparseableLocalVersionFallsBackToHash()
+	{
+		var remote = new TemplateMetadata("different", "2.0.0");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "different", "bad-version")
+			.Should().BeTrue("unparseable local version, falls back to hash which matches");
+	}
+
+	[Test]
+	public void BothVersionsUnparseableFallsBackToHash()
+	{
+		var remote = new TemplateMetadata("different_hash", "alpha");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "local_hash", "beta")
+			.Should().BeFalse("both versions unparseable, hashes differ");
+	}
+
+	[Test]
+	public void ThreePartVsFourPartVersionComparesCorrectly()
+	{
+		var remote = new TemplateMetadata("different", "1.0.0.1");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "local_hash", "1.0.0")
+			.Should().BeTrue("1.0.0.1 > 1.0.0");
+	}
+
+	[Test]
+	public void FourPartVersionEqualDoesNotSkipOnHashMismatch()
+	{
+		var remote = new TemplateMetadata("different", "1.0.0.0");
+		TemplateMetadataHelper.ShouldSkipBootstrap(remote, "local_hash", "1.0.0.0")
+			.Should().BeFalse("versions equal, hashes differ");
+	}
+
+	// ── Rolling deployment scenario ─────────────────────────────────────
+
+	[Test]
+	public void OlderPodDoesNotOverwriteNewerTemplates()
+	{
+		// Version N deployed and updated templates
+		var remoteAfterVersionN = new TemplateMetadata("hash_from_v2", "2.0.0");
+
+		// Version N-1 pod restarts, sees different hash
+		var localHashFromV1 = "hash_from_v1";
+		var localVersionV1 = "1.0.0";
+
+		TemplateMetadataHelper.ShouldSkipBootstrap(remoteAfterVersionN, localHashFromV1, localVersionV1)
+			.Should().BeTrue("N-1 pod must not overwrite N's templates");
+	}
+
+	[Test]
+	public void NewerPodCanUpgradeTemplates()
+	{
+		// Version N-1 templates are on the cluster
+		var remoteBeforeUpgrade = new TemplateMetadata("hash_from_v1", "1.0.0");
+
+		// Version N pod deploys with updated mappings
+		var localHashFromV2 = "hash_from_v2";
+		var localVersionV2 = "2.0.0";
+
+		TemplateMetadataHelper.ShouldSkipBootstrap(remoteBeforeUpgrade, localHashFromV2, localVersionV2)
+			.Should().BeFalse("newer pod should upgrade the templates");
+	}
+}
+
+public class TemplateMetadataBuildMappingVersionFragmentTests
+{
+	[Test]
+	public void NullInputReturnsEmptyString()
+	{
+		TemplateMetadataHelper.BuildMappingVersionFragment(null)
+			.Should().BeEmpty();
+	}
+
+	[Test]
+	public void NonNullInputReturnsJsonFragment()
+	{
+		var fragment = TemplateMetadataHelper.BuildMappingVersionFragment("1.2.3");
+
+		fragment.Should().Contain("\"mapping_version\"");
+		fragment.Should().Contain("\"1.2.3\"");
+		fragment.Should().StartWith(",", "fragment is appended after existing _meta fields");
+	}
+
+	[Test]
+	public void DifferentVersionsProduceDifferentFragments()
+	{
+		var f1 = TemplateMetadataHelper.BuildMappingVersionFragment("1.0.0");
+		var f2 = TemplateMetadataHelper.BuildMappingVersionFragment("2.0.0");
+
+		f1.Should().NotBe(f2);
+	}
+}

--- a/tests/Elastic.Mapping.Tests/MappingVersionTests.cs
+++ b/tests/Elastic.Mapping.Tests/MappingVersionTests.cs
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Mapping.Tests;
+
+/// <summary>
+/// Tests that the MappingVersion attribute property is correctly wired through the
+/// source generator into <see cref="ElasticsearchTypeContext.MappingVersion"/>.
+/// </summary>
+public class MappingVersionTests
+{
+	[Test]
+	public void IndexWithMappingVersion_FlowsToContext()
+	{
+		var ctx = VersionedMappingContext.SimpleDocument.Context;
+
+		ctx.MappingVersion.Should().Be("3.2.1");
+	}
+
+	[Test]
+	public void DataStreamWithMappingVersion_FlowsToContext()
+	{
+		var ctx = VersionedMappingContext.SimpleDocumentVersioned.Context;
+
+		ctx.MappingVersion.Should().Be("1.0.0");
+	}
+
+	[Test]
+	public void IndexWithoutMappingVersion_IsNull()
+	{
+		var ctx = VersionedMappingContext.SimpleDocumentUnversioned.Context;
+
+		ctx.MappingVersion.Should().BeNull(
+			"MappingVersion was not set on the attribute, so it defaults to null (hash-only)");
+	}
+
+	[Test]
+	public void VersionedAndUnversioned_HaveSameMappedType()
+	{
+		var versioned = VersionedMappingContext.SimpleDocument.Context;
+		var unversioned = VersionedMappingContext.SimpleDocumentUnversioned.Context;
+
+		versioned.MappedType.Should().Be<SimpleDocument>();
+		unversioned.MappedType.Should().Be<SimpleDocument>();
+	}
+
+	[Test]
+	public void VersionedIndex_HasExpectedEntityTarget()
+	{
+		var ctx = VersionedMappingContext.SimpleDocument.Context;
+
+		ctx.EntityTarget.Should().Be(EntityTarget.Index);
+		ctx.IndexStrategy!.WriteTarget.Should().Be("versioned-index");
+	}
+
+	[Test]
+	public void VersionedDataStream_HasExpectedEntityTarget()
+	{
+		var ctx = VersionedMappingContext.SimpleDocumentVersioned.Context;
+
+		ctx.EntityTarget.Should().Be(EntityTarget.DataStream);
+		ctx.IndexStrategy!.Type.Should().Be("logs");
+		ctx.IndexStrategy!.Dataset.Should().Be("versioned");
+	}
+}

--- a/tests/Elastic.Mapping.Tests/MappingVersionTests.cs
+++ b/tests/Elastic.Mapping.Tests/MappingVersionTests.cs
@@ -63,4 +63,36 @@ public class MappingVersionTests
 		ctx.IndexStrategy!.Type.Should().Be("logs");
 		ctx.IndexStrategy!.Dataset.Should().Be("versioned");
 	}
+
+	[Test]
+	public void AssemblyVersionIndex_ResolvesFromAssembly()
+	{
+		var ctx = VersionedMappingContext.SimpleDocumentAssemblyVersioned.Context;
+
+		ctx.MappingVersion.Should().NotBeNull(
+			"MappingVersionFromAssembly = true should resolve the assembly version at runtime");
+
+		// The test assembly has a version — verify it parses as a valid System.Version
+		System.Version.TryParse(ctx.MappingVersion, out var parsed).Should().BeTrue(
+			$"'{ctx.MappingVersion}' should be a valid System.Version");
+		parsed.Should().NotBeNull();
+	}
+
+	[Test]
+	public void AssemblyVersionDataStream_ResolvesFromAssembly()
+	{
+		var ctx = VersionedMappingContext.SimpleDocumentAssemblyVersionedDs.Context;
+
+		ctx.MappingVersion.Should().NotBeNull(
+			"MappingVersionFromAssembly = true should resolve the assembly version at runtime");
+	}
+
+	[Test]
+	public void AssemblyVersionMatchesTestAssemblyVersion()
+	{
+		var ctx = VersionedMappingContext.SimpleDocumentAssemblyVersioned.Context;
+
+		var expectedVersion = typeof(VersionedMappingContext).Assembly.GetName().Version?.ToString();
+		ctx.MappingVersion.Should().Be(expectedVersion);
+	}
 }

--- a/tests/Elastic.Mapping.Tests/TestModels.cs
+++ b/tests/Elastic.Mapping.Tests/TestModels.cs
@@ -1102,3 +1102,14 @@ public static partial class TemplatedMergeTestMappingContext
 			.Tokenizer(BuiltInAnalysis.Tokenizers.Standard)
 			.Filters(BuiltInAnalysis.TokenFilters.Lowercase));
 }
+
+// ============================================================================
+// VERSIONED MAPPING CONTEXT: tests MappingVersion attribute on Index and DataStream
+// ============================================================================
+
+[ElasticsearchMappingContext]
+[Index<SimpleDocument>(Name = "versioned-index", MappingVersion = "3.2.1")]
+[DataStream<SimpleDocument>(Type = "logs", Dataset = "versioned", Namespace = "test",
+	MappingVersion = "1.0.0", Variant = "Versioned")]
+[Index<SimpleDocument>(Name = "unversioned-index", Variant = "Unversioned")]
+public static partial class VersionedMappingContext;

--- a/tests/Elastic.Mapping.Tests/TestModels.cs
+++ b/tests/Elastic.Mapping.Tests/TestModels.cs
@@ -1112,4 +1112,7 @@ public static partial class TemplatedMergeTestMappingContext
 [DataStream<SimpleDocument>(Type = "logs", Dataset = "versioned", Namespace = "test",
 	MappingVersion = "1.0.0", Variant = "Versioned")]
 [Index<SimpleDocument>(Name = "unversioned-index", Variant = "Unversioned")]
+[Index<SimpleDocument>(Name = "asm-versioned-index", MappingVersionFromAssembly = true, Variant = "AssemblyVersioned")]
+[DataStream<SimpleDocument>(Type = "logs", Dataset = "asm-versioned", Namespace = "test",
+	MappingVersionFromAssembly = true, Variant = "AssemblyVersionedDs")]
 public static partial class VersionedMappingContext;


### PR DESCRIPTION
## Summary

During rolling deployments, a pod running version N can upgrade index templates with new mappings, but a pod still on version N-1 that restarts will see a different hash and re-bootstrap — **overwriting version N's templates** with older mappings. This PR adds an opt-in `MappingVersion` guard to prevent that.

## What changed

A new `_meta.mapping_version` field is introduced alongside the existing `_meta.hash`. When configured, bootstrap compares versions before proceeding: if the remote template was deployed by a **newer** version, the older pod refuses to bootstrap.

**This is fully opt-in.** When `MappingVersion` is not set (the default), behavior is identical to today — pure hash-based comparison.

The existing `_meta.assembly_version` is **untouched** — it remains `LibraryVersion.Current` and is purely informational.

## How to set it up

### Option 1: Use your assembly version (easiest)

Set `MappingVersionFromAssembly = true` on your attribute. The source generator emits code that reads your assembly version at runtime, so it automatically tracks your project's `<Version>` MSBuild property:

```csharp
[Index<Product>(Name = "products", MappingVersionFromAssembly = true)]

[DataStream<LogEntry>(Type = "logs", Dataset = "myapp", MappingVersionFromAssembly = true)]
```

This resolves `typeof(YourMappingContext).Assembly.GetName().Version` at runtime — no hardcoded strings.

### Option 2: Explicit version string

Pin to a specific version. Bump it when you release mapping changes:

```csharp
[Index<Product>(Name = "products", MappingVersion = "1.0.0")]

[DataStream<LogEntry>(Type = "logs", Dataset = "myapp", MappingVersion = "2.1.0")]
```

If both are set, `MappingVersionFromAssembly` takes precedence.

### Option 3: Programmatic (no attributes)

Override a source-generated context or set it directly:

```csharp
// Use record 'with' expression to override
var appVersion = typeof(MyMappingContext).Assembly.GetName().Version?.ToString();
var context = MyMappingContext.Product.Context with { MappingVersion = appVersion };
var options = new IngestChannelOptions<Product>(transport, context);

// Or set on BootstrapContext for custom strategies
var bootstrapContext = new BootstrapContext
{
    Transport = transport,
    BootstrapMethod = BootstrapMethod.Failure,
    TemplateName = "my-template",
    TemplateWildcard = "my-index-*",
    MappingVersion = "1.2.0"
};
```

### Default: hash-only (no change needed)

```csharp
[Index<Product>(Name = "products")]
```

Omit `MappingVersion` entirely. Templates are updated whenever the hash changes, regardless of which version is deploying. This is the existing behavior — nothing changes for existing users.

## When should you use this?

- **Rolling deployments** where pods with different code versions share the same Elasticsearch cluster
- **Canary deployments** where a new version upgrades mappings but old pods may still restart
- **Blue/green deployments** where you want the newer version's templates to stick

You do **not** need this if:
- All pods always run the same version
- You manage templates externally (e.g. via Terraform/Pulumi)
- You use `BootstrapMethod.None`

## How the decision logic works

Bootstrap is skipped when **either** condition is met:

| Remote version vs local | Hash | Result |
|------------------------|------|--------|
| Remote **newer** than local | _any_ | **Skip** — don't downgrade |
| Equal or local newer | **Matches** | **Skip** — nothing changed |
| Equal or local newer | **Differs** | **Proceed** — templates changed, upgrade |
| Remote has no version | **Matches** | **Skip** — hash says nothing changed |
| Remote has no version | **Differs** | **Proceed** — hash says templates changed |

Bootstrap only proceeds when the hash differs **and** the remote version is not newer. This is the key protection: an older pod sees a different hash (because its mappings are older) but also sees that the remote version is higher, so it backs off.

## What's in the `_meta`

```json
{
  "_meta": {
    "description": "Template installed by .NET ingest libraries ...",
    "assembly_version": "0.11.0",
    "hash": "abc123def456...",
    "mapping_version": "1.0.0"
  }
}
```

- `assembly_version` — always the library version, informational only (unchanged)
- `hash` — content hash of settings + mappings (unchanged)
- `mapping_version` — **new**, only present when `MappingVersion` or `MappingVersionFromAssembly` is configured

## Implementation details

- New `TemplateMetadataHelper` consolidates all `_meta` parsing and comparison logic (was duplicated across 5 files)
- `filter_path` now requests both `hash` and `mapping_version` in a single GET
- Source generator wires `MappingVersion` / `MappingVersionFromAssembly` from attributes through `IndexConfigModel`/`DataStreamConfigModel` into `ElasticsearchTypeContext`
- `MappingVersionFromAssembly = true` emits `typeof(ContextClass).Assembly.GetName().Version?.ToString()` in generated code
- 46 new unit tests covering the full decision matrix, edge cases, rolling deployment scenarios, and assembly version resolution

## Files changed

| Area | Files |
|------|-------|
| Core logic | `TemplateMetadata.cs` (new), `BootstrapContext.cs` |
| Bootstrap steps | `IndexTemplateStep.cs`, `DataStreamTemplateStep.cs`, `ComponentTemplateStep.cs` |
| Provisioning | `HashBasedReuseProvisioning.cs` |
| Legacy path | `IngestChannelBase.Bootstrap.cs`, `CatalogIndexChannel.cs` |
| Channel wiring | `IngestChannel.cs` |
| Orchestrators | `IncrementalSyncOrchestrator.cs`, `DeltaSyncOrchestrator.cs` |
| Attributes | `IndexAttribute.cs`, `DataStreamAttribute.cs` |
| Type context | `ElasticsearchTypeContext.cs` |
| Source generator | `ContextEmitter.cs`, `MappingSourceGenerator.cs`, `TypeMappingModel.cs` |
| Tests | `TemplateMetadataTests.cs` (new), `MappingVersionTests.cs` (new), `StrategyFactoryTests.cs`, `TestModels.cs` |
| Docs | `docs/strategies/bootstrap.md` |