### PR TITLE
docs: add Elastic.Mapping documentation section

### DIFF
--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -4,6 +4,7 @@ cross_links:
 toc:
   - file: index.md
   - toc: getting-started
+  - toc: mapping
   - toc: channels
   - toc: architecture
   - toc: index-management

--- a/docs/_docset.yml
+++ b/docs/_docset.yml
@@ -3,6 +3,7 @@ cross_links:
   - elasticsearch
 toc:
   - file: index.md
+  - file: ai-enrichment.md
   - toc: getting-started
   - toc: mapping
   - toc: channels

--- a/docs/getting-started/toc.yml
+++ b/docs/getting-started/toc.yml
@@ -1,3 +1,4 @@
 toc:
   - file: index.md
   - file: mapping-context.md
+  - file: templated-index-names.md

--- a/docs/mapping/analysis.md
+++ b/docs/mapping/analysis.md
@@ -1,0 +1,237 @@
+---
+navigation_title: Analysis configuration
+---
+
+# Analysis configuration
+
+Custom analysis (analyzers, tokenizers, token filters, character filters, and normalizers) is configured through the `AnalysisBuilder` fluent API inside your `ConfigureAnalysis` method.
+
+:::{tip}
+When you define custom analysis components, the source generator emits strongly-typed accessor classes so you can reference them without magic strings. See [strongly-typed analysis names](strongly-typed-analysis-names.md).
+:::
+
+## AnalysisBuilder fluent API
+
+`AnalysisBuilder` provides five registration methods, one per analysis component category:
+
+```csharp
+public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+    analysis
+        .Analyzer("my_analyzer", a => a
+            .Custom()
+            .Tokenizer("standard")
+            .Filters("lowercase", "asciifolding", "my_stop"))
+        .Tokenizer("my_tokenizer", t => t
+            .EdgeNGram()
+            .MinGram(2)
+            .MaxGram(20))
+        .TokenFilter("my_stop", f => f
+            .Stop()
+            .StopWords("_english_"))
+        .CharFilter("my_char_filter", c => c
+            .PatternReplace()
+            .Pattern("[^\\w\\s]")
+            .Replacement(""))
+        .Normalizer("my_normalizer", n => n
+            .Custom()
+            .Filters("lowercase", "asciifolding"));
+```
+
+Each method takes a name (the Elasticsearch component name) and a configuration lambda.
+
+## Analyzer types
+
+### Custom analyzer
+
+The most common type. Composes a tokenizer with optional char filters and token filters:
+
+```csharp
+.Analyzer("english_html", a => a
+    .Custom()
+    .CharFilters("html_strip")
+    .Tokenizer("standard")
+    .Filters("lowercase", "english_stop", "english_stemmer"))
+```
+
+:::{dropdown} Other analyzer types
+**Standard analyzer (with options)**
+
+```csharp
+.Analyzer("my_standard", a => a
+    .Standard()
+    .MaxTokenLength(255)
+    .StopWords("_english_"))
+```
+
+**Pattern analyzer**
+
+```csharp
+.Analyzer("email_parts", a => a
+    .Pattern()
+    .Pattern("[.@]")
+    .Lowercase(true))
+```
+:::
+
+## Tokenizer types
+
+```csharp
+// Edge NGram (autocomplete)
+.Tokenizer("autocomplete", t => t
+    .EdgeNGram()
+    .MinGram(1)
+    .MaxGram(20)
+    .TokenChars("letter", "digit"))
+
+// Pattern
+.Tokenizer("comma_split", t => t
+    .Pattern()
+    .Pattern(",\\s*"))
+```
+
+:::{dropdown} More tokenizer types
+```csharp
+// NGram
+.Tokenizer("trigram", t => t
+    .NGram()
+    .MinGram(3)
+    .MaxGram(3)
+    .TokenChars("letter", "digit"))
+
+// Path hierarchy
+.Tokenizer("file_path", t => t
+    .PathHierarchy()
+    .Delimiter('/'))
+```
+:::
+
+## Token filter types
+
+```csharp
+// Stop words
+.TokenFilter("english_stop", f => f
+    .Stop()
+    .StopWords("_english_"))
+
+// Stemmer
+.TokenFilter("english_stemmer", f => f
+    .Stemmer()
+    .Language("english"))
+
+// Synonym graph
+.TokenFilter("product_synonyms", f => f
+    .SynonymGraph()
+    .Synonyms("laptop, notebook, portable computer", "phone, mobile, cell"))
+```
+
+:::{dropdown} More token filter types
+```csharp
+// Shingle (word n-grams)
+.TokenFilter("bigrams", f => f
+    .Shingle()
+    .MinShingleSize(2)
+    .MaxShingleSize(2)
+    .OutputUnigrams(false))
+
+// Edge NGram (as filter)
+.TokenFilter("autocomplete_filter", f => f
+    .EdgeNGram()
+    .MinGram(1)
+    .MaxGram(20))
+```
+:::
+
+## Character filters
+
+```csharp
+// Pattern replace
+.CharFilter("strip_special", c => c
+    .PatternReplace()
+    .Pattern("[^a-zA-Z0-9\\s]")
+    .Replacement(""))
+
+// Mapping
+.CharFilter("emoticons", c => c
+    .Mapping()
+    .Mappings(":) => happy", ":( => sad"))
+```
+
+## Normalizers
+
+Normalizers apply to `keyword` fields for case-insensitive exact matching:
+
+```csharp
+.Normalizer("lowercase_normalizer", n => n
+    .Custom()
+    .Filters("lowercase", "asciifolding"))
+```
+
+Reference it from the attribute: `[Keyword(Normalizer = "lowercase_normalizer")]`
+
+## Built-in analysis constants
+
+The `BuiltInAnalysis` class provides compile-time constants for all standard Elasticsearch analysis components:
+
+```csharp
+using Elastic.Mapping.Analysis;
+
+.Analyzer("my_analyzer", a => a
+    .Custom()
+    .Tokenizer(BuiltInAnalysis.Tokenizers.Standard)
+    .Filters(BuiltInAnalysis.TokenFilters.Lowercase, BuiltInAnalysis.TokenFilters.AsciiFolding))
+```
+
+:::{dropdown} Available constant groups
+| Class | Examples |
+|-------|----------|
+| `BuiltInAnalysis.Analyzers` | `Standard`, `Simple`, `Whitespace`, `Stop`, `Keyword`, `Pattern`, `Fingerprint` |
+| `BuiltInAnalysis.Analyzers.Language` | `English`, `French`, `German`, `Spanish`, `Cjk` (30+ languages) |
+| `BuiltInAnalysis.Tokenizers` | `Standard`, `Letter`, `Whitespace`, `NGram`, `EdgeNGram`, `PathHierarchy`, `Pattern` |
+| `BuiltInAnalysis.TokenFilters` | `Lowercase`, `Uppercase`, `AsciiFolding`, `Stop`, `Stemmer`, `Snowball`, `Synonym`, `SynonymGraph`, `NGram`, `EdgeNGram`, `Shingle` (40+) |
+| `BuiltInAnalysis.CharFilters` | `HtmlStrip`, `Mapping`, `PatternReplace`, `IcuNormalizer` |
+| `BuiltInAnalysis.StopWords` | `English`, `French`, `German` (language-specific stop word lists) |
+| `BuiltInAnalysis.StemmerLanguages` | `English`, `LightEnglish`, `Porter2`, `French`, `LightFrench` (50+ variants) |
+:::
+
+## Using strongly-typed analysis names in mappings
+
+When you define custom analysis, the source generator emits accessor classes that provide compile-time verified names. Use these in your `ConfigureMappings` instead of raw strings:
+
+```csharp
+public class ProductConfig : IConfigureElasticsearch<Product>
+{
+    public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+        analysis
+            .Analyzer("product_name_analyzer", a => a.Custom().Tokenizer("standard").Filters("lowercase"))
+            .Normalizer("lowercase_normalizer", n => n.Custom().Filters("lowercase"));
+
+    public MappingsBuilder<Product> ConfigureMappings(MappingsBuilder<Product> mappings) =>
+        mappings
+            // Use the generated accessor instead of a string literal
+            .Name(f => f.Analyzer(ProductAnalysis.Analyzers.ProductNameAnalyzer))
+            .Category(f => f.Normalizer(ProductAnalysis.Normalizers.LowercaseNormalizer));
+
+    public IReadOnlyDictionary<string, string>? IndexSettings => null;
+}
+```
+
+A typo in the property name is now a compile error rather than a runtime failure. See [strongly-typed analysis names](strongly-typed-analysis-names.md) for the full reference on generated accessors, base-type anchoring, and how delegation following works.
+
+## Merging analysis from other types
+
+Use `AnalysisBuilder.Merge` to include another type's analysis components:
+
+```csharp
+public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+    analysis
+        .Analyzer("local_analyzer", a => a.Custom().Tokenizer("standard").Filters("lowercase"))
+        .Merge<OtherDocument>(OtherContext.OtherDocument);
+```
+
+Names already defined on the current builder are never overwritten. See [mapping merge](merge-strategies.md) for the complete reference.
+
+## How analysis flows to Elasticsearch
+
+1. **Compile time**: The source generator parses your `ConfigureAnalysis` method and stores a delegate reference in the generated context.
+2. **Runtime (bootstrap)**: The channel invokes the delegate, builds `AnalysisSettings`, and merges the result into the base settings JSON.
+3. **Push**: The merged settings JSON (including `"analysis": { ... }`) is sent to Elasticsearch as part of the component template.

--- a/docs/mapping/code-driven-mappings.md
+++ b/docs/mapping/code-driven-mappings.md
@@ -1,0 +1,156 @@
+---
+navigation_title: Code-driven mappings
+---
+
+# Code-driven mappings
+
+Field attributes handle most mapping declarations. For custom analyzers, runtime fields, dynamic templates, or field overrides, implement `IConfigureElasticsearch<T>`.
+
+## The IConfigureElasticsearch interface
+
+```csharp
+public interface IConfigureElasticsearch<TDocument> where TDocument : class
+{
+    AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis);
+    MappingsBuilder<TDocument> ConfigureMappings(MappingsBuilder<TDocument> mappings);
+    IReadOnlyDictionary<string, string>? IndexSettings { get; }
+}
+```
+
+| Member | What it produces |
+|--------|-----------------|
+| `ConfigureAnalysis` | Custom analyzers, tokenizers, filters merged into the settings component template |
+| `ConfigureMappings` | Field overrides, dynamic templates, runtime fields merged into the mappings component template |
+| `IndexSettings` | Additional key-value pairs in the settings JSON (e.g. `index.default_pipeline`) |
+
+## Priority resolution
+
+The source generator discovers configuration using this priority chain (first match wins):
+
+| Priority | Source |
+|----------|--------|
+| 1 (highest) | Configuration class specified via `Configuration = typeof(...)` on the target attribute |
+| 2 (lowest) | The document type itself implementing `IConfigureElasticsearch<T>` |
+
+## Configuration class
+
+:::{tip}
+This is the recommended approach. It keeps your document type clean and allows reuse across multiple contexts.
+:::
+
+Reference a dedicated configuration class via the `Configuration` property on the target attribute:
+
+```csharp
+[ElasticsearchMappingContext]
+[Index<Product>(Name = "products", Configuration = typeof(ProductConfig))]
+public static partial class MyContext;
+
+public class ProductConfig : IConfigureElasticsearch<Product>
+{
+    public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+        analysis
+            .Analyzer("product_name_analyzer", a => a
+                .Custom()
+                .Tokenizer("standard")
+                .Filters("lowercase", "asciifolding"))
+            .Normalizer("lowercase_normalizer", n => n
+                .Custom()
+                .Filters("lowercase"));
+
+    public MappingsBuilder<Product> ConfigureMappings(MappingsBuilder<Product> mappings) =>
+        mappings.Name(f => f.Analyzer("product_name_analyzer"));
+
+    public IReadOnlyDictionary<string, string>? IndexSettings =>
+        new Dictionary<string, string>
+        {
+            ["index.default_pipeline"] = "product-enrichment"
+        };
+}
+```
+
+## Self-configuring entity
+
+The document type can implement the interface directly when configuration is inherent to the type:
+
+```csharp
+public class LogEntry : IConfigureElasticsearch<LogEntry>
+{
+    [Timestamp]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [Text]
+    public string Message { get; set; }
+
+    [Keyword]
+    public string Level { get; set; }
+
+    public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+        analysis
+            .Analyzer("log_message_analyzer", a => a
+                .Custom()
+                .Tokenizer("standard")
+                .Filters("lowercase", "stop"));
+
+    public MappingsBuilder<LogEntry> ConfigureMappings(MappingsBuilder<LogEntry> mappings) =>
+        mappings.Message(f => f.Analyzer("log_message_analyzer"));
+
+    public IReadOnlyDictionary<string, string>? IndexSettings => null;
+}
+```
+
+## Generated MappingsBuilder extensions
+
+The source generator emits strongly-typed extension methods for each property on your document type. These let you override field settings without using strings:
+
+```csharp
+public MappingsBuilder<Product> ConfigureMappings(MappingsBuilder<Product> mappings) =>
+    mappings
+        .Name(f => f.Analyzer("product_name_analyzer"))
+        .Category(f => f.Normalizer("lowercase_normalizer"))
+        .Description(f => f.Analyzer("english").SearchAnalyzer("english"));
+```
+
+Each generated method corresponds to a property on the document class.
+
+## Delegating to shared factories
+
+Configuration classes can delegate to shared factory methods. The source generator follows the call graph to discover analysis component names:
+
+```csharp
+public static class SharedAnalysisFactory
+{
+    public static AnalysisBuilder BuildStandardAnalysis(AnalysisBuilder analysis) =>
+        analysis
+            .Normalizer("keyword_normalizer", n => n.Custom().Filters("lowercase"))
+            .Analyzer("starts_with_analyzer", a => a
+                .Custom()
+                .Tokenizer("starts_with_tokenizer")
+                .Filters("lowercase"))
+            .Tokenizer("starts_with_tokenizer", t => t
+                .EdgeNGram()
+                .MinGram(1)
+                .MaxGram(20));
+}
+
+public class ProductConfig : IConfigureElasticsearch<Product>
+{
+    public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+        SharedAnalysisFactory.BuildStandardAnalysis(analysis);
+
+    public MappingsBuilder<Product> ConfigureMappings(MappingsBuilder<Product> mappings) => mappings;
+    public IReadOnlyDictionary<string, string>? IndexSettings => null;
+}
+```
+
+The generator traces calls transitively and emits strongly-typed accessors for all discovered names. See [strongly-typed analysis names](strongly-typed-analysis-names.md) for details.
+
+## Variants with separate configurations
+
+When using `Variant` to register the same document type multiple times, each variant can have its own configuration class:
+
+```csharp
+[ElasticsearchMappingContext]
+[Index<Article>(Name = "articles-lexical", Configuration = typeof(ArticleLexicalConfig))]
+[Index<Article>(Name = "articles-semantic", Variant = "Semantic", Configuration = typeof(ArticleSemanticConfig))]
+public static partial class ArticleContext;
+```

--- a/docs/mapping/dynamic-templates.md
+++ b/docs/mapping/dynamic-templates.md
@@ -1,0 +1,119 @@
+---
+navigation_title: Dynamic templates
+---
+
+# Dynamic templates
+
+Dynamic templates define catch-all rules for fields not explicitly declared on your document type. When Elasticsearch encounters a field name matching the template's pattern, it applies the specified mapping instead of the default dynamic behavior.
+
+## Adding dynamic templates
+
+Use `AddDynamicTemplate` on `MappingsBuilder<T>` in your `ConfigureMappings` method:
+
+```csharp
+public MappingsBuilder<LogEntry> ConfigureMappings(MappingsBuilder<LogEntry> mappings) =>
+    mappings
+        .AddDynamicTemplate("strings_as_keywords", t => t
+            .MatchMappingType("string")
+            .Mapping(f => f.Keyword()))
+        .AddDynamicTemplate("labels_as_keywords", t => t
+            .PathMatch("labels.*")
+            .Mapping(f => f.Keyword()));
+```
+
+## DynamicTemplateBuilder API
+
+| Method | Description |
+|--------|-------------|
+| `Match(string)` | Matches field names using a simple pattern (supports `*` wildcard) |
+| `Unmatch(string)` | Excludes field names matching this pattern |
+| `PathMatch(string)` | Matches full dotted field paths (e.g. `labels.*`) |
+| `PathUnmatch(string)` | Excludes dotted field paths matching this pattern |
+| `MatchMappingType(string)` | Matches fields by detected JSON type (`string`, `long`, `double`, `boolean`, `date`, `object`) |
+| `MatchPattern(string)` | Sets the pattern style (`regex` or `simple`, default is `simple`) |
+| `Mapping(Func<FieldBuilder, FieldBuilder>)` | Defines the mapping applied to matched fields |
+
+## Common patterns
+
+### Map all unmapped strings as keywords
+
+Prevents Elasticsearch from creating both `text` and `keyword` sub-fields for every dynamic string:
+
+```csharp
+.AddDynamicTemplate("strings_as_keywords", t => t
+    .MatchMappingType("string")
+    .Mapping(f => f.Keyword()))
+```
+
+### Map label fields as keywords
+
+When your documents have a dynamic `labels` object:
+
+```csharp
+.AddDynamicTemplate("labels", t => t
+    .PathMatch("labels.*")
+    .Mapping(f => f.Keyword()))
+```
+
+### Use regex pattern matching
+
+```csharp
+.AddDynamicTemplate("ip_fields", t => t
+    .MatchPattern("regex")
+    .Match(".*_ip$")
+    .Mapping(f => f.Ip()))
+```
+
+## Template ordering
+
+Dynamic templates are evaluated in order. The first matching template wins. Place more specific templates before general ones:
+
+```csharp
+mappings
+    .AddDynamicTemplate("ip_fields", t => t       // Specific: IP fields
+        .Match("*_ip")
+        .Mapping(f => f.Ip()))
+    .AddDynamicTemplate("date_fields", t => t     // Specific: date fields
+        .Match("*_at")
+        .Mapping(f => f.Date()))
+    .AddDynamicTemplate("all_strings", t => t     // General: everything else
+        .MatchMappingType("string")
+        .Mapping(f => f.Keyword()));
+```
+
+## Interaction with field attributes
+
+Dynamic templates apply only to fields not already mapped. Fields declared with attributes on your document type always take priority. This makes dynamic templates useful for:
+
+- Open-ended metadata objects (e.g. `labels`, `tags`, `metrics`)
+- Documents with a known core schema plus variable extension fields
+- Catch-all defaults that reduce index bloat from unexpected fields
+
+## Complete example
+
+```csharp
+public class LogEntry : IConfigureElasticsearch<LogEntry>
+{
+    [Timestamp]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [Text]
+    public string Message { get; set; }
+
+    [Keyword]
+    public string Level { get; set; }
+
+    // Dynamic object, handled by template below
+    public Dictionary<string, string> Labels { get; set; }
+
+    public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) => analysis;
+
+    public MappingsBuilder<LogEntry> ConfigureMappings(MappingsBuilder<LogEntry> mappings) =>
+        mappings
+            .AddDynamicTemplate("labels_as_keywords", t => t
+                .PathMatch("labels.*")
+                .Mapping(f => f.Keyword().IgnoreAbove(256)));
+
+    public IReadOnlyDictionary<string, string>? IndexSettings => null;
+}
+```

--- a/docs/mapping/field-attributes.md
+++ b/docs/mapping/field-attributes.md
@@ -1,0 +1,260 @@
+---
+navigation_title: Field attributes
+---
+
+# Field attributes
+
+Field attributes on your document class properties control which Elasticsearch field type the source generator emits. When no attribute is present, the generator infers a type from CLR conventions.
+
+## Default type inference
+
+| CLR type | Default ES field type |
+|----------|----------------------|
+| `string` | `text` with `.keyword` sub-field |
+| `int`, `long` | `long` |
+| `float`, `double`, `decimal` | `double` |
+| `bool` | `boolean` |
+| `DateTime`, `DateTimeOffset` | `date` |
+| `Guid` | `keyword` |
+| Enum types | `keyword` (serialized by name) |
+| Complex types (classes) | `object` (recursively mapped) |
+| `IEnumerable<T>` | Array of inferred type for `T` |
+
+Use explicit attributes to override the default or set field-specific options.
+
+## Text and keyword fields
+
+```csharp
+public class Article
+{
+    [Text(Analyzer = "english", SearchAnalyzer = "english")]
+    public string Body { get; set; }
+
+    [Keyword(Normalizer = "lowercase", IgnoreAbove = 256)]
+    public string Category { get; set; }
+
+    [Completion(Analyzer = "simple")]
+    public string Suggest { get; set; }
+}
+```
+
+:::{dropdown} [Text] options
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Analyzer` | `string?` | `null` | Analyzer used at index time |
+| `SearchAnalyzer` | `string?` | `null` | Analyzer used at search time (falls back to `Analyzer`) |
+| `Norms` | `bool` | `true` | Store field length norms for relevance scoring |
+| `Index` | `bool` | `true` | Whether the field is searchable |
+
+When no `[Text]` or `[Keyword]` attribute is present on a `string` property, the generator defaults to `text` with an automatic `.keyword` sub-field. Use `[Text]` explicitly when you need to set analyzer options.
+:::
+
+:::{dropdown} [Keyword] options
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Normalizer` | `string?` | `null` | Normalizer for case-insensitive matching |
+| `IgnoreAbove` | `int` | `0` (no limit) | Values longer than this are not indexed (still stored) |
+| `DocValues` | `bool` | `true` | Store doc values for sorting and aggregations |
+| `Index` | `bool` | `true` | Whether the field is searchable |
+:::
+
+:::{dropdown} [Completion] options
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Analyzer` | `string?` | `null` | Analyzer for indexing |
+| `SearchAnalyzer` | `string?` | `null` | Analyzer for search |
+:::
+
+## Numeric, date, and boolean fields
+
+```csharp
+public class Order
+{
+    [Long]
+    public int Quantity { get; set; }
+
+    [Double]
+    public decimal Price { get; set; }
+
+    [Date(Format = "strict_date_optional_time||epoch_millis")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [Boolean]
+    public bool IsActive { get; set; }
+}
+```
+
+:::{dropdown} Options for numeric and date fields
+All of `[Long]`, `[Double]`, `[Date]`, and `[Boolean]` support:
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `DocValues` | `bool` | `true` | Store doc values for sorting and aggregations |
+| `Index` | `bool` | `true` | Whether the field is searchable |
+
+`[Date]` additionally supports:
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Format` | `string?` | `null` | Date format string |
+:::
+
+## Geo and network fields
+
+```csharp
+public class Store
+{
+    [GeoPoint]
+    public GeoLocation Location { get; set; }
+
+    [GeoShape]
+    public object DeliveryZone { get; set; }
+
+    [Ip]
+    public string ClientIp { get; set; }
+}
+```
+
+These attributes have no additional options.
+
+## Vector and semantic fields
+
+```csharp
+public class Document
+{
+    [DenseVector(Dims = 384, Similarity = "cosine")]
+    public float[] Embedding { get; set; }
+
+    [SemanticText(InferenceId = "my-elser-endpoint")]
+    public string Content { get; set; }
+}
+```
+
+:::{dropdown} [DenseVector] and [SemanticText] options
+**[DenseVector]**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Dims` | `int` | `0` | Number of dimensions |
+| `Similarity` | `string?` | `null` | Similarity function (`cosine`, `dot_product`, `l2_norm`) |
+
+**[SemanticText]**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `InferenceId` | `string?` | `null` | Inference endpoint ID |
+:::
+
+## Complex types
+
+```csharp
+public class Order
+{
+    [Object]
+    public Address ShippingAddress { get; set; }
+
+    [Nested(IncludeInParent = true)]
+    public List<LineItem> Items { get; set; }
+}
+```
+
+:::{dropdown} [Object] and [Nested] options
+**[Object]**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Enabled` | `bool` | `true` | When `false`, the object is stored but not indexed |
+
+**[Nested]**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `IncludeInParent` | `bool` | `false` | Include nested documents in the parent document |
+| `IncludeInRoot` | `bool` | `false` | Include nested documents in the root document |
+
+Use `[Nested]` when you need to query array elements independently (e.g. "find orders where item.name = X AND item.price < Y" without cross-matching).
+:::
+
+## Ingest metadata attributes
+
+:::{note}
+These attributes do not produce Elasticsearch field type mappings. They tell the source generator to produce accessor delegates that the ingest channel uses at runtime for bulk operations, index naming, and deduplication.
+:::
+
+| Attribute | Purpose | Effect on ingest |
+|-----------|---------|-----------------|
+| `[Id]` | Marks the document `_id` field | Bulk operations use `index` (upsert) instead of `create` |
+| `[Timestamp]` | Marks the timestamp field | Required for data streams; used for date-based index naming |
+| `[ContentHash]` | Marks a content hash field | Enables hash-based index reuse (skip recreating unchanged indices) |
+| `[BatchIndexDate]` | Auto-stamped batch date | All documents in a batch share one timestamp for index naming |
+| `[LastUpdated]` | Auto-stamped current time | Each document gets the write time |
+
+```csharp
+public class Product
+{
+    [Id]
+    [Keyword]
+    public string Sku { get; set; }
+
+    [Timestamp]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [ContentHash]
+    [Keyword]
+    public string Hash { get; set; }
+
+    [BatchIndexDate]
+    public DateTimeOffset IndexedAt { get; set; }
+
+    [LastUpdated]
+    public DateTimeOffset UpdatedAt { get; set; }
+}
+```
+
+## AI enrichment attributes
+
+:::{note}
+These attributes mark fields for the AI enrichment pipeline. They do not affect Elasticsearch field type mappings.
+:::
+
+| Attribute | Purpose |
+|-----------|---------|
+| `[AiInput]` | Field content is sent to the LLM as input |
+| `[AiField]` | Field is populated by LLM output |
+
+## TSDB dimensions
+
+Use `[Dimension]` on keyword fields when `DataStreamMode = DataStreamMode.Tsdb`:
+
+```csharp
+public class Metric
+{
+    [Dimension]
+    [Keyword]
+    public string Host { get; set; }
+
+    [Dimension]
+    [Keyword]
+    public string Service { get; set; }
+
+    [Long]
+    public long CpuPercent { get; set; }
+}
+```
+
+## Combining attributes
+
+Field attributes can be combined with ingest metadata attributes on the same property:
+
+```csharp
+public class Product
+{
+    [Id]           // Ingest: use as _id
+    [Keyword]      // Mapping: keyword field type
+    public string Sku { get; set; }
+
+    [Timestamp]    // Ingest: use for date-pattern naming
+    [Date]         // Mapping: date field type
+    public DateTimeOffset CreatedAt { get; set; }
+}
+```

--- a/docs/mapping/how-it-deploys.md
+++ b/docs/mapping/how-it-deploys.md
@@ -63,7 +63,7 @@ For date-rolling indices with aliases, this means zero-downtime schema evolution
 
 Because the mapping is derived from your C# class, every change shows up in your version control history:
 
-```diff
+```csharp
  public class Product
  {
      [Id]
@@ -73,9 +73,9 @@ Because the mapping is derived from your C# class, every change shows up in your
      [Text(Analyzer = "product_name_analyzer")]
      public string Name { get; set; }
 
-+    [Text(Analyzer = "product_name_analyzer")]
-+    public string Description { get; set; }
-+
+     [Text(Analyzer = "product_name_analyzer")]  // new field
+     public string Description { get; set; }
+
      [Keyword(Normalizer = "lowercase")]
      public string Category { get; set; }
  }

--- a/docs/mapping/how-it-deploys.md
+++ b/docs/mapping/how-it-deploys.md
@@ -1,0 +1,153 @@
+---
+navigation_title: How it deploys
+---
+
+# How mapping deploys with your application
+
+With `Elastic.Mapping`, your Elasticsearch mapping is compiled into your application binary. When the application starts and creates an ingest channel, the mapping is automatically pushed to Elasticsearch as component and index templates. There is no separate deployment step, no out-of-band script, no ops ticket.
+
+## The deployment flow
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant CI as Build / CI
+    participant App as Application
+    participant ES as Elasticsearch
+
+    Dev->>CI: Push code (C# class + attributes)
+    CI->>CI: Source generator produces mapping JSON
+    CI->>CI: Build succeeds (mapping is valid)
+    CI->>App: Deploy application
+    App->>App: Create IngestChannel
+    App->>ES: BootstrapElasticsearchAsync()
+    Note over App,ES: Push component template (settings + mappings)
+    Note over App,ES: Push index template
+    Note over App,ES: Create index (if needed)
+    App->>ES: TryWrite(documents)
+```
+
+## What bootstrap does
+
+When your application calls `channel.BootstrapElasticsearchAsync()`, the channel:
+
+1. Reads the generated mappings and settings JSON from the compiled context
+2. Merges in any custom analysis or index settings
+3. Computes a content hash of the final template body
+4. Checks if the component template in Elasticsearch already has the same hash
+5. If unchanged, skips the update (no-op)
+6. If changed, creates or updates the component template and index template
+7. Provisions the index according to the strategy (create new, or reuse existing)
+
+:::{tip}
+The hash-based check means your application can bootstrap on every startup without causing unnecessary template updates. Only actual mapping changes trigger writes to Elasticsearch.
+:::
+
+## What this means in practice
+
+### No more "did someone apply the mapping?"
+
+The mapping is part of the application. If the app is running, the mapping is applied. There is no window where the app is deployed but the mapping is stale.
+
+### Rolling updates are safe
+
+When you deploy a new version with an updated mapping:
+
+1. The new instance starts and calls `BootstrapElasticsearchAsync()`
+2. The hash differs from the existing template, so it updates the template
+3. Depending on your strategy, it either creates a new index (for date-rolling patterns) or the template applies to the next index creation
+
+For date-rolling indices with aliases, this means zero-downtime schema evolution: the old index keeps the old mapping, the new index gets the new mapping, and the write alias swaps automatically.
+
+### Mapping changes are auditable
+
+Because the mapping is derived from your C# class, every change shows up in your version control history:
+
+```diff
+ public class Product
+ {
+     [Id]
+     [Keyword]
+     public string Sku { get; set; }
+
+     [Text(Analyzer = "product_name_analyzer")]
+     public string Name { get; set; }
+
++    [Text(Analyzer = "product_name_analyzer")]
++    public string Description { get; set; }
++
+     [Keyword(Normalizer = "lowercase")]
+     public string Category { get; set; }
+ }
+```
+
+This diff tells the reviewer: "we added a `Description` field with full-text search using the same analyzer as `Name`." No separate JSON diff, no Terraform plan output.
+
+## Environment-specific behavior
+
+### Namespace resolution
+
+For data streams and wired streams, the namespace segment is resolved from environment variables at runtime:
+
+`DOTNET_ENVIRONMENT` > `ASPNETCORE_ENVIRONMENT` > `ENVIRONMENT` > `"dev"`
+
+This means the same binary creates `logs-myapp-production` in production and `logs-myapp-dev` locally, without configuration changes.
+
+### Templated index names
+
+For indices that need runtime parameters (e.g. multi-tenant scenarios), use `NameTemplate`:
+
+```csharp
+[Index<Product>(NameTemplate = "products-{tenant}")]
+```
+
+This generates a `CreateContext(string tenant)` method instead of a static property. The mapping is the same everywhere, but the index name varies per tenant.
+
+## Strategies for schema evolution
+
+| Scenario | Approach |
+|----------|----------|
+| Add a new field | Add the property to your class. The template updates on next bootstrap. Existing indices keep the old mapping (Elasticsearch merges compatible changes). |
+| Change a field type | Use date-rolling indices with `DatePattern`. The new index gets the new mapping. Old indices are unaffected. |
+| Rename a field | Add the new field, deprecate the old one. Backfill with a reindex if needed. |
+| Remove a field | Remove the property. The template updates. Existing documents still have the old field stored but it is no longer mapped. |
+
+## Complete example: from code to cluster
+
+```csharp
+// This is all you write:
+public class Product
+{
+    [Id] [Keyword]
+    public string Sku { get; set; }
+
+    [Text(Analyzer = "product_name_analyzer")]
+    public string Name { get; set; }
+
+    [Keyword(Normalizer = "lowercase")]
+    public string Category { get; set; }
+}
+
+[ElasticsearchMappingContext]
+[Index<Product>(
+    Name = "products",
+    WriteAlias = "products-write",
+    ReadAlias = "products-search",
+    DatePattern = "yyyy.MM.dd",
+    Configuration = typeof(ProductConfig))]
+public static partial class CatalogContext;
+
+// At startup:
+var options = new IngestChannelOptions<Product>(transport, CatalogContext.Product.Context);
+using var channel = new IngestChannel<Product>(options);
+await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure);
+```
+
+After bootstrap, Elasticsearch has:
+
+- A component template `products-template` with your mappings and settings (including custom analysis)
+- An index template referencing that component template, matching `products-*`
+- A concrete index like `products-2026.07.23` with the write alias `products-write` pointing to it
+- A search alias `products-search` spanning all `products-*` indices
+
+All from your C# class definition. No JSON. No scripts. No ops.

--- a/docs/mapping/index.md
+++ b/docs/mapping/index.md
@@ -1,0 +1,74 @@
+---
+navigation_title: Mapping
+---
+
+# Elastic.Mapping
+
+Describe your Elasticsearch mapping with C# attributes. A source generator turns those declarations into component template JSON at compile time, so you never write mapping JSON by hand.
+
+```csharp
+public class Product
+{
+    [Id]
+    [Keyword]
+    public string Sku { get; set; }
+
+    [Text(Analyzer = "standard")]
+    public string Name { get; set; }
+
+    [Keyword]
+    public string Category { get; set; }
+}
+
+[ElasticsearchMappingContext]
+[Index<Product>(Name = "products")]
+public static partial class MyContext;
+```
+
+From this declaration, the source generator produces all the JSON, hashes, and metadata that `Elastic.Ingest.Elasticsearch` needs to create templates, send bulk requests, and manage indices.
+
+## Install
+
+```shell
+dotnet add package Elastic.Ingest.Elasticsearch
+```
+
+This pulls in `Elastic.Mapping` (with the bundled source generator) and `Elastic.Channels` as transitive dependencies.
+
+## What happens at compile time
+
+```mermaid
+flowchart LR
+    A["Document class\n+ field attributes"] --> B["Source generator"]
+    C["Context class\n+ Index, DataStream"] --> B
+    D["ConfigureAnalysis\nConfigureMappings"] --> B
+    B --> E["Mappings JSON"]
+    B --> F["Settings JSON"]
+    B --> G["Accessor delegates\n(GetId, GetTimestamp)"]
+    B --> H["Content hash"]
+    E --> I["Component template"]
+    F --> I
+    G --> J["Bulk operations"]
+    H --> K["Change detection"]
+```
+
+The generator:
+
+- Finds classes marked with `[ElasticsearchMappingContext]`
+- Reads each `[Index<T>]`, `[DataStream<T>]`, or `[WiredStream<T>]` registration
+- Walks the document type's properties to infer Elasticsearch field types
+- Parses any `ConfigureAnalysis` / `ConfigureMappings` methods
+- Emits a partial context class with everything the ingest channel needs
+
+:::{dropdown} What exactly gets generated?
+For each type registration, the generator emits:
+
+- **Mappings JSON** for the component template `properties` section
+- **Settings JSON** with shards, replicas, refresh interval
+- **Combined SHA-256 hash** for change detection (skips template updates when unchanged)
+- **Accessor delegates** like `GetId`, `GetTimestamp`, `GetContentHash`, `SetBatchIndexDate`
+- **Index/search strategy metadata** with write target, date pattern, data stream name, aliases
+- **ConfigureAnalysis delegate** wired to your analysis configuration method
+- **MappingsBuilder extensions** with strongly-typed per-property fluent methods
+- **Analysis name accessors** for compile-time verified analyzer/tokenizer/filter references
+:::

--- a/docs/mapping/integration-with-ingest.md
+++ b/docs/mapping/integration-with-ingest.md
@@ -1,0 +1,188 @@
+---
+navigation_title: Integration with Elastic.Ingest
+---
+
+# Integration with Elastic.Ingest
+
+Put attributes on your document type, declare a mapping context, and the ingest channel auto-configures itself. This page explains how the pieces connect.
+
+## End-to-end example
+
+```csharp
+// 1. Document with attributes
+public class Product
+{
+    [Id]
+    [Keyword]
+    public string Sku { get; set; }
+
+    [Text(Analyzer = "product_analyzer")]
+    public string Name { get; set; }
+
+    [Keyword]
+    public string Category { get; set; }
+
+    [ContentHash]
+    [Keyword]
+    public string Hash { get; set; }
+}
+
+// 2. Mapping context with configuration
+[ElasticsearchMappingContext]
+[Index<Product>(
+    Name = "products",
+    WriteAlias = "products-write",
+    ReadAlias = "products-search",
+    DatePattern = "yyyy.MM.dd.HHmmss",
+    Configuration = typeof(ProductConfig))]
+public static partial class CatalogContext;
+
+// 3. Create a channel (strategy is fully auto-resolved)
+var options = new IngestChannelOptions<Product>(transport, CatalogContext.Product.Context);
+using var channel = new IngestChannel<Product>(options);
+
+await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure);
+
+foreach (var product in products)
+    channel.TryWrite(product);
+```
+
+From this declaration, the channel auto-resolves:
+
+| Behavior | Resolved to | Why |
+|----------|------------|-----|
+| Entity target | `Index` | `[Index<T>]` used |
+| Bulk operation | `index` (upsert) | `[Id]` present |
+| Bootstrap | Component + index templates | Index target |
+| Provisioning | Hash-based reuse | `[ContentHash]` present |
+| Alias | Write + search aliases | `WriteAlias` / `ReadAlias` set |
+| Index naming | `products-2026.07.23.120000` | `DatePattern` set |
+
+## How attributes drive behavior
+
+```mermaid
+flowchart TD
+    A["Index / DataStream / WiredStream"] --> B["EntityTarget"]
+    C["Id attribute"] --> D["Bulk uses index ops\n(upserts enabled)"]
+    E["Timestamp attribute"] --> F["Date-pattern index naming"]
+    G["ContentHash attribute"] --> H["Hash-based provisioning\n(skip unchanged)"]
+    I["BatchIndexDate attribute"] --> J["Batch date stamping"]
+    K["WriteAlias / ReadAlias"] --> L["Alias strategy"]
+    M["ConfigureAnalysis"] --> N["Settings component template"]
+```
+
+### Target attributes
+
+| Attribute | EntityTarget | Bulk operation | Bootstrap |
+|-----------|-------------|---------------|-----------|
+| `[Index<T>]` | `Index` | `index` (with `[Id]`) or `create` | Component + index templates |
+| `[DataStream<T>]` | `DataStream` | `create` (append-only) | Component + data stream templates |
+| `[WiredStream<T>]` | `WiredStream` | `create` (append-only) | No-op (managed by Elasticsearch) |
+
+### Field attributes
+
+| Attribute | Generated delegate | Effect |
+|-----------|-------------------|--------|
+| `[Id]` | `GetId` | Bulk headers include `_id`, enabling upserts |
+| `[Timestamp]` | `GetTimestamp` | Date-pattern index naming |
+| `[ContentHash]` | `GetContentHash` | Reuse existing index if hash matches |
+| `[BatchIndexDate]` | `SetBatchIndexDate` | All batch documents share one index date |
+| `[LastUpdated]` | `SetLastUpdated` | Each document gets the write time |
+
+### When an attribute is absent
+
+| Absent attribute | Effect |
+|-----------------|--------|
+| No `[Id]` | Bulk uses `create` (no upserts) |
+| No `[ContentHash]` | Always creates a new index on bootstrap |
+| No `[Timestamp]` with `DatePattern` | Compile-time error |
+
+## The handoff: ElasticsearchTypeContext
+
+The source generator populates an `ElasticsearchTypeContext` record at compile time. The ingest channel reads it at runtime.
+
+:::{dropdown} What the channel reads from the context
+
+| Field | Used for |
+|-------|----------|
+| `GetSettingsJson()` | Component template (settings) |
+| `GetMappingsJson()` | Component template (mappings) |
+| `Hash` / `SettingsHash` | Change detection (skip update if unchanged) |
+| `IndexStrategy` | Write target, date pattern, aliases |
+| `SearchStrategy` | Read alias, search pattern |
+| `EntityTarget` | Index vs DataStream vs WiredStream |
+| `GetId()` | Bulk header `_id` field |
+| `GetTimestamp()` | Date-pattern index naming |
+| `GetContentHash()` | Hash-based reuse provisioning |
+| `SetBatchIndexDate()` | Stamp batch date on documents |
+| `SetLastUpdated()` | Stamp current time on documents |
+| `ConfigureAnalysis` | Runtime analysis merge into settings |
+| `IndexSettings` | Additional settings key-value pairs |
+:::
+
+## Bootstrap flow
+
+When you call `channel.BootstrapElasticsearchAsync()`:
+
+1. Reads settings and mappings JSON from the generated context
+2. Merges custom analysis (if `ConfigureAnalysis` is configured)
+3. Merges additional index settings (if `IndexSettings` is configured)
+4. Computes the template name from the context
+5. Checks the hash. If the template already exists with the same hash, skips the update
+6. Creates or updates the component template
+7. Creates or updates the index template
+8. Provisions the index according to the provisioning strategy
+
+## Package dependency
+
+You only reference `Elastic.Ingest.Elasticsearch`. Everything else arrives transitively:
+
+```
+Elastic.Ingest.Elasticsearch
+  └── Elastic.Mapping (includes source generator)
+  └── Elastic.Ingest.Transport
+        └── Elastic.Channels
+```
+
+:::{dropdown} Advanced: name resolution and DI integration
+
+### Name resolution at runtime
+
+The generated context provides resolve methods:
+
+| Method | Returns |
+|--------|---------|
+| `ResolveIndexName(timestamp)` | Concrete index name (e.g. `products-2026.07.23.120000`) |
+| `ResolveWriteAlias()` | Write alias name |
+| `ResolveReadTarget()` | Best read target (read alias or write alias) |
+| `ResolveSearchPattern()` | Wildcard pattern for templates |
+| `ResolveDataStreamName()` | Full data stream name (`type-dataset-namespace`) |
+| `ResolveTemplateName()` | Component/index template name |
+
+For data streams, namespace resolution falls through environment variables:
+`DOTNET_ENVIRONMENT` > `ASPNETCORE_ENVIRONMENT` > `ENVIRONMENT` > `"dev"`
+
+### DI integration
+
+The generator produces an `IElasticsearchMappingContext` implementation for dependency injection:
+
+```csharp
+services.AddSingleton<IElasticsearchMappingContext>(MyContext.Instance);
+
+// Look up context by CLR type at runtime
+if (MyContext.Instance.All.TryGetValue(typeof(Product), out var metadata))
+{
+    var indexName = metadata.ResolveIndexName(DateTimeOffset.UtcNow);
+}
+```
+
+### IStaticMappingResolver
+
+The generated resolver interface (`IStaticMappingResolver<T>`) provides:
+
+- `Context` property (the `ElasticsearchTypeContext`)
+- Field name dictionaries (`PropertyToField`, `FieldToProperty`)
+- Typed setter delegates for `BatchIndexDate` and `LastUpdated`
+
+Used by `MappingsBuilder.Merge`, `AnalysisBuilder.Merge`, and `IncrementalSyncOrchestrator`.
+:::

--- a/docs/mapping/merge-strategies.md
+++ b/docs/mapping/merge-strategies.md
@@ -1,0 +1,121 @@
+---
+navigation_title: Mapping merge
+---
+
+# Mapping and analysis merge
+
+When multiple document types share analysis components or field structures, you can merge one type's generated mapping and analysis into another. This avoids duplicating configuration and enables superset indices (one index holding multiple document shapes).
+
+:::{important}
+**Conflict rule:** The local definition always wins. A name or path already present on the builder is never overwritten by a merge source. No exception is thrown for conflicts.
+:::
+
+## MappingsBuilder.Merge
+
+### Merge from a static resolver
+
+Merges all generated fields from another type's context:
+
+```csharp
+public MappingsBuilder<Product> ConfigureMappings(MappingsBuilder<Product> mappings) =>
+    mappings.Merge<OtherDocument>(MyContext.OtherDocument);
+```
+
+Every field path present on `OtherDocument` that is **not** already present on `Product` is added.
+
+### Merge with overrides
+
+Apply additional configuration to the merged type before merging:
+
+```csharp
+public MappingsBuilder<Product> ConfigureMappings(MappingsBuilder<Product> mappings) =>
+    mappings.Merge<OtherDocument>(
+        MyContext.OtherDocument,
+        other => other.Title(f => f.Analyzer("english")));
+```
+
+### Merge from a resolved context
+
+When the source uses `NameTemplate` and has a `CreateContext(...)` method:
+
+```csharp
+var otherContext = OtherMappingContext.Article.CreateContext("search", "prod");
+
+mappings.Merge(otherContext);
+```
+
+## AnalysisBuilder.Merge
+
+Include another type's analysis components in the current builder:
+
+```csharp
+public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+    analysis
+        .Analyzer("local_analyzer", a => a.Custom().Tokenizer("standard").Filters("lowercase"))
+        .Merge<OtherDocument>(MyContext.OtherDocument);
+```
+
+Same conflict rule: names already defined locally are never overwritten.
+
+## Use case: superset index
+
+Combine multiple document types into a single index:
+
+```csharp
+[ElasticsearchMappingContext]
+[Index<UnifiedDocument>(Name = "content", Configuration = typeof(UnifiedConfig))]
+public static partial class ContentContext;
+
+public class UnifiedConfig : IConfigureElasticsearch<UnifiedDocument>
+{
+    public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+        analysis
+            .Merge<Article>(ArticleContext.Article)
+            .Merge<BlogPost>(BlogContext.BlogPost);
+
+    public MappingsBuilder<UnifiedDocument> ConfigureMappings(MappingsBuilder<UnifiedDocument> mappings) =>
+        mappings
+            .Merge<Article>(ArticleContext.Article)
+            .Merge<BlogPost>(BlogContext.BlogPost);
+
+    public IReadOnlyDictionary<string, string>? IndexSettings => null;
+}
+```
+
+The `UnifiedDocument` index gets fields from both `Article` and `BlogPost`, plus any fields declared directly on `UnifiedDocument`.
+
+## AddField and AddProperty
+
+In addition to `Merge`, `MappingsBuilder` provides methods for adding individual fields not present on the CLR type.
+
+### AddField: add a multi-field (sub-field)
+
+Adds a sub-field under an existing leaf field's `fields` container:
+
+```csharp
+mappings.AddField("title.raw", f => f.Keyword().IgnoreAbove(256));
+// Result: "title": { "type": "text", "fields": { "raw": { "type": "keyword" } } }
+```
+
+### AddProperty: add a sub-property
+
+Adds a sub-property under an existing object field's `properties` container:
+
+```csharp
+mappings.AddProperty("address.zip_code", f => f.Keyword());
+// Result: "address": { "type": "object", "properties": { "zip_code": { "type": "keyword" } } }
+```
+
+:::{note}
+The generator reports diagnostics (`EMAP001`, `EMAP002`) if you use the wrong method. `AddField` is for leaf-type parents (text, keyword). `AddProperty` is for object/nested parents.
+:::
+
+## Order of operations
+
+When the channel bootstraps, mappings are composed in this order:
+
+1. Generated base mapping from field attributes on the CLR type
+2. `ConfigureMappings` overrides (`AddField`, `AddProperty`, generated extension methods)
+3. Merge sources (additive, local always wins)
+4. Dynamic templates (appended in declaration order)
+5. Runtime fields (appended to the `runtime` section)

--- a/docs/mapping/runtime-fields.md
+++ b/docs/mapping/runtime-fields.md
@@ -1,0 +1,105 @@
+---
+navigation_title: Runtime fields
+---
+
+# Runtime fields
+
+Runtime fields are computed at query time using Painless scripts. They are not indexed and exist only in the mapping definition. Use them for derived values that do not need to be searchable at scale or that change logic without requiring a reindex.
+
+## Adding runtime fields
+
+Use `AddRuntimeField` on `MappingsBuilder<T>` in your `ConfigureMappings` method:
+
+```csharp
+public MappingsBuilder<Order> ConfigureMappings(MappingsBuilder<Order> mappings) =>
+    mappings
+        .AddRuntimeField("day_of_week", r => r
+            .Keyword()
+            .Script("emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"))
+        .AddRuntimeField("total_with_tax", r => r
+            .Double()
+            .Script("emit(doc['subtotal'].value * 1.21)"));
+```
+
+## RuntimeFieldBuilder API
+
+The builder requires two steps: choose the type, then provide the script.
+
+### Type methods
+
+| Method | ES type | Description |
+|--------|---------|-------------|
+| `Keyword()` | `keyword` | String values (exact match, aggregations) |
+| `Long()` | `long` | Integer values |
+| `Double()` | `double` | Floating-point values |
+| `Date()` | `date` | Date/time values |
+| `Boolean()` | `boolean` | True/false values |
+| `Ip()` | `ip` | IP addresses |
+| `GeoPoint()` | `geo_point` | Latitude/longitude pairs |
+
+### Script method
+
+| Method | Description |
+|--------|-------------|
+| `Script(string)` | Painless script that calls `emit(value)` to produce the field value |
+
+Both type and script are required. The builder throws at build time if either is missing.
+
+## Examples
+
+```csharp
+// Day of week from timestamp
+.AddRuntimeField("day_of_week", r => r
+    .Keyword()
+    .Script("emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"))
+
+// Computed numeric value
+.AddRuntimeField("price_per_unit", r => r
+    .Double()
+    .Script("emit(doc['total_price'].value / doc['quantity'].value)"))
+
+// Boolean flag from condition
+.AddRuntimeField("is_completed", r => r
+    .Boolean()
+    .Script("emit(doc['status.keyword'].value == 'completed')"))
+
+// Full name from parts
+.AddRuntimeField("full_name", r => r
+    .Keyword()
+    .Script("""
+        def first = doc['first_name.keyword'].value;
+        def last = doc['last_name.keyword'].value;
+        emit(first + ' ' + last)
+        """))
+```
+
+## When to use runtime fields
+
+**Good for:**
+
+- Derived values that are cheap to compute (e.g. `day_of_week`)
+- Exploration before committing to indexing a field
+- Schema evolution without reindexing
+- Exposing computed values without exposing source fields
+
+**Avoid for:**
+
+- High-cardinality aggregations (per-document script cost adds up)
+- Full-text search (runtime fields cannot use analyzers)
+- Sort-heavy workloads (sorting evaluates the script for every matching document)
+
+## Generated output
+
+Runtime fields defined in `ConfigureMappings` are included in the component template JSON under the `runtime` section:
+
+```json
+{
+  "properties": { "..." },
+  "runtime": {
+    "day_of_week": {
+      "type": "keyword",
+      "script": { "source": "emit(...)" }
+    }
+  }
+}
+```

--- a/docs/mapping/strongly-typed-analysis-names.md
+++ b/docs/mapping/strongly-typed-analysis-names.md
@@ -1,0 +1,165 @@
+---
+navigation_title: Strongly-typed analysis names
+---
+
+# Strongly-typed analysis names
+
+When you define custom analyzers, tokenizers, or filters via `ConfigureAnalysis`, the source generator emits accessor classes that expose those names as properties. This gives you compile-time verification instead of runtime failures from typos.
+
+## The problem
+
+A typo in an analyzer reference silently produces a broken mapping:
+
+```csharp
+// No compile-time check. Fails at index time.
+[Text(Analyzer = "product_naem_analyzer")]  // typo!
+public string Name { get; set; }
+```
+
+## The solution
+
+The generator emits a static class with properties for each custom analysis component:
+
+```csharp
+// Generated: ProductAnalysis
+public static class ProductAnalysis
+{
+    public sealed class AnalyzersAccessor : Elastic.Mapping.Analysis.AnalyzersAccessor
+    {
+        public string ProductNameAnalyzer => "product_name_analyzer";
+    }
+
+    public sealed class NormalizersAccessor : Elastic.Mapping.Analysis.NormalizersAccessor
+    {
+        public string LowercaseNormalizer => "lowercase_normalizer";
+    }
+
+    public static readonly AnalyzersAccessor Analyzers = new();
+    public static readonly TokenizersAccessor Tokenizers = new();
+    public static readonly TokenFiltersAccessor TokenFilters = new();
+    public static readonly CharFiltersAccessor CharFilters = new();
+    public static readonly NormalizersAccessor Normalizers = new();
+}
+```
+
+## Using the accessor
+
+Reference analysis components through the generated accessor:
+
+```csharp
+// Compile-time verified. A typo here is a build error.
+mappings.Name(f => f.Analyzer(ProductAnalysis.Analyzers.ProductNameAnalyzer));
+
+// Built-in names are also available through the same accessor
+mappings.Title(f => f.Analyzer(ProductAnalysis.Analyzers.Standard));
+
+// Language analyzers
+mappings.Body(f => f.Analyzer(ProductAnalysis.Analyzers.Language.English));
+```
+
+Each accessor class inherits from a base class that exposes all built-in Elasticsearch names. Custom names are added as additional properties.
+
+## Naming convention
+
+Component names are converted from snake_case to PascalCase:
+
+| Analysis component name | Generated property name |
+|------------------------|------------------------|
+| `product_name_analyzer` | `ProductNameAnalyzer` |
+| `keyword_normalizer` | `KeywordNormalizer` |
+| `starts_with_tokenizer` | `StartsWithTokenizer` |
+| `english_stop` | `EnglishStop` |
+
+## Built-in names on the accessor
+
+Every generated accessor inherits built-in Elasticsearch names alongside your custom ones:
+
+```csharp
+// Custom analyzer
+ProductAnalysis.Analyzers.ProductNameAnalyzer   // "product_name_analyzer"
+
+// Built-in analyzer (inherited from base)
+ProductAnalysis.Analyzers.Standard              // "standard"
+ProductAnalysis.Analyzers.Whitespace            // "whitespace"
+ProductAnalysis.Analyzers.Language.English       // "english"
+
+// Built-in token filters (inherited from base)
+ProductAnalysis.TokenFilters.Lowercase          // "lowercase"
+ProductAnalysis.TokenFilters.AsciiFolding       // "asciifolding"
+```
+
+One accessor is your single source of truth for all analysis component names.
+
+## Advanced: base-type anchoring and delegation
+
+:::{dropdown} How the generator handles shared factories and inheritance
+### Base-type anchored accessors
+
+When your `ConfigureAnalysis` method delegates to a shared factory (rather than defining analysis inline), the generator anchors the accessor to the nearest user-defined base type. This enables generic code constrained on the base type to reference analysis names without knowing the concrete document type.
+
+**Example:**
+
+```csharp
+public class SearchBaseDocument
+{
+    [Id] [Keyword]
+    public string Id { get; set; }
+}
+
+public class SearchArticle : SearchBaseDocument { /* ... */ }
+public class SearchProduct : SearchBaseDocument { /* ... */ }
+
+public static class SearchAnalysisFactory
+{
+    public const string KeywordNormalizerName = "keyword_normalizer";
+
+    public static AnalysisBuilder BuildBaseAnalysis(AnalysisBuilder analysis) =>
+        analysis
+            .Normalizer(KeywordNormalizerName, n => n.Custom().Filters("lowercase"))
+            .Analyzer("starts_with_analyzer", a => a
+                .Custom().Tokenizer("starts_with_tokenizer").Filters("lowercase"))
+            .Tokenizer("starts_with_tokenizer", t => t
+                .EdgeNGram().MinGram(1).MaxGram(20));
+}
+
+public class SearchArticleConfig : IConfigureElasticsearch<SearchArticle>
+{
+    public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+        SearchAnalysisFactory.BuildBaseAnalysis(analysis);
+    // ...
+}
+```
+
+Because both configs delegate to the same factory and share a base type, the generator emits a single `SearchBaseDocumentAnalysis` class usable in generic code:
+
+```csharp
+// Static accessor (anywhere)
+var name = SearchBaseDocumentAnalysis.Analyzers.StartsWithAnalyzer;
+
+// Generic-constrained extension (in MappingsBuilder context)
+public MappingsBuilder<T> Configure<T>(MappingsBuilder<T> m) where T : SearchBaseDocument
+{
+    var name = m.Analyzers().StartsWithAnalyzer;  // same value
+    return m;
+}
+```
+
+### Transitive delegation following
+
+The generator follows method calls transitively. If `ConfigureAnalysis` calls method A which calls method B, all analysis components in both A and B are discovered.
+
+### Const resolution
+
+The generator resolves `const` field references when extracting names:
+
+```csharp
+public const string KeywordNormalizerName = "keyword_normalizer";
+
+// This works. The generator resolves the const to "keyword_normalizer".
+analysis.Normalizer(KeywordNormalizerName, n => n.Custom().Filters("lowercase"))
+```
+
+### Union merging across registrations
+
+When multiple registered types share the same base-type anchor but delegate to different factory methods, the generated accessor contains the **union** of all discovered components across all registrations.
+:::

--- a/docs/mapping/toc.yml
+++ b/docs/mapping/toc.yml
@@ -1,0 +1,12 @@
+toc:
+  - file: index.md
+  - file: why-mapping-as-code.md
+  - file: how-it-deploys.md
+  - file: field-attributes.md
+  - file: code-driven-mappings.md
+  - file: analysis.md
+  - file: strongly-typed-analysis-names.md
+  - file: dynamic-templates.md
+  - file: runtime-fields.md
+  - file: merge-strategies.md
+  - file: integration-with-ingest.md

--- a/docs/mapping/why-mapping-as-code.md
+++ b/docs/mapping/why-mapping-as-code.md
@@ -1,0 +1,88 @@
+---
+navigation_title: Why mapping as code
+---
+
+# Why mapping as code
+
+Elasticsearch mappings define how your data is indexed, searched, and stored. Traditionally, teams manage these mappings as JSON files, Kibana dev tools scripts, or Terraform resources that live separately from the application code that produces the data. This separation creates real problems.
+
+## The drift problem
+
+When your mapping lives in a JSON file or an ops pipeline and your document model lives in C#, they inevitably drift apart:
+
+- A developer adds a new property to the C# class but forgets to update the mapping JSON.
+- Someone renames a field in the mapping but the application still writes the old name.
+- Two teams change the same index template without coordinating.
+- A typo in an analyzer name only surfaces when documents fail to index in production.
+
+None of these failures surface at compile time. You find them in logs, in missing search results, or in production incidents.
+
+## Mapping as code
+
+`Elastic.Mapping` takes a different approach: your C# document class **is** the mapping. Attributes on properties declare the Elasticsearch field types. A source generator produces the mapping JSON at compile time. If the class compiles, the mapping is valid.
+
+```csharp
+public class Product
+{
+    [Id]
+    [Keyword]
+    public string Sku { get; set; }
+
+    [Text(Analyzer = "product_name_analyzer")]
+    public string Name { get; set; }
+
+    [Keyword(Normalizer = "lowercase")]
+    public string Category { get; set; }
+
+    [Double]
+    public decimal Price { get; set; }
+}
+```
+
+This gives you:
+
+- **One source of truth.** The C# class defines both your application's data model and its Elasticsearch mapping. They cannot drift.
+- **Compile-time verification.** A renamed property updates the mapping automatically. A deleted field disappears from the template. A misspelled analyzer name is a build error (when using strongly-typed accessors).
+- **Refactoring safety.** IDE rename refactorings propagate through your mapping. You do not need to remember to update a separate JSON file.
+- **Code review.** Mapping changes show up in pull requests alongside the application logic that motivated them.
+
+## What about custom analysis?
+
+Field attributes cover the mapping shape, but real-world search requires custom analyzers, tokenizers, and filters. These are also defined in code through `IConfigureElasticsearch<T>`:
+
+```csharp
+public class ProductConfig : IConfigureElasticsearch<Product>
+{
+    public AnalysisBuilder ConfigureAnalysis(AnalysisBuilder analysis) =>
+        analysis
+            .Analyzer("product_name_analyzer", a => a
+                .Custom()
+                .Tokenizer("standard")
+                .Filters("lowercase", "asciifolding"))
+            .Normalizer("lowercase", n => n
+                .Custom()
+                .Filters("lowercase"));
+
+    public MappingsBuilder<Product> ConfigureMappings(MappingsBuilder<Product> mappings) => mappings;
+    public IReadOnlyDictionary<string, string>? IndexSettings => null;
+}
+```
+
+The source generator discovers the analysis component names and emits strongly-typed accessor classes. Referencing `ProductAnalysis.Analyzers.ProductNameAnalyzer` instead of the string `"product_name_analyzer"` turns a runtime failure into a compile error.
+
+## Comparison with other approaches
+
+| Approach | Drift risk | Compile-time safety | Deploys with app |
+|----------|-----------|--------------------|--------------------|
+| JSON files in ops repo | High | None | No |
+| Terraform / Pulumi | Medium | Schema validation only | Separate pipeline |
+| Kibana dev tools | High | None | No |
+| **Elastic.Mapping** | **None** | **Full** | **Yes** |
+
+## When not to use this
+
+Mapping-as-code works best when your application owns the data it writes to Elasticsearch. If you are:
+
+- Ingesting data from external sources with unpredictable schemas, consider dynamic templates instead of exhaustive attribute-based mapping.
+- Managing shared indices that multiple teams write to, you may still want a coordination layer on top.
+- Using Elasticsearch purely for log storage with Elastic Agent / Fleet, the built-in index templates handle mapping for you.


### PR DESCRIPTION
## Summary

Adds a new top-level `docs/mapping/` section with comprehensive documentation for the `Elastic.Mapping` source generator and its integration with `Elastic.Ingest.Elasticsearch`.

## Pages added

### Narrative pages (why and how)
- **Why mapping as code** — The drift problem, compile-time safety, comparison with JSON/Terraform approaches
- **How it deploys** — Bootstrap flow, rolling updates, schema evolution strategies

### Reference pages
- **Field attributes** — Complete reference for all mapping attributes with dropdown detail blocks
- **Code-driven mappings** — `IConfigureElasticsearch<T>`, configuration classes, generated extensions
- **Analysis configuration** — `AnalysisBuilder` fluent API, built-in constants, merge
- **Strongly-typed analysis names** — Generated accessor classes, base-type anchoring, delegation
- **Dynamic templates** — `DynamicTemplateBuilder` API and common patterns
- **Runtime fields** — `RuntimeFieldBuilder` API and examples
- **Mapping merge** — `MappingsBuilder.Merge`, `AnalysisBuilder.Merge`, conflict semantics
- **Integration with Elastic.Ingest** — How the generated context drives channels and strategies

## Style

Uses Elastic docs-builder directives:
- Mermaid diagrams for architecture and sequence flows
- Dropdowns for detailed API tables that would interrupt reading flow
- Admonitions (tip, note, important) for callouts
- Short intros before code examples
- Written for newcomers, not internals contributors

Made with [Cursor](https://cursor.com)