### PR TITLE
fix(generator): guard against syntax trees not part of compilation

### DIFF
--- a/src/Elastic.Mapping.Generator/Analysis/ConfigureAnalysisParser.cs
+++ b/src/Elastic.Mapping.Generator/Analysis/ConfigureAnalysisParser.cs
@@ -175,6 +175,12 @@ internal static class ConfigureAnalysisParser
 		{
 			ct.ThrowIfCancellationRequested();
 
+			// The IDE may hand generators a partial/frozen compilation (e.g. while a solution is
+			// still loading) that doesn't contain every syntax tree a symbol's declaring references
+			// point to. Guard against that instead of letting GetSemanticModel throw.
+			if (!compilation.ContainsSyntaxTree(syntaxRef.SyntaxTree))
+				continue;
+
 			var methodSyntax = syntaxRef.GetSyntax(ct);
 
 			// Obtain the semantic model for the specific syntax tree this method lives in.

--- a/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
+++ b/src/Elastic.Mapping.Generator/MappingSourceGenerator.cs
@@ -674,6 +674,13 @@ public class MappingSourceGenerator : IIncrementalGenerator
 		foreach (var syntaxRef in method.DeclaringSyntaxReferences)
 		{
 			ct.ThrowIfCancellationRequested();
+
+			// The IDE may hand generators a partial/frozen compilation (e.g. while a solution is
+			// still loading) that doesn't contain every syntax tree a symbol's declaring references
+			// point to. Guard against that instead of letting GetSemanticModel throw.
+			if (!compilation.ContainsSyntaxTree(syntaxRef.SyntaxTree))
+				continue;
+
 			var methodSyntax = syntaxRef.GetSyntax(ct);
 			var semanticModel = compilation.GetSemanticModel(syntaxRef.SyntaxTree);
 


### PR DESCRIPTION
## Summary
- `MappingSourceGenerator.MethodDelegatesAnalysis` and `ConfigureAnalysisParser.Walk` called `Compilation.GetSemanticModel(syntaxRef.SyntaxTree)` for syntax trees found via a method symbol's `DeclaringSyntaxReferences`, assuming they always belong to the `Compilation` instance passed in.
- During IDE/design-time-build scenarios (e.g. while a solution is still loading), Roslyn can hand generators a partial/frozen `Compilation` that doesn't contain every syntax tree, causing `GetSemanticModel` to throw `ArgumentException: SyntaxTree is not part of the compilation` and crashing the whole generator for the file/project.
- Added a `compilation.ContainsSyntaxTree(...)` guard before calling `GetSemanticModel` at both call sites so the generator skips that particular syntax reference instead of throwing.

## Test plan
- [x] `dotnet build src/Elastic.Mapping.Generator/Elastic.Mapping.Generator.csproj` succeeds
- [x] `dotnet test tests/Elastic.Mapping.Tests/Elastic.Mapping.Tests.csproj` — all 284 tests pass

Made with [Cursor](https://cursor.com)