### PR TITLE
Add logs.ecs/logs.otel wired ingest endpoints and Streams docs

### DIFF
--- a/docs/getting-started/mapping-context.md
+++ b/docs/getting-started/mapping-context.md
@@ -140,22 +140,26 @@ Data stream name: `{type}-{dataset}-{namespace}` (e.g. `logs-myapp-production`)
 
 ## Wired stream parameters
 
-`[WiredStream<T>]` is similar to `[DataStream<T>]` but bootstrap is fully managed by Elasticsearch:
+`[WiredStream<T>]` is similar to `[DataStream<T>]` but bootstrap is fully managed by Elasticsearch. Documents are sent to a managed bulk endpoint:
 
 ```csharp
 [WiredStream<LogEntry>(
     Type = "logs",
-    Dataset = "myapp"
+    Dataset = "myapp",
+    IngestEndpoint = WiredStreamIngestEndpoint.LogsEcs
 )]
 ```
 
 | Parameter | Default | Effect |
 |-----------|---------|--------|
-| `Type` | Required | Data category |
+| `Type` | Required | Data category (naming / search patterns) |
 | `Dataset` | Required | Source identifier |
 | `Namespace` | Environment variable | Resolved from environment when omitted |
+| `IngestEndpoint` | `Logs` | Bulk path: `logs`, `logs.ecs`, or `logs.otel` |
 | `Configuration` | None | Static class with configuration methods |
 | `Variant` | None | Registers multiple configurations for the same type |
+
+See [Wired streams](../index-management/wired-streams.md) and [ECS and OTel endpoints](../index-management/ecs-and-otel-endpoints.md).
 
 ## Variants
 

--- a/docs/index-management/data-streams.md
+++ b/docs/index-management/data-streams.md
@@ -64,5 +64,6 @@ Data streams support two lifecycle approaches:
 ## Related
 
 - [Time-series](../use-cases/time-series.md): end-to-end guide for time-series data
+- [Streams](streams.md): classic vs wired Streams terminology
 - [TSDB](tsdb.md): time-series database mode for metrics
 - [LogsDB](logsdb.md): LogsDB mode for log ingestion

--- a/docs/index-management/ecs-and-otel-endpoints.md
+++ b/docs/index-management/ecs-and-otel-endpoints.md
@@ -1,0 +1,109 @@
+---
+navigation_title: ECS and OTel endpoints
+---
+
+# ECS and OTel endpoints
+
+Wired streams expose specialized bulk endpoints that control how field names are stored. See Elastic's [wired streams field naming](https://www.elastic.co/docs/solutions/observability/streams/wired-streams-field-naming) for the full conversion table.
+
+## Endpoints
+
+| Endpoint | Path | Behavior |
+|----------|------|----------|
+| `WiredStreamIngestEndpoint.Logs` | `logs/_bulk` | Default; backward-compatible generic wired path |
+| `WiredStreamIngestEndpoint.LogsEcs` | `logs.ecs/_bulk` | Stores ECS field names as sent |
+| `WiredStreamIngestEndpoint.LogsOtel` | `logs.otel/_bulk` | Stores OTel semantic conventions; creates ECS aliases for existing queries |
+
+```csharp
+[ElasticsearchMappingContext]
+[WiredStream<EcsLog>(
+    Type = "logs",
+    Dataset = "dotnet",
+    IngestEndpoint = WiredStreamIngestEndpoint.LogsEcs)]
+public static partial class EcsWiredContext;
+```
+
+## Document shape for `logs.ecs`
+
+Documents should use Elastic Common Schema field names. A minimal shape:
+
+```csharp
+public class EcsLog
+{
+    [Timestamp]
+    [JsonPropertyName("@timestamp")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+
+    [JsonPropertyName("log.level")]
+    public string LogLevel { get; set; }
+
+    [JsonPropertyName("service.name")]
+    public string ServiceName { get; set; }
+
+    [JsonPropertyName("host.name")]
+    public string? HostName { get; set; }
+
+    [JsonPropertyName("trace.id")]
+    public string? TraceId { get; set; }
+}
+```
+
+Useful fields for Kibana Streams features (significant events, knowledge indicators, Streamlang conditions):
+
+- `@timestamp` — required for time-based views
+- `message` / `body.text` — free-text used by extraction and queries
+- `service.*`, `host.*` — entity identity for topology and knowledge indicators
+- `log.level` / `severity_text` — filtering and alerting
+- `trace.id`, `transaction.id` — correlation with APM
+
+## Integration with ecs-dotnet
+
+[elastic/ecs-dotnet](https://github.com/elastic/ecs-dotnet) formats logs as ECS JSON and ships via Serilog, NLog, or Microsoft.Extensions.Logging.
+
+### Path A — Classic data stream (existing sinks)
+
+`Elastic.Serilog.Sinks` and related shippers use a classic data stream (`logs-dotnet-default` by default) with optional template bootstrap. That path maps to `[DataStream<T>]` in this library and appears as a **classic stream** in Kibana Streams.
+
+```csharp
+// ecs-dotnet Serilog sink (classic)
+.WriteTo.Elasticsearch(nodes, opts =>
+{
+    opts.DataStream = new DataStreamName("logs", "dotnet", "production");
+    opts.BootstrapMethod = BootstrapMethod.Failure;
+})
+```
+
+### Path B — Wired streams (this library)
+
+For Kibana **wired** streams, send ECS documents through `IngestChannel` with `LogsEcs`:
+
+```csharp
+[ElasticsearchMappingContext]
+[WiredStream<LogEventEcsDocument>(
+    Type = "logs",
+    Dataset = "dotnet",
+    IngestEndpoint = WiredStreamIngestEndpoint.LogsEcs)]
+public static partial class WiredEcsContext;
+
+// ...
+var options = new IngestChannelOptions<LogEventEcsDocument>(
+    transport, WiredEcsContext.LogEventEcsDocument.Context);
+using var channel = new IngestChannel<LogEventEcsDocument>(options);
+await channel.BootstrapElasticsearchAsync(BootstrapMethod.None);
+channel.TryWrite(ecsDocument);
+```
+
+Until ecs-dotnet sinks expose a first-class wired option, Path B is the supported way to target `logs.ecs` from .NET.
+
+### Path C — OpenTelemetry
+
+Use `IngestEndpoint = LogsOtel` when documents follow OTel log semantic conventions (or when you want Streams to normalize ECS → OTel storage). Prefer this for OpenTelemetry Collector / OTLP-shaped payloads rather than ecs-dotnet formatters.
+
+## Related
+
+- [Wired streams](wired-streams.md)
+- [Streams overview](streams.md)
+- [Downstream Streams features](streams-downstream-features.md)

--- a/docs/index-management/index.md
+++ b/docs/index-management/index.md
@@ -16,8 +16,11 @@ Elastic.Ingest.Elasticsearch supports several index management strategies. The r
 | Automatic lifecycle | ILM managed | No | [ILM managed](rollover/ilm-managed.md) |
 | Simplified lifecycle | Data stream lifecycle | Yes | [Data stream lifecycle](rollover/data-stream-lifecycle.md) |
 | Append-only time-series | Data streams | Yes | [Data streams](data-streams.md) |
+| Kibana classic stream | Data streams | Yes | [Streams](streams.md) |
+| Kibana wired stream | Wired Streams | Yes | [Wired streams](wired-streams.md) |
+| ECS / OTel wired ingest | Wired Streams (`logs.ecs` / `logs.otel`) | Yes | [ECS and OTel endpoints](ecs-and-otel-endpoints.md) |
 | TSDB metrics | TSDB mode | Yes | [TSDB](tsdb.md) |
-| Log ingestion | LogsDB / Wired Streams | Yes | [LogsDB](logsdb.md) |
+| Log storage optimization | LogsDB | Yes | [LogsDB](logsdb.md) |
 
 ## EntityTarget
 
@@ -26,8 +29,8 @@ The target-specific attribute on your mapping context (`[Index<T>]`, `[DataStrea
 | EntityTarget | Description | Bootstrap |
 |---|---|---|
 | `Index` | Traditional Elasticsearch index. Supports updates, upserts, aliases. | Component + index templates |
-| `DataStream` | Append-only data stream. Automatic rollover and lifecycle. | Component + data stream templates |
-| `WiredStream` | Serverless managed stream. No local bootstrap needed. | No-op |
+| `DataStream` | Append-only data stream. Automatic rollover and lifecycle. Maps to Kibana **classic** streams. | Component + data stream templates |
+| `WiredStream` | Managed wired ingest (`logs` / `logs.ecs` / `logs.otel`). No local bootstrap. | No-op |
 
 ## How bootstrap works
 

--- a/docs/index-management/logsdb.md
+++ b/docs/index-management/logsdb.md
@@ -2,13 +2,11 @@
 navigation_title: LogsDB
 ---
 
-# LogsDB and wired streams
+# LogsDB
 
-LogsDB mode and wired streams provide optimized log ingestion paths, particularly useful on serverless Elasticsearch.
+LogsDB mode optimizes data streams for log storage with synthetic `_source` and automatic field mapping. It is a `[DataStream<T>]` option — not a separate entity target.
 
-## LogsDB mode
-
-LogsDB mode optimizes data streams for log storage with synthetic `_source` and automatic field mapping.
+## Configuration
 
 ```csharp
 [ElasticsearchMappingContext]
@@ -21,49 +19,14 @@ LogsDB mode optimizes data streams for log storage with synthetic `_source` and 
 public static partial class LogsContext;
 ```
 
-LogsDB data streams work the same as regular data streams but with storage optimizations applied automatically by Elasticsearch.
+LogsDB data streams work the same as regular data streams but with storage optimizations applied automatically by Elasticsearch. Bootstrap still creates component and data stream templates (classic Streams path).
 
 ## Wired streams
 
-Wired streams are serverless managed ingestion endpoints. Unlike data streams, **no local bootstrap is needed** -- Elasticsearch manages templates and lifecycle entirely.
-
-### Configuration
-
-```csharp
-[ElasticsearchMappingContext]
-[WiredStream<LogEntry>(Type = "logs", Dataset = "myapp")]
-public static partial class WiredContext;
-```
-
-### Channel setup
-
-```csharp
-var options = new IngestChannelOptions<LogEntry>(transport, WiredContext.LogEntry.Context);
-using var channel = new IngestChannel<LogEntry>(options);
-
-// Bootstrap is a no-op for wired streams
-await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure);
-
-foreach (var entry in logEntries)
-    channel.TryWrite(entry);
-
-await channel.WaitForDrainAsync(TimeSpan.FromSeconds(10), ctx);
-```
-
-### How it works
-
-- `WiredStreamIngestStrategy` sends bulk requests to the `logs/_bulk` endpoint
-- `NoopBootstrapStep` skips all template creation
-- Documents use `create` operations (append-only)
-- Elasticsearch manages all index templates, lifecycle, and retention
-
-### When to use
-
-- Serverless Elasticsearch where you want the simplest possible ingestion path
-- Log data that doesn't need custom templates or mappings
-- Scenarios where Elasticsearch should manage the full index lifecycle
+For managed Kibana **wired** streams (no local bootstrap, `logs.ecs` / `logs.otel` endpoints), see [Wired streams](wired-streams.md). LogsDB mode does not apply to `[WiredStream<T>]`.
 
 ## Related
 
 - [Data streams](data-streams.md): standard data stream bootstrapping
+- [Streams](streams.md): classic vs wired in Kibana Streams
 - [Time-series](../use-cases/time-series.md): end-to-end time-series guide

--- a/docs/index-management/streams-downstream-features.md
+++ b/docs/index-management/streams-downstream-features.md
@@ -1,0 +1,53 @@
+---
+navigation_title: Downstream Streams features
+---
+
+# Downstream Streams features
+
+After documents are ingested, Kibana Streams can process and enrich them. These features are **not configured in Elastic.Ingest.Elasticsearch** — they live in Kibana / the Streams API. Good document shape still matters so those features work well.
+
+## Streamlang
+
+[Streamlang](https://www.elastic.co/docs/solutions/observability/streams/streamlang) is a YAML DSL for processors and partition conditions. Streams converts it to ingest pipelines or ES|QL.
+
+**Library implication:** Send consistently typed fields. Prefer stable ECS/OTel names (`message`, `log.level`, `service.name`) so Streamlang `where` conditions and grok/dissect processors match without fighting dynamic mapping surprises.
+
+Wired streams: field naming depends on the endpoint — see [ECS and OTel endpoints](ecs-and-otel-endpoints.md). Classic `[DataStream]` targets: your bootstrapped mappings define the schema Streamlang sees.
+
+## Partitioning (child streams)
+
+Wired streams can route documents into child streams based on partition conditions (often written in Streamlang). Routing keys are typically high-cardinality identifiers such as `service.name` or dataset attributes.
+
+**Library implication:** Populate identity fields on every event. Do not rely on this library to create child streams — enable and configure partitioning in Kibana after data is flowing.
+
+## Significant events
+
+Significant events surface notable conditions in a stream (including query knowledge indicators). They are managed via the Streams UI / API (`significant_events`).
+
+**Library implication:** Keep `@timestamp` accurate and include enough structured context (`service.*`, `error.*`, `event.*`) that ES|QL-based detections can match. The library does not emit significant-event definitions.
+
+## Knowledge indicators
+
+[Knowledge indicators](https://www.elastic.co/docs/solutions/observability/streams/knowledge-indicators) automatically extract structured facts (services, infrastructure, dependencies, schemas) and optional ES|QL query suggestions from log samples.
+
+**Library implication:**
+
+- Prefer readable `message` (or OTel `body.text`) text — extraction samples raw log content
+- Include `service.name` / resource attributes so entities merge correctly
+- Continuous extraction runs in Kibana with a Generative AI connector — not from the ingest channel
+
+## Summary
+
+| Concern | Owned by |
+|---------|----------|
+| Bulk ingest, batching, retries | This library |
+| Classic template bootstrap | This library (`[DataStream]`) |
+| Wired template / lifecycle | Elasticsearch |
+| Streamlang, partitions, significant events, KIs | Kibana Streams |
+| Field naming at wired ingest | Endpoint (`logs.ecs` / `logs.otel`) |
+
+## Related
+
+- [Streams overview](streams.md)
+- [Wired streams](wired-streams.md)
+- [Get data into Streams](https://www.elastic.co/docs/solutions/observability/streams/get-data-in) (Elastic docs)

--- a/docs/index-management/streams.md
+++ b/docs/index-management/streams.md
@@ -1,0 +1,50 @@
+---
+navigation_title: Streams
+---
+
+# Streams
+
+[Kibana Streams](https://www.elastic.co/docs/solutions/observability/streams/streams) is a centralized UI for managing Elasticsearch data streams: retention, field extraction, routing into child streams, and data quality. This library maps to Streams through two ingest targets.
+
+## Terminology
+
+| Kibana Streams | This library | What it means |
+|----------------|--------------|---------------|
+| Classic stream | `[DataStream<T>]` | You own templates. Bootstrap creates component + data stream templates. |
+| Wired stream | `[WiredStream<T>]` | Elasticsearch manages templates and lifecycle. Bulk goes to a managed endpoint. |
+
+Classic streams work with existing `{type}-{dataset}-{namespace}` data streams. Wired streams are the managed ingest path (Elastic Stack 9.2+ / serverless preview) that supports hierarchical inheritance and cascading configuration.
+
+## Choosing a target
+
+```mermaid
+flowchart TD
+  start[Need Streams-friendly log ingest?] --> q1{Manage templates yourself?}
+  q1 -->|Yes / self-managed stack| classic["DataStream EntityTarget"]
+  q1 -->|No / serverless managed| wired["WiredStream EntityTarget"]
+  classic --> bootstrap[Bootstrap component + DS templates]
+  wired --> endpoint[Pick logs / logs.ecs / logs.otel]
+  bootstrap --> kibanaClassic[Appears as classic stream in Kibana]
+  endpoint --> kibanaWired[Appears under wired streams hierarchy]
+```
+
+| Use case | Attribute | Guide |
+|----------|-----------|-------|
+| Append-only logs/metrics with local mappings | `[DataStream<T>]` | [Data streams](data-streams.md) |
+| LogsDB storage mode | `[DataStream<T>(DataStreamMode = LogsDb)]` | [LogsDB](logsdb.md) |
+| Managed wired ingest (serverless / Streams) | `[WiredStream<T>]` | [Wired streams](wired-streams.md) |
+| ECS documents from ecs-dotnet | `[WiredStream<T>(IngestEndpoint = LogsEcs)]` | [ECS and OTel endpoints](ecs-and-otel-endpoints.md) |
+
+## What Kibana owns after ingest
+
+Once documents land in Streams, Kibana features operate on them. The .NET library does **not** author Streamlang or extract knowledge indicators — those are configured in Kibana (or via the Streams API).
+
+See [Downstream Streams features](streams-downstream-features.md) for how document shape affects Streamlang, significant events, and knowledge indicators.
+
+## Related Elastic docs
+
+- [Streams overview](https://www.elastic.co/docs/solutions/observability/streams/streams)
+- [Get data into Streams](https://www.elastic.co/docs/solutions/observability/streams/get-data-in)
+- [Wired streams field naming](https://www.elastic.co/docs/solutions/observability/streams/wired-streams-field-naming)
+- [Streamlang](https://www.elastic.co/docs/solutions/observability/streams/streamlang)
+- [Knowledge indicators](https://www.elastic.co/docs/solutions/observability/streams/knowledge-indicators)

--- a/docs/index-management/toc.yml
+++ b/docs/index-management/toc.yml
@@ -3,5 +3,9 @@ toc:
   - file: single-index.md
   - toc: rollover
   - file: data-streams.md
+  - file: streams.md
+  - file: wired-streams.md
+  - file: ecs-and-otel-endpoints.md
+  - file: streams-downstream-features.md
   - file: tsdb.md
   - file: logsdb.md

--- a/docs/index-management/wired-streams.md
+++ b/docs/index-management/wired-streams.md
@@ -59,15 +59,21 @@ await channel.WaitForDrainAsync(TimeSpan.FromSeconds(10), ctx);
 
 ## Mappings and wired streams
 
-Attribute-generated mappings on a `[WiredStream<T>]` document type are **not deployed**. There is no component template step. Field mappings are governed by the wired stream endpoint and Streams-managed schema.
+Wired streams **do support field mappings** — they are managed by [Kibana Streams](https://www.elastic.co/docs/solutions/observability/streams/map-fields) (Schema / Processing tabs), not by this library’s bootstrap.
 
-Use mapping attributes for:
+What “bootstrap is a no-op” means here:
 
-- Compile-time documentation of expected fields
-- Serialization helpers (`[Timestamp]`, `[JsonPropertyName]`)
-- Consistency with classic `[DataStream]` types you may also register
+| Who | What happens for `[WiredStream<T>]` |
+|-----|--------------------------------------|
+| This library | Does **not** PUT component/index templates from your `[Text]` / `[Keyword]` attributes |
+| Elasticsearch / Streams | Owns templates and lifecycle; you map fields in the Streams UI (or Streams API). Wired children can **inherit** parent mappings |
+| Ingest endpoint | `logs.ecs` / `logs.otel` controls field-name normalization at ingest ([field naming](https://www.elastic.co/docs/solutions/observability/streams/wired-streams-field-naming)) |
 
-Do **not** expect `[Text]` / `[Keyword]` on a wired target to change cluster mappings.
+Unmapped fields can still be queried (e.g. ES|QL `SET unmapped_fields = 'LOAD'`). Prefer ECS/OTel document shapes so Streams schema and processors line up.
+
+Use mapping attributes on wired document types for serialization and shared type definitions with classic `[DataStream]` targets — not as a way to install cluster templates via `BootstrapElasticsearchAsync`.
+
+For local template ownership (including LogsDB), use `[DataStream<T>]` instead.
 
 ## Related
 

--- a/docs/index-management/wired-streams.md
+++ b/docs/index-management/wired-streams.md
@@ -1,0 +1,77 @@
+---
+navigation_title: Wired streams
+---
+
+# Wired streams
+
+Wired streams send documents to a managed Elasticsearch bulk endpoint. Elasticsearch owns index templates, lifecycle, and retention — bootstrap in this library is a no-op.
+
+## When to use
+
+- Serverless Elasticsearch or Elastic Stack with wired streams enabled
+- You want Kibana Streams hierarchy (parent/child routing) without managing templates
+- Log data whose field naming follows ECS or OTel conventions (see [ECS and OTel endpoints](ecs-and-otel-endpoints.md))
+
+Prefer `[DataStream<T>]` when you need custom mappings, ILM policies, or LogsDB/TSDB modes that you bootstrap yourself.
+
+## Configuration
+
+```csharp
+[ElasticsearchMappingContext]
+[WiredStream<LogEntry>(
+    Type = "logs",
+    Dataset = "myapp",
+    IngestEndpoint = WiredStreamIngestEndpoint.LogsEcs)]
+public static partial class WiredContext;
+```
+
+`Type`, `Dataset`, and optional `Namespace` still form the conventional `{type}-{dataset}-{namespace}` name used for search patterns and template naming helpers. They do **not** change the bulk URL — that comes from `IngestEndpoint`.
+
+| `IngestEndpoint` | Bulk path | Field naming |
+|------------------|-----------|--------------|
+| `Logs` (default) | `logs/_bulk` | Legacy/generic wired endpoint |
+| `LogsEcs` | `logs.ecs/_bulk` | ECS fields stored as-is |
+| `LogsOtel` | `logs.otel/_bulk` | OTel semantic conventions (+ ECS aliases) |
+
+## Channel setup
+
+```csharp
+var options = new IngestChannelOptions<LogEntry>(transport, WiredContext.LogEntry.Context);
+using var channel = new IngestChannel<LogEntry>(options);
+
+// Bootstrap is a no-op for wired streams
+await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure);
+
+foreach (var entry in logEntries)
+    channel.TryWrite(entry);
+
+await channel.WaitForDrainAsync(TimeSpan.FromSeconds(10), ctx);
+```
+
+## What the channel infers
+
+| Behavior | Strategy | Why |
+|----------|----------|-----|
+| Ingest | `WiredStreamIngestStrategy` | Sends to `{endpoint}/_bulk` with `create` ops |
+| Bootstrap | `NoopBootstrapStep` | Elasticsearch manages all templates |
+| Provisioning | `AlwaysCreateProvisioning` | No local index management |
+| Alias | `NoAliasStrategy` | Elasticsearch manages routing |
+
+## Mappings and wired streams
+
+Attribute-generated mappings on a `[WiredStream<T>]` document type are **not deployed**. There is no component template step. Field mappings are governed by the wired stream endpoint and Streams-managed schema.
+
+Use mapping attributes for:
+
+- Compile-time documentation of expected fields
+- Serialization helpers (`[Timestamp]`, `[JsonPropertyName]`)
+- Consistency with classic `[DataStream]` types you may also register
+
+Do **not** expect `[Text]` / `[Keyword]` on a wired target to change cluster mappings.
+
+## Related
+
+- [Streams overview](streams.md): classic vs wired terminology
+- [ECS and OTel endpoints](ecs-and-otel-endpoints.md): endpoint choice and ecs-dotnet
+- [Use case: Wired streams](../use-cases/wired-streams.md): end-to-end example
+- [Data streams](data-streams.md): classic path with local bootstrap

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,7 +113,7 @@ dotnet add package Elastic.Ingest.Elasticsearch
 - [Getting started](getting-started/index.md): install, define documents, create your first channel
 - [Channels](channels/index.md): buffer tuning, callbacks, serialization
 - [Architecture](architecture/index.md): how the two-stage buffered pipeline works
-- [Index management](index-management/index.md): indices, data streams, rollover, and lifecycle
+- [Index management](index-management/index.md): indices, data streams, Streams (classic/wired), rollover, and lifecycle
 - [Strategies](strategies/index.md): composable strategy pattern and factory methods
 - [Orchestration](orchestration/index.md): coordinating multiple channels
 - [Helpers](helpers/index.md): PIT search, server-side reindex, delete-by-query, client-side reindex

--- a/docs/mapping/integration-with-ingest.md
+++ b/docs/mapping/integration-with-ingest.md
@@ -79,6 +79,10 @@ flowchart TD
 | `[DataStream<T>]` | `DataStream` | `create` (append-only) | Component + data stream templates |
 | `[WiredStream<T>]` | `WiredStream` | `create` (append-only) | No-op (managed by Elasticsearch) |
 
+:::{note}
+**Wired streams and mappings.** Attribute-generated field mappings are not installed for `[WiredStream<T>]` — bootstrap is a no-op. Field naming is governed by the wired ingest endpoint (`logs`, `logs.ecs`, or `logs.otel`). Prefer ECS/OTel document shapes and set `IngestEndpoint` accordingly. See [Wired streams](../index-management/wired-streams.md) and [ECS and OTel endpoints](../index-management/ecs-and-otel-endpoints.md).
+:::
+
 ### Field attributes
 
 | Attribute | Generated delegate | Effect |

--- a/docs/mapping/integration-with-ingest.md
+++ b/docs/mapping/integration-with-ingest.md
@@ -80,7 +80,7 @@ flowchart TD
 | `[WiredStream<T>]` | `WiredStream` | `create` (append-only) | No-op (managed by Elasticsearch) |
 
 :::{note}
-**Wired streams and mappings.** Attribute-generated field mappings are not installed for `[WiredStream<T>]` — bootstrap is a no-op. Field naming is governed by the wired ingest endpoint (`logs`, `logs.ecs`, or `logs.otel`). Prefer ECS/OTel document shapes and set `IngestEndpoint` accordingly. See [Wired streams](../index-management/wired-streams.md) and [ECS and OTel endpoints](../index-management/ecs-and-otel-endpoints.md).
+**Wired streams and mappings.** Wired streams support mappings via [Kibana Streams](https://www.elastic.co/docs/solutions/observability/streams/map-fields) (including inherited parent→child schema). This library’s bootstrap is a no-op for `[WiredStream<T>]`, so attribute-generated mappings are **not** pushed as component templates — configure schema in Streams, and choose `IngestEndpoint` (`logs.ecs` / `logs.otel`) for field-name normalization. See [Wired streams](../index-management/wired-streams.md) and [ECS and OTel endpoints](../index-management/ecs-and-otel-endpoints.md).
 :::
 
 ### Field attributes

--- a/docs/strategies/ingest.md
+++ b/docs/strategies/ingest.md
@@ -49,4 +49,4 @@ Writes `index` operations with explicit document IDs for upsert patterns:
 
 ### WiredStreamIngestStrategy
 
-Writes to wired streams (Elasticsearch serverless managed streams). Uses `create` operations without explicit index targeting.
+Writes to wired streams (managed Elasticsearch Streams ingest). Uses `create` operations against `logs/_bulk`, `logs.ecs/_bulk`, or `logs.otel/_bulk` depending on `WiredStreamIngestEndpoint` on the mapping context.

--- a/docs/use-cases/wired-streams.md
+++ b/docs/use-cases/wired-streams.md
@@ -4,15 +4,17 @@ navigation_title: Wired streams
 
 # Wired streams (serverless)
 
-Wired streams are the simplest ingestion path. Elasticsearch manages all templates and lifecycle -- you just send documents.
+Wired streams are the simplest managed ingestion path. Elasticsearch owns templates and lifecycle — you send documents to a wired bulk endpoint.
+
+For the full reference (endpoints, mappings caveats, Kibana Streams), see [Wired streams](../index-management/wired-streams.md) under index management.
 
 ## When to use
 
-- Serverless Elasticsearch
-- Log data that doesn't need custom mappings or templates
-- You want the minimum possible configuration
+- Serverless Elasticsearch or Elastic Stack with wired streams enabled
+- ECS or OTel log documents that should land in Kibana Streams
+- You want the minimum local configuration (no template bootstrap)
 
-## Document type
+## Document type (ECS-shaped)
 
 ```csharp
 public class LogEntry
@@ -21,22 +23,27 @@ public class LogEntry
     [JsonPropertyName("@timestamp")]
     public DateTimeOffset Timestamp { get; set; }
 
-    [Keyword]
+    [JsonPropertyName("log.level")]
     public string Level { get; set; }
 
-    [Text]
+    [JsonPropertyName("message")]
     public string Message { get; set; }
 
-    [Keyword]
+    [JsonPropertyName("service.name")]
     public string Service { get; set; }
 }
 ```
 
 ## Mapping context
 
+Prefer `LogsEcs` when sending Elastic Common Schema documents (including payloads from [ecs-dotnet](https://github.com/elastic/ecs-dotnet)):
+
 ```csharp
 [ElasticsearchMappingContext]
-[WiredStream<LogEntry>(Type = "logs", Dataset = "myapp")]
+[WiredStream<LogEntry>(
+    Type = "logs",
+    Dataset = "myapp",
+    IngestEndpoint = WiredStreamIngestEndpoint.LogsEcs)]
 public static partial class WiredContext;
 ```
 
@@ -59,12 +66,14 @@ await channel.WaitForDrainAsync(TimeSpan.FromSeconds(10), ctx);
 
 | Behavior | Strategy | Why |
 |----------|----------|-----|
-| Ingest | `WiredStreamIngestStrategy` | Sends to `logs/_bulk` endpoint |
+| Ingest | `WiredStreamIngestStrategy` | Sends to `logs.ecs/_bulk` (or `logs` / `logs.otel`) |
 | Bootstrap | `NoopBootstrapStep` | Elasticsearch manages all templates |
 | Provisioning | `AlwaysCreateProvisioning` | No local index management |
 | Alias | `NoAliasStrategy` | Elasticsearch manages routing |
 
 ## Related
 
-- [LogsDB](../index-management/logsdb.md): LogsDB mode and wired stream details
+- [Wired streams](../index-management/wired-streams.md): reference
+- [ECS and OTel endpoints](../index-management/ecs-and-otel-endpoints.md): endpoint choice and ecs-dotnet paths
+- [Streams](../index-management/streams.md): classic vs wired
 - [Time-series](time-series.md): data streams with local template management

--- a/src/Elastic.Ingest.Elasticsearch/Strategies/Ingest/WiredStreamIngestStrategy.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Strategies/Ingest/WiredStreamIngestStrategy.cs
@@ -3,25 +3,49 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Ingest.Elasticsearch.Serialization;
+using Elastic.Mapping;
 
 namespace Elastic.Ingest.Elasticsearch.Strategies;
 
 /// <summary>
 /// Ingest strategy for wired streams (managed by Elasticsearch).
-/// Sends to logs/_bulk with standard Bulk API NDJSON format using CreateOperation.
+/// Sends to a wired bulk endpoint (<c>logs/_bulk</c>, <c>logs.ecs/_bulk</c>, or
+/// <c>logs.otel/_bulk</c>) using CreateOperation.
 /// </summary>
 public class WiredStreamIngestStrategy<TDocument> : IDocumentIngestStrategy<TDocument>
 {
 	private readonly CreateOperation _fixedHeader = new();
+	private readonly string _bulkPathPrefix;
 	private readonly string _url;
 
 	/// <summary>
-	/// Creates a new wired stream ingest strategy.
+	/// Creates a new wired stream ingest strategy targeting the legacy <c>logs</c> endpoint.
 	/// </summary>
 	/// <param name="baseBulkPathAndQuery">The base bulk path and query string.</param>
 	public WiredStreamIngestStrategy(string baseBulkPathAndQuery)
+		: this(baseBulkPathAndQuery, WiredStreamIngestEndpoint.Logs)
 	{
-		_url = $"logs/{baseBulkPathAndQuery}";
+	}
+
+	/// <summary>
+	/// Creates a new wired stream ingest strategy for the given endpoint.
+	/// </summary>
+	/// <param name="baseBulkPathAndQuery">The base bulk path and query string.</param>
+	/// <param name="endpoint">The wired stream ingest endpoint.</param>
+	public WiredStreamIngestStrategy(string baseBulkPathAndQuery, WiredStreamIngestEndpoint endpoint)
+		: this(baseBulkPathAndQuery, endpoint.ToBulkPathPrefix())
+	{
+	}
+
+	/// <summary>
+	/// Creates a new wired stream ingest strategy with an explicit bulk path prefix.
+	/// </summary>
+	/// <param name="baseBulkPathAndQuery">The base bulk path and query string.</param>
+	/// <param name="bulkPathPrefix">The URL path prefix (e.g. <c>logs.ecs</c>).</param>
+	public WiredStreamIngestStrategy(string baseBulkPathAndQuery, string bulkPathPrefix)
+	{
+		_bulkPathPrefix = bulkPathPrefix;
+		_url = $"{bulkPathPrefix}/{baseBulkPathAndQuery}";
 	}
 
 	/// <inheritdoc />
@@ -31,5 +55,5 @@ public class WiredStreamIngestStrategy<TDocument> : IDocumentIngestStrategy<TDoc
 	public string GetBulkUrl(string baseBulkPathAndQuery) => _url;
 
 	/// <inheritdoc />
-	public string RefreshTargets => "logs";
+	public string RefreshTargets => _bulkPathPrefix;
 }

--- a/src/Elastic.Ingest.Elasticsearch/Strategies/IngestStrategies.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Strategies/IngestStrategies.cs
@@ -88,13 +88,14 @@ public static class IngestStrategies
 
 	/// <summary>
 	/// Creates a wired stream ingest strategy (bootstrap managed by Elasticsearch).
+	/// Uses <see cref="ElasticsearchTypeContext.WiredStreamIngestEndpoint"/> for the bulk path prefix.
 	/// </summary>
 	public static IIngestStrategy<TEvent> WiredStream<TEvent>(
 		ElasticsearchTypeContext tc) where TEvent : class
 	{
 		return new IngestStrategy<TEvent>(tc,
 			BootstrapStrategies.None(),
-			new WiredStreamIngestStrategy<TEvent>(DefaultBulkPathAndQuery),
+			new WiredStreamIngestStrategy<TEvent>(DefaultBulkPathAndQuery, tc.WiredStreamIngestEndpoint),
 			new AlwaysCreateProvisioning(),
 			new NoAliasStrategy());
 	}

--- a/src/Elastic.Mapping.Generator/Emitters/ContextEmitter.cs
+++ b/src/Elastic.Mapping.Generator/Emitters/ContextEmitter.cs
@@ -210,6 +210,7 @@ internal static class ContextEmitter
 
 		sb.AppendLine($"{indent}\t\tglobal::Elastic.Mapping.EntityTarget.{reg.EntityConfig.EntityTarget},");
 		sb.AppendLine($"{indent}\t\tDataStreamMode: global::Elastic.Mapping.DataStreamMode.{reg.EntityConfig.DataStreamMode},");
+		sb.AppendLine($"{indent}\t\tWiredStreamIngestEndpoint: global::Elastic.Mapping.WiredStreamIngestEndpoint.{reg.EntityConfig.WiredStreamIngestEndpoint},");
 
 		EmitAccessorDelegate(sb, reg.IngestProperties.IdPropertyName, typeFqn, "GetId", false, indent + "\t\t");
 		EmitAccessorDelegate(sb, reg.IngestProperties.ContentHashPropertyName, typeFqn, "GetContentHash", false, indent + "\t\t");

--- a/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
+++ b/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
@@ -223,7 +223,10 @@ public class MappingSourceGenerator : IIncrementalGenerator
 			return null;
 
 		var dataStreamModeValue = GetNamedEnumArg(attr, "DataStreamMode", "Default");
-		var entityConfig = new EntityConfigModel(entityTarget, dataStreamModeValue);
+		var ingestEndpointValue = entityTarget == "WiredStream"
+			? GetNamedEnumArg(attr, "IngestEndpoint", "Logs")
+			: "Logs";
+		var entityConfig = new EntityConfigModel(entityTarget, dataStreamModeValue, ingestEndpointValue);
 
 		var type = GetNamedArg<string>(attr, "Type");
 		var dataset = GetNamedArg<string>(attr, "Dataset");

--- a/src/Elastic.Mapping.Generator/Model/TypeMappingModel.cs
+++ b/src/Elastic.Mapping.Generator/Model/TypeMappingModel.cs
@@ -72,7 +72,8 @@ internal sealed record DataStreamConfigModel(
 /// </summary>
 internal sealed record EntityConfigModel(
 	string EntityTarget,
-	string DataStreamMode
+	string DataStreamMode,
+	string WiredStreamIngestEndpoint = "Logs"
 );
 
 /// <summary>

--- a/src/Elastic.Mapping/Attributes/Index/WiredStreamAttribute.cs
+++ b/src/Elastic.Mapping/Attributes/Index/WiredStreamAttribute.cs
@@ -8,8 +8,9 @@ namespace Elastic.Mapping;
 /// Registers <typeparamref name="T"/> as an Elasticsearch wired stream within an
 /// <see cref="ElasticsearchMappingContextAttribute"/> context.
 /// <para>
-/// Wired streams send data to the Elasticsearch <c>/logs</c> endpoint. Bootstrap is fully
-/// managed by Elasticsearch — no index templates or component templates are created.
+/// Wired streams send data to a managed Elasticsearch bulk endpoint
+/// (<c>logs</c>, <c>logs.ecs</c>, or <c>logs.otel</c> — see <see cref="IngestEndpoint"/>).
+/// Bootstrap is fully managed by Elasticsearch — no index templates or component templates are created.
 /// </para>
 /// <para>
 /// Like data streams, names follow the <c>{type}-{dataset}-{namespace}</c> convention.
@@ -58,4 +59,16 @@ public sealed class WiredStreamAttribute<T> : Attribute where T : class
 	/// with different configurations.
 	/// </summary>
 	public string? Variant { get; init; }
+
+	/// <summary>
+	/// Wired stream bulk ingest endpoint. Defaults to <see cref="WiredStreamIngestEndpoint.Logs"/>
+	/// for backward compatibility.
+	/// </summary>
+	/// <remarks>
+	/// Use <see cref="WiredStreamIngestEndpoint.LogsEcs"/> when sending Elastic Common Schema
+	/// documents (e.g. from <c>Elastic.CommonSchema</c> / ecs-dotnet). Use
+	/// <see cref="WiredStreamIngestEndpoint.LogsOtel"/> for OpenTelemetry semantic conventions.
+	/// See <see href="https://www.elastic.co/docs/solutions/observability/streams/wired-streams-field-naming"/>.
+	/// </remarks>
+	public WiredStreamIngestEndpoint IngestEndpoint { get; init; } = WiredStreamIngestEndpoint.Logs;
 }

--- a/src/Elastic.Mapping/ElasticsearchTypeContext.cs
+++ b/src/Elastic.Mapping/ElasticsearchTypeContext.cs
@@ -27,6 +27,7 @@ namespace Elastic.Mapping;
 /// <param name="SearchStrategy">Search target configuration (pattern, read alias).</param>
 /// <param name="EntityTarget">The Elasticsearch target type (Index, DataStream, WiredStream).</param>
 /// <param name="DataStreamMode">Data stream mode for specialized types (Default, LogsDb, Tsdb).</param>
+/// <param name="WiredStreamIngestEndpoint">Bulk path prefix for wired streams (<c>logs</c>, <c>logs.ecs</c>, <c>logs.otel</c>).</param>
 /// <param name="GetId">Generated accessor delegate for the [Id] property. Returns document _id.</param>
 /// <param name="GetContentHash">Generated accessor delegate for the [ContentHash] property. Returns content hash for upserts.</param>
 /// <param name="ContentHashFieldName">The JSON field name of the [ContentHash] property (resolved from [JsonPropertyName] or naming policy).</param>
@@ -53,6 +54,7 @@ public record ElasticsearchTypeContext(
 	SearchStrategy? SearchStrategy,
 	EntityTarget EntityTarget,
 	DataStreamMode DataStreamMode = DataStreamMode.Default,
+	WiredStreamIngestEndpoint WiredStreamIngestEndpoint = WiredStreamIngestEndpoint.Logs,
 	Func<object, string?>? GetId = null,
 	Func<object, string?>? GetContentHash = null,
 	string? ContentHashFieldName = null,
@@ -209,6 +211,12 @@ public record ElasticsearchTypeContext(
 			_ => MappedType?.Name.ToLowerInvariant() + "-template"
 				?? throw new InvalidOperationException("Cannot resolve template name from context.")
 		}).ToLowerInvariant();
+
+	/// <summary>
+	/// Resolves the wired stream bulk URL path prefix (<c>logs</c>, <c>logs.ecs</c>, or <c>logs.otel</c>).
+	/// </summary>
+	public string ResolveWiredStreamBulkPathPrefix() =>
+		WiredStreamIngestEndpoint.ToBulkPathPrefix();
 
 	// ── With* methods ────────────────────────────────────────────────────
 

--- a/src/Elastic.Mapping/WiredStreamIngestEndpoint.cs
+++ b/src/Elastic.Mapping/WiredStreamIngestEndpoint.cs
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Mapping;
+
+/// <summary>
+/// Wired stream bulk ingest endpoint. Controls the URL prefix used by
+/// <c>WiredStreamIngestStrategy</c> (e.g. <c>logs/_bulk</c>, <c>logs.ecs/_bulk</c>).
+/// </summary>
+/// <remarks>
+/// See <see href="https://www.elastic.co/docs/solutions/observability/streams/wired-streams-field-naming">
+/// Wired streams field naming</see> for how <see cref="LogsEcs"/> and <see cref="LogsOtel"/>
+/// normalize field names.
+/// </remarks>
+public enum WiredStreamIngestEndpoint
+{
+	/// <summary>
+	/// Legacy/generic wired logs endpoint (<c>logs/_bulk</c>).
+	/// Default for backward compatibility.
+	/// </summary>
+	Logs,
+
+	/// <summary>
+	/// ECS field naming endpoint (<c>logs.ecs/_bulk</c>).
+	/// Prefer this when sending Elastic Common Schema documents (e.g. from ecs-dotnet).
+	/// </summary>
+	LogsEcs,
+
+	/// <summary>
+	/// OpenTelemetry semantic convention endpoint (<c>logs.otel/_bulk</c>).
+	/// Converts ECS fields to OTel equivalents; creates ECS aliases for queries.
+	/// </summary>
+	LogsOtel
+}
+
+/// <summary>
+/// Helpers for <see cref="WiredStreamIngestEndpoint"/>.
+/// </summary>
+public static class WiredStreamIngestEndpointExtensions
+{
+	/// <summary>
+	/// Returns the bulk URL path prefix for the endpoint (without trailing slash).
+	/// </summary>
+	public static string ToBulkPathPrefix(this WiredStreamIngestEndpoint endpoint) =>
+		endpoint switch
+		{
+			WiredStreamIngestEndpoint.LogsEcs => "logs.ecs",
+			WiredStreamIngestEndpoint.LogsOtel => "logs.otel",
+			_ => "logs"
+		};
+}

--- a/tests/Elastic.Ingest.Elasticsearch.Tests/StrategyFactoryTests.cs
+++ b/tests/Elastic.Ingest.Elasticsearch.Tests/StrategyFactoryTests.cs
@@ -34,13 +34,15 @@ public class StrategyFactoryTests
 			MappedType: typeof(TestDocument)
 		);
 
-	private static ElasticsearchTypeContext CreateWiredStreamContext() =>
+	private static ElasticsearchTypeContext CreateWiredStreamContext(
+		WiredStreamIngestEndpoint endpoint = WiredStreamIngestEndpoint.Logs) =>
 		new(
 			() => "{}", () => "{}", () => "{}",
 			"hash", "sh", "mh",
-			new IndexStrategy(),
+			new IndexStrategy { Type = "logs", Dataset = "myapp", Namespace = "default" },
 			new SearchStrategy(),
 			EntityTarget.WiredStream,
+			WiredStreamIngestEndpoint: endpoint,
 			MappedType: typeof(TestDocument)
 		);
 
@@ -215,6 +217,31 @@ public class StrategyFactoryTests
 
 		var bootstrap = strategy.Bootstrap.Should().BeOfType<DefaultBootstrapStrategy>().Subject;
 		bootstrap.Steps.Should().ContainSingle().Which.Should().BeOfType<NoopBootstrapStep>();
+	}
+
+	[Test]
+	[Arguments(WiredStreamIngestEndpoint.Logs, "logs")]
+	[Arguments(WiredStreamIngestEndpoint.LogsEcs, "logs.ecs")]
+	[Arguments(WiredStreamIngestEndpoint.LogsOtel, "logs.otel")]
+	public void WiredStreamUsesEndpointBulkPathPrefix(WiredStreamIngestEndpoint endpoint, string prefix)
+	{
+		var tc = CreateWiredStreamContext(endpoint);
+		var strategy = IngestStrategies.WiredStream<TestDocument>(tc);
+
+		var ingest = strategy.DocumentIngest.Should().BeOfType<WiredStreamIngestStrategy<TestDocument>>().Subject;
+		ingest.RefreshTargets.Should().Be(prefix);
+		ingest.GetBulkUrl("ignored").Should().StartWith($"{prefix}/_bulk");
+	}
+
+	[Test]
+	public void WiredStreamContextResolvesBulkPathPrefix()
+	{
+		CreateWiredStreamContext(WiredStreamIngestEndpoint.LogsEcs)
+			.ResolveWiredStreamBulkPathPrefix().Should().Be("logs.ecs");
+		CreateWiredStreamContext(WiredStreamIngestEndpoint.LogsOtel)
+			.ResolveWiredStreamBulkPathPrefix().Should().Be("logs.otel");
+		CreateWiredStreamContext()
+			.ResolveWiredStreamBulkPathPrefix().Should().Be("logs");
 	}
 
 	// --- BootstrapStrategies ---

--- a/tests/Elastic.Mapping.Tests/EntityConfigurationTests.cs
+++ b/tests/Elastic.Mapping.Tests/EntityConfigurationTests.cs
@@ -109,5 +109,33 @@ public class EntityConfigurationTests
 	{
 		TestMappingContext.LogEntry.Context.EntityTarget.Should().Be(EntityTarget.Index);
 		TestMappingContext.NginxAccessLog.Context.EntityTarget.Should().Be(EntityTarget.DataStream);
+		TestMappingContext.WiredLogEntry.Context.EntityTarget.Should().Be(EntityTarget.WiredStream);
+	}
+
+	[Test]
+	public void WiredStream_DefaultsToLogsEndpoint()
+	{
+		TestMappingContext.WiredLogEntry.Context.WiredStreamIngestEndpoint
+			.Should().Be(WiredStreamIngestEndpoint.Logs);
+		TestMappingContext.WiredLogEntry.Context.ResolveWiredStreamBulkPathPrefix()
+			.Should().Be("logs");
+	}
+
+	[Test]
+	public void WiredStream_LogsEcsEndpointFlowsToContext()
+	{
+		TestMappingContext.WiredLogEntryEcs.Context.WiredStreamIngestEndpoint
+			.Should().Be(WiredStreamIngestEndpoint.LogsEcs);
+		TestMappingContext.WiredLogEntryEcs.Context.ResolveWiredStreamBulkPathPrefix()
+			.Should().Be("logs.ecs");
+	}
+
+	[Test]
+	public void WiredStream_LogsOtelEndpointFlowsToContext()
+	{
+		TestMappingContext.WiredLogEntryOtel.Context.WiredStreamIngestEndpoint
+			.Should().Be(WiredStreamIngestEndpoint.LogsOtel);
+		TestMappingContext.WiredLogEntryOtel.Context.ResolveWiredStreamBulkPathPrefix()
+			.Should().Be("logs.otel");
 	}
 }

--- a/tests/Elastic.Mapping.Tests/TestModels.cs
+++ b/tests/Elastic.Mapping.Tests/TestModels.cs
@@ -23,6 +23,25 @@ namespace Elastic.Mapping.Tests;
 	Dataset = "nginx.access",
 	Namespace = "production"
 )]
+[WiredStream<WiredLogEntry>(
+	Type = "logs",
+	Dataset = "wired.default",
+	Namespace = "test"
+)]
+[WiredStream<WiredLogEntry>(
+	Type = "logs",
+	Dataset = "wired.ecs",
+	Namespace = "test",
+	IngestEndpoint = WiredStreamIngestEndpoint.LogsEcs,
+	Variant = "Ecs"
+)]
+[WiredStream<WiredLogEntry>(
+	Type = "logs",
+	Dataset = "wired.otel",
+	Namespace = "test",
+	IngestEndpoint = WiredStreamIngestEndpoint.LogsOtel,
+	Variant = "Otel"
+)]
 [Index<SimpleDocument>(Name = "simple-docs")]
 [Index<AdvancedDocument>(Name = "advanced-docs")]
 public static partial class TestMappingContext
@@ -88,6 +107,23 @@ public class NginxAccessLog
 
 	[Ip]
 	public string? ClientIp { get; set; }
+}
+
+/// <summary>
+/// Test model for wired stream configuration (registered via context).
+/// </summary>
+public class WiredLogEntry
+{
+	[JsonPropertyName("@timestamp")]
+	[Date]
+	[Timestamp]
+	public DateTimeOffset Timestamp { get; set; }
+
+	[Text]
+	public string Message { get; set; } = string.Empty;
+
+	[Keyword]
+	public string Level { get; set; } = string.Empty;
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Add `WiredStreamIngestEndpoint` (`Logs`, `LogsEcs`, `LogsOtel`) on `[WiredStream<T>]` so bulk ingest can target managed Streams endpoints (`logs/_bulk`, `logs.ecs/_bulk`, `logs.otel/_bulk`).
- Document Kibana Streams terminology (classic vs wired), field-naming endpoints, ecs-dotnet integration paths, and that Streamlang / knowledge indicators / significant events remain Kibana-owned.
- Clarify that **this library** does not bootstrap templates for wired targets; mappings are still supported via [Kibana Streams schema](https://www.elastic.co/docs/solutions/observability/streams/map-fields) (not “no mappings”).

## Test plan
- [x] `EntityConfigurationTests` (wired endpoint flows from attribute → context)
- [x] `StrategyFactoryTests` (bulk URL / refresh targets for all three endpoints)
- [ ] Spot-check generated docs TOC under index-management
- [ ] Manual wired ingest against a Streams-enabled cluster with `LogsEcs` (optional)

## Follow-up
- ecs-dotnet: https://github.com/elastic/ecs-dotnet/issues/570